### PR TITLE
Disable warnings in tests due to deprecated types

### DIFF
--- a/tests/Chat/ChatClientTests.cs
+++ b/tests/Chat/ChatClientTests.cs
@@ -507,7 +507,9 @@ public partial class ChatClientTests : SyncAsyncTestBase
         else
         {
             // We construct a new instance. Later, we serialize it and confirm it was constructed correctly.
+#pragma warning disable CS0618
             choice = new ChatFunctionChoice(new ChatFunction(functionName));
+#pragma warning restore CS0618
         }
 
         BinaryData serializedChoice = ModelReaderWriter.Write(choice);

--- a/tests/Chat/ChatToolTests.cs
+++ b/tests/Chat/ChatToolTests.cs
@@ -64,6 +64,7 @@ public partial class ChatToolTests : SyncAsyncTestBase
 
     private const string GetFavoriteColorForMonthFunctionName = "get_favorite_color_for_month";
 
+#pragma warning disable CS0618
     private static ChatFunction s_getFavoriteColorForMonthFunction = new ChatFunction(
         GetFavoriteColorForMonthToolFunctionName,
         "gets the caller's favorite color for a given month",
@@ -80,6 +81,7 @@ public partial class ChatToolTests : SyncAsyncTestBase
             }
             """)
     );
+#pragma warning restore CS0618
 
     private const string GetWeatherForCityToolName = "get_weather_for_city";
 
@@ -232,7 +234,9 @@ public partial class ChatToolTests : SyncAsyncTestBase
         Assert.That(argumentsJson.ContainsKey("month_name"));
         Assert.That(argumentsJson["month_name"].ToString().ToLowerInvariant(), Is.EqualTo("february"));
         messages.Add(new AssistantChatMessage(result.Value));
+#pragma warning disable CS0618
         messages.Add(new FunctionChatMessage(GetFavoriteColorForMonthFunctionName, "chartreuse"));
+#pragma warning restore CS0618
         result = IsAsync
             ? await client.CompleteChatAsync(messages, options)
             : client.CompleteChat(messages, options);


### PR DESCRIPTION
`ChatFunction` and `FunctionChatMessage` are deprecated but we still have to test them. Disable the warnings.