### PR TITLE
Remove seemingly unnecessary string allocation from ClientUriBuilder.AppendPath

### DIFF
--- a/src/Generated/Internal/ClientUriBuilder.cs
+++ b/src/Generated/Internal/ClientUriBuilder.cs
@@ -47,7 +47,6 @@ namespace OpenAI
             }
 
             PathBuilder.Append(value);
-            UriBuilder.Path = PathBuilder.ToString();
         }
 
         public void AppendPath(bool value, bool escape = false)


### PR DESCRIPTION
There aren't any tests in the repo currently to help me validate this, but it looks like this PathBuilder.ToString() call in ClientUriBuilder.AppendPath is superfluous. Every use I see of ClientUriBuilder ends with a call to ToUri, which will itself call PathBuilder.ToString() and overwrite the UriBuilder's Path. Further, the corresponding ClientUriBuilder.AppendQuery doesn't similarly write to UriBuilder.Query.