### PR TITLE
Get clean on warnings

### DIFF
--- a/src/Custom/Assistants/Internal/GeneratorStubs.Internal.cs
+++ b/src/Custom/Assistants/Internal/GeneratorStubs.Internal.cs
@@ -34,10 +34,10 @@ internal partial class MessageDeltaContentImageUrlObjectImageUrl
 }
 
 [CodeGenModel("MessageDeltaContentImageFileObject")]
-internal partial class MessageDeltaContentImageFileObject { private readonly string Type; }
+internal partial class MessageDeltaContentImageFileObject { private readonly new string Type; }
 
 [CodeGenModel("MessageDeltaContentImageUrlObject")]
-internal partial class MessageDeltaContentImageUrlObject { private readonly string Type; }
+internal partial class MessageDeltaContentImageUrlObject { private readonly new string Type; }
 
 [CodeGenModel("MessageDeltaObjectDelta")]
 internal partial class MessageDeltaObjectDelta

--- a/src/Custom/Audio/TranscribedSegment.cs
+++ b/src/Custom/Audio/TranscribedSegment.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace OpenAI.Audio;
 
 [CodeGenModel("TranscriptionSegment")]
+[StructLayout(LayoutKind.Auto)]
 public readonly partial struct TranscribedSegment
 {
     // CUSTOM: Rename.

--- a/src/Custom/Chat/ChatMessageContentPart.cs
+++ b/src/Custom/Chat/ChatMessageContentPart.cs
@@ -11,9 +11,9 @@ namespace OpenAI.Chat;
 public partial class ChatMessageContentPart
 {
     private readonly ChatMessageContentPartKind _kind;
-    private readonly string _text = default;
-    private readonly InternalChatCompletionRequestMessageContentPartImageImageUrl _imageUrl = default;
-    private readonly string _dataUri = default;
+    private readonly string _text;
+    private readonly InternalChatCompletionRequestMessageContentPartImageImageUrl _imageUrl;
+    private readonly string _dataUri;
 
     internal ChatMessageContentPart(string text)
     {

--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -28,14 +28,22 @@
    
     <!-- Embed source files that are not tracked by the source control manager in the PDB -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-</PropertyGroup>
+
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Disable missing XML documentation warnings -->
+    <NoWarn>$(NoWarn),1570,1573,1574,1591</NoWarn>
+    
+    <!-- Disable obsolete warnings -->
+    <NoWarn>$(NoWarn),0618</NoWarn>
+
+    <!-- Disable unused fields warnings -->
+    <NoWarn>$(NoWarn),0169</NoWarn>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <!-- Normalize stored file paths in symbols when in a CI build. -->
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-
-    <!-- Disable missing XML documentation warnings -->
-    <NoWarn>$(NoWarn),1570,1573,1574,1591</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Utility/CustomSerializationHelpers.cs
+++ b/src/Utility/CustomSerializationHelpers.cs
@@ -1,6 +1,7 @@
+#nullable enable
+
 using System;
 using System.ClientModel.Primitives;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
 

--- a/src/Utility/Polyfill/System.Diagnostics.CodeAnalysis.ExperimentalAttribute.cs
+++ b/src/Utility/Polyfill/System.Diagnostics.CodeAnalysis.ExperimentalAttribute.cs
@@ -1,4 +1,5 @@
 #if !NET8_0_OR_GREATER
+#nullable enable
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.


### PR DESCRIPTION
More meaningful warnings were being obscured by 1334 warnings being triggered during build. This gets it to 0 and sets TreatWarningsAsErrors. Most of getting to 0 was just via broad suppression.