### PR TITLE
feat: Added net4.6.2/net8.0.

### DIFF
--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>beta.2</VersionSuffix>
 
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net4.6.2;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
     <!-- Sign the assembly with the specified key file. -->


### PR DESCRIPTION
- net4.6.2 was added because it is standard practice due to problems with netstandard2.0 in the .Net Framework, where it only fully works for the .Net Framework 4.7.2+. Explicitly specifying net462 for the library allows this to be used for .Net Framewok 4.6.2 without these problems
https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version
![image](https://github.com/openai/openai-dotnet/assets/3002068/e0d91e3a-0a71-4c3c-b748-021588b21b7f)
Since 4.6.1 is no longer supported, I chose 4.6.2 as the minimum.
Similar can be seen for example for System.Memory.Data 8.0.0
![image](https://github.com/openai/openai-dotnet/assets/3002068/80831480-a500-4bec-a1e6-ada8d62b2964)


- Explicitly specifying net8 allows using #ifdef to use optimizations only available for net8, as well as new diagnostics, such as more complete nullable annotations for system types