### PR TITLE
Assistants: fix "Logs" on RunStepUpdateCodeInterpreterOutput

### DIFF
--- a/src/Custom/Assistants/Streaming/RunStepDetailsUpdateCodeInterpreterOutput.cs
+++ b/src/Custom/Assistants/Streaming/RunStepDetailsUpdateCodeInterpreterOutput.cs
@@ -7,7 +7,7 @@ public partial class RunStepUpdateCodeInterpreterOutput
     public int OutputIndex => AsLogs?.Index ?? AsImage?.Index ?? 0;
 
     /// <inheritdoc cref="InternalRunStepDeltaStepDetailsToolCallsCodeOutputLogsObject.InternalLogs"/>
-    public string Logs => AsLogs?.Logs;
+    public string Logs => AsLogs?.InternalLogs;
 
     /// <inheritdoc cref="InternalRunStepDeltaStepDetailsToolCallsCodeOutputImageObjectImage.FileId"/>
     public string ImageFileId => AsImage?.Image?.FileId;


### PR DESCRIPTION
The `InternalRunStepDeltaStepDetailsToolCallsCodeOutputLogsObject` type derives from `RunStepUpdateCodeInterpreterOutput`, so the current call will infinitely recurse if the output is a logs instance. The property on the internal type was already renamed to handle this; this change just uses the intended `InternalLogs` target.