### PR TITLE
Mitigate message content serialization problems in mono/wasm/etc.

### DIFF
--- a/src/Custom/Assistants/AssistantClient.cs
+++ b/src/Custom/Assistants/AssistantClient.cs
@@ -19,6 +19,8 @@ namespace OpenAI.Assistants;
 [CodeGenSuppress("AssistantClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateAssistantAsync", typeof(AssistantCreationOptions))]
 [CodeGenSuppress("CreateAssistant", typeof(AssistantCreationOptions))]
+[CodeGenSuppress("DeleteAssistantAsync", typeof(string))]
+[CodeGenSuppress("DeleteAssistant", typeof(string))]
 [CodeGenSuppress("GetAssistantsAsync", typeof(int?), typeof(ListOrder?), typeof(string), typeof(string))]
 [CodeGenSuppress("GetAssistants", typeof(int?), typeof(ListOrder?), typeof(string), typeof(string))]
 public partial class AssistantClient

--- a/src/Custom/Assistants/CodeInterpreterToolDefinition.Serialization.cs
+++ b/src/Custom/Assistants/CodeInterpreterToolDefinition.Serialization.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.CodeInterpreterToolDefinition>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+public partial class CodeInterpreterToolDefinition : IJsonModel<CodeInterpreterToolDefinition>
+{
+    void IJsonModel<CodeInterpreterToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, SerializeCodeInterpreterToolDefinition, writer, options);
+
+    internal static void SerializeCodeInterpreterToolDefinition(CodeInterpreterToolDefinition instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(Type);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/FileSearchToolDefinition.Serialization.cs
+++ b/src/Custom/Assistants/FileSearchToolDefinition.Serialization.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.FileSearchToolDefinition>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+public partial class FileSearchToolDefinition : IJsonModel<FileSearchToolDefinition>
+{
+    void IJsonModel<FileSearchToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, SerializeFileSearchToolDefinition, writer, options);
+
+    internal static void SerializeFileSearchToolDefinition(FileSearchToolDefinition instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(Type);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/FunctionToolDefinition.Serialization.cs
+++ b/src/Custom/Assistants/FunctionToolDefinition.Serialization.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.FunctionToolDefinition>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+public partial class FunctionToolDefinition : IJsonModel<FunctionToolDefinition>
+{
+    void IJsonModel<FunctionToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance<ToolDefinition, FunctionToolDefinition>(this, SerializeFunctionToolDefinition, writer, options);
+
+    internal static void SerializeFunctionToolDefinition(FunctionToolDefinition instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+    
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("function"u8);
+        writer.WriteObjectValue<InternalFunctionDefinition>(_internalFunction, options);
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(Type);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/Internal/InternalMessageImageFileContent.Serialization.cs
+++ b/src/Custom/Assistants/Internal/InternalMessageImageFileContent.Serialization.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.InternalMessageImageFileContent>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+internal partial class InternalMessageImageFileContent : IJsonModel<InternalMessageImageFileContent>
+{
+    void IJsonModel<InternalMessageImageFileContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, SerializeInternalMessageImageFileContent, writer, options);
+
+    internal static void SerializeInternalMessageImageFileContent(InternalMessageImageFileContent instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(_type);
+        writer.WritePropertyName("image_file"u8);
+        writer.WriteObjectValue<InternalMessageContentItemFileObjectImageFile>(_imageFile, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/Internal/InternalMessageImageUrlContent.Serialization.cs
+++ b/src/Custom/Assistants/Internal/InternalMessageImageUrlContent.Serialization.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.InternalMessageImageUrlContent>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+internal partial class InternalMessageImageUrlContent : IJsonModel<InternalMessageImageUrlContent>
+{
+    void IJsonModel<InternalMessageImageUrlContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, SerializeInternalMessageImageUrlContent, writer, options);
+
+    internal static void SerializeInternalMessageImageUrlContent(InternalMessageImageUrlContent instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(_type);
+        writer.WritePropertyName("image_url"u8);
+        writer.WriteObjectValue<InternalMessageContentImageUrlObjectImageUrl>(_imageUrl, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/Internal/InternalRequestMessageTextContent.Serialization.cs
+++ b/src/Custom/Assistants/Internal/InternalRequestMessageTextContent.Serialization.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.InternalRequestMessageTextContent>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+internal partial class InternalRequestMessageTextContent : IJsonModel<InternalRequestMessageTextContent>
+{
+    void IJsonModel<InternalRequestMessageTextContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, SerializeInternalRequestMessageTextContent, writer, options);
+
+    internal static void SerializeInternalRequestMessageTextContent(InternalRequestMessageTextContent instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(Type.ToString());
+        writer.WritePropertyName("text"u8);
+        writer.WriteStringValue(InternalText);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/Internal/InternalResponseMessageTextContent.Serialization.cs
+++ b/src/Custom/Assistants/Internal/InternalResponseMessageTextContent.Serialization.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.InternalResponseMessageTextContent>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+internal partial class InternalResponseMessageTextContent : IJsonModel<InternalResponseMessageTextContent>
+{
+    void IJsonModel<InternalResponseMessageTextContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, SerializeInternalResponseMessageTextContent, writer, options);
+
+    internal static void SerializeInternalResponseMessageTextContent(InternalResponseMessageTextContent instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(_type);
+        writer.WritePropertyName("text"u8);
+        writer.WriteObjectValue<MessageContentTextObjectText>(_text, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/Internal/UnknownAssistantToolDefinition.Serialization.cs
+++ b/src/Custom/Assistants/Internal/UnknownAssistantToolDefinition.Serialization.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.ToolDefinition>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+internal partial class UnknownAssistantToolDefinition : IJsonModel<ToolDefinition>
+{
+    void IJsonModel<ToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance<ToolDefinition, UnknownAssistantToolDefinition>(this, SerializeUnknownAssistantToolDefinition, writer, options);
+
+    internal static void SerializeUnknownAssistantToolDefinition(UnknownAssistantToolDefinition instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("type"u8);
+        writer.WriteStringValue(Type);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
+        writer.WriteEndObject();
+    }
+}

--- a/src/Custom/Assistants/MessageContent.Serialization.cs
+++ b/src/Custom/Assistants/MessageContent.Serialization.cs
@@ -2,8 +2,18 @@ using System.ClientModel.Primitives;
 using System.Text.Json;
 
 namespace OpenAI.Assistants;
-public partial class MessageContent : IJsonModel<MessageContent>
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.MessageContent>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+public abstract partial class MessageContent : IJsonModel<MessageContent>
 {
+    void IJsonModel<MessageContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, WriteCore, writer, options);
+
+    internal static void WriteCore(MessageContent instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected abstract void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options);
+
     internal static MessageContent DeserializeMessageContent(JsonElement element, ModelReaderWriterOptions options = null)
     {
         options ??= ModelSerializationExtensions.WireOptions;

--- a/src/Custom/Assistants/ToolDefinition.Serialization.cs
+++ b/src/Custom/Assistants/ToolDefinition.Serialization.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace OpenAI.Assistants;
+
+[CodeGenSuppress("global::System.ClientModel.Primitives.IJsonModel<OpenAI.Assistants.ToolDefinition>.Write", typeof(Utf8JsonWriter), typeof(ModelReaderWriterOptions))]
+public abstract partial class ToolDefinition : IJsonModel<ToolDefinition>
+{
+    void IJsonModel<ToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, WriteCore, writer, options);
+
+    internal static void WriteCore(ToolDefinition instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected abstract void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options);
+}

--- a/src/Custom/Chat/AssistantChatMessage.Serialization.cs
+++ b/src/Custom/Chat/AssistantChatMessage.Serialization.cs
@@ -11,107 +11,33 @@ public partial class AssistantChatMessage : IJsonModel<AssistantChatMessage>
     void IJsonModel<AssistantChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         => CustomSerializationHelpers.SerializeInstance(this, SerializeAssistantChatMessage, writer, options);
 
-    internal static AssistantChatMessage DeserializeAssistantChatMessage(JsonElement element, ModelReaderWriterOptions options = null)
-    {
-        options ??= ModelSerializationExtensions.WireOptions;
-
-        if (element.ValueKind == JsonValueKind.Null)
-        {
-            return null;
-        }
-        string name = default;
-        IList<ChatToolCall> toolCalls = default;
-        ChatFunctionCall functionCall = default;
-        string role = default;
-        IList<ChatMessageContentPart> content = default;
-        IDictionary<string, BinaryData> serializedAdditionalRawData = default;
-        Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
-        foreach (var property in element.EnumerateObject())
-        {
-            if (property.NameEquals("name"u8))
-            {
-                name = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("tool_calls"u8))
-            {
-                if (property.Value.ValueKind == JsonValueKind.Null)
-                {
-                    continue;
-                }
-                List<ChatToolCall> array = new List<ChatToolCall>();
-                foreach (var item in property.Value.EnumerateArray())
-                {
-                    array.Add(ChatToolCall.DeserializeChatToolCall(item, options));
-                }
-                toolCalls = array;
-                continue;
-            }
-            if (property.NameEquals("function_call"u8))
-            {
-                if (property.Value.ValueKind == JsonValueKind.Null)
-                {
-                    functionCall = null;
-                    continue;
-                }
-                functionCall = ChatFunctionCall.DeserializeChatFunctionCall(property.Value, options);
-                continue;
-            }
-            if (property.NameEquals("role"u8))
-            {
-                role = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("content"u8))
-            {
-                if (property.Value.ValueKind == JsonValueKind.Null)
-                {
-                    continue;
-                }
-                List<ChatMessageContentPart> array = new List<ChatMessageContentPart>();
-                array.Add(ChatMessageContentPart.CreateTextMessageContentPart(property.Value.GetString()));
-                content = array;
-                continue;
-            }
-            if (true)
-            {
-                rawDataDictionary.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
-            }
-        }
-        serializedAdditionalRawData = rawDataDictionary;
-        return new AssistantChatMessage(
-            role,
-            content ?? new ChangeTrackingList<ChatMessageContentPart>(),
-            serializedAdditionalRawData,
-            name,
-            toolCalls ?? new ChangeTrackingList<ChatToolCall>(),
-            functionCall);
-    }
-
     internal static void SerializeAssistantChatMessage(AssistantChatMessage instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         writer.WriteStartObject();
-        if (Optional.IsDefined(instance.ParticipantName))
+        if (Optional.IsDefined(ParticipantName))
         {
             writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(instance.ParticipantName);
+            writer.WriteStringValue(ParticipantName);
         }
-        if (Optional.IsCollectionDefined(instance.ToolCalls))
+        if (Optional.IsCollectionDefined(ToolCalls))
         {
             writer.WritePropertyName("tool_calls"u8);
             writer.WriteStartArray();
-            foreach (var item in instance.ToolCalls)
+            foreach (var item in ToolCalls)
             {
                 writer.WriteObjectValue(item, options);
             }
             writer.WriteEndArray();
         }
-        if (Optional.IsDefined(instance.FunctionCall))
+        if (Optional.IsDefined(FunctionCall))
         {
-            if (instance.FunctionCall != null)
+            if (FunctionCall != null)
             {
                 writer.WritePropertyName("function_call"u8);
-                writer.WriteObjectValue(instance.FunctionCall, options);
+                writer.WriteObjectValue(FunctionCall, options);
             }
             else
             {
@@ -119,20 +45,20 @@ public partial class AssistantChatMessage : IJsonModel<AssistantChatMessage>
             }
         }
         writer.WritePropertyName("role"u8);
-        writer.WriteStringValue(instance.Role);
-        if (Optional.IsCollectionDefined(instance.Content))
+        writer.WriteStringValue(Role);
+        if (Optional.IsCollectionDefined(Content))
         {
-            if (instance.Content[0] != null)
+            if (Content[0] != null)
             {
                 writer.WritePropertyName("content"u8);
-                writer.WriteStringValue(instance.Content[0].Text);
+                writer.WriteStringValue(Content[0].Text);
             }
             else
             {
                 writer.WriteNull("content");
             }
         }
-        writer.WriteSerializedAdditionalRawData(instance._serializedAdditionalRawData, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
         writer.WriteEndObject();
     }
 }

--- a/src/Custom/Chat/ChatMessageContentPart.Serialization.cs
+++ b/src/Custom/Chat/ChatMessageContentPart.Serialization.cs
@@ -9,9 +9,9 @@ namespace OpenAI.Chat;
 public partial class ChatMessageContentPart : IJsonModel<ChatMessageContentPart>
 {
     void IJsonModel<ChatMessageContentPart>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        => CustomSerializationHelpers.SerializeInstance(this, SerializeChatMessageContentPart, writer, options);
+        => CustomSerializationHelpers.SerializeInstance(this, WriteCoreContentPart, writer, options);
 
-    internal static void SerializeChatMessageContentPart(ChatMessageContentPart instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    internal static void WriteCoreContentPart(ChatMessageContentPart instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         writer.WriteStartObject();
 

--- a/src/Custom/Chat/FunctionChatMessage.Serialization.cs
+++ b/src/Custom/Chat/FunctionChatMessage.Serialization.cs
@@ -13,24 +13,29 @@ public partial class FunctionChatMessage : IJsonModel<FunctionChatMessage>
 
     internal static void SerializeFunctionChatMessage(FunctionChatMessage instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        instance.WriteCore(writer, options);
+    }
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
         writer.WriteStartObject();
         writer.WritePropertyName("name"u8);
-        writer.WriteStringValue(instance.FunctionName);
+        writer.WriteStringValue(FunctionName);
         writer.WritePropertyName("role"u8);
-        writer.WriteStringValue(instance.Role);
-        if (Optional.IsCollectionDefined(instance.Content))
+        writer.WriteStringValue(Role);
+        if (Optional.IsCollectionDefined(Content))
         {
-            if (instance.Content[0] != null)
+            if (Content[0] != null)
             {
                 writer.WritePropertyName("content"u8);
-                writer.WriteStringValue(instance.Content[0].Text);
+                writer.WriteStringValue(Content[0].Text);
             }
             else
             {
                 writer.WriteNull("content");
             }
         }
-        writer.WriteSerializedAdditionalRawData(instance._serializedAdditionalRawData, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
         writer.WriteEndObject();
     }
 

--- a/src/Custom/Chat/Internal/UnknownChatMessage.Serialization.cs
+++ b/src/Custom/Chat/Internal/UnknownChatMessage.Serialization.cs
@@ -9,24 +9,29 @@ namespace OpenAI.Chat;
 internal partial class UnknownChatMessage : IJsonModel<ChatMessage>
 {
     void IJsonModel<ChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        => CustomSerializationHelpers.SerializeInstance<ChatMessage,UnknownChatMessage>(this, SerializeChatMessage, writer, options);
+        => CustomSerializationHelpers.SerializeInstance<ChatMessage,UnknownChatMessage>(this, WriteCore, writer, options);
 
-    internal static void SerializeChatMessage(UnknownChatMessage instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    internal static void WriteCore(UnknownChatMessage instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        instance.WriteCore(writer, options);
+    }
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         writer.WriteStartObject();
         writer.WritePropertyName("role"u8);
-        writer.WriteStringValue(instance.Role);
-        if (Optional.IsCollectionDefined(instance.Content))
+        writer.WriteStringValue(Role);
+        if (Optional.IsCollectionDefined(Content))
         {
             writer.WritePropertyName("content"u8);
             writer.WriteStartArray();
-            foreach (var item in instance.Content)
+            foreach (var item in Content)
             {
                 writer.WriteObjectValue(item, options);
             }
             writer.WriteEndArray();
         }
-        writer.WriteSerializedAdditionalRawData(instance._serializedAdditionalRawData, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
         writer.WriteEndObject();
     }
 

--- a/src/Custom/Chat/SystemChatMessage.Serialization.cs
+++ b/src/Custom/Chat/SystemChatMessage.Serialization.cs
@@ -12,62 +12,24 @@ public partial class SystemChatMessage : IJsonModel<SystemChatMessage>
         => CustomSerializationHelpers.SerializeInstance(this, SerializeSystemChatMessage, writer, options);
 
     internal static void SerializeSystemChatMessage(SystemChatMessage instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         writer.WriteStartObject();
-        if (Optional.IsDefined(instance.ParticipantName))
+        if (Optional.IsDefined(ParticipantName))
         {
             writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(instance.ParticipantName);
+            writer.WriteStringValue(ParticipantName);
         }
         writer.WritePropertyName("role"u8);
-        writer.WriteStringValue(instance.Role);
-        if (Optional.IsCollectionDefined(instance.Content))
+        writer.WriteStringValue(Role);
+        if (Optional.IsCollectionDefined(Content))
         {
             writer.WritePropertyName("content"u8);
-            writer.WriteStringValue(instance.Content[0].Text);
+            writer.WriteStringValue(Content[0].Text);
         }
-        writer.WriteSerializedAdditionalRawData(instance._serializedAdditionalRawData, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
         writer.WriteEndObject();
-    }
-
-    internal static SystemChatMessage DeserializeSystemChatMessage(JsonElement element, ModelReaderWriterOptions options = null)
-    {
-        options ??= ModelSerializationExtensions.WireOptions;
-
-        if (element.ValueKind == JsonValueKind.Null)
-        {
-            return null;
-        }
-        string name = default;
-        string role = default;
-        IList<ChatMessageContentPart> content = default;
-        IDictionary<string, BinaryData> serializedAdditionalRawData = default;
-        Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
-        foreach (var property in element.EnumerateObject())
-        {
-            if (property.NameEquals("name"u8))
-            {
-                name = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("role"u8))
-            {
-                role = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("content"u8))
-            {
-                List<ChatMessageContentPart> array = new List<ChatMessageContentPart>();
-                array.Add(ChatMessageContentPart.CreateTextMessageContentPart(property.Value.GetString()));
-                content = array;
-                continue;
-            }
-            if (true)
-            {
-                rawDataDictionary.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
-            }
-        }
-        serializedAdditionalRawData = rawDataDictionary;
-        return new SystemChatMessage(role, content ?? new ChangeTrackingList<ChatMessageContentPart>(), serializedAdditionalRawData, name);
     }
 }

--- a/src/Custom/Chat/SystemChatMessage.cs
+++ b/src/Custom/Chat/SystemChatMessage.cs
@@ -22,7 +22,8 @@ public partial class SystemChatMessage : ChatMessage
         Argument.AssertNotNull(content, nameof(content));
 
         Role = "system";
-        Content = [ChatMessageContentPart.CreateTextMessageContentPart(content)];
+        Content = new ChangeTrackingList<ChatMessageContentPart>(
+            (IList<ChatMessageContentPart>)[ChatMessageContentPart.CreateTextMessageContentPart(content)]);
     }
 
     /// <summary>

--- a/src/Custom/Chat/ToolChatMessage.Serialization.cs
+++ b/src/Custom/Chat/ToolChatMessage.Serialization.cs
@@ -12,59 +12,21 @@ public partial class ToolChatMessage : IJsonModel<ToolChatMessage>
         => CustomSerializationHelpers.SerializeInstance(this, SerializeToolChatMessage, writer, options);
 
     internal static void SerializeToolChatMessage(ToolChatMessage instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         writer.WriteStartObject();
         writer.WritePropertyName("tool_call_id"u8);
-        writer.WriteStringValue(instance.ToolCallId);
+        writer.WriteStringValue(ToolCallId);
         writer.WritePropertyName("role"u8);
-        writer.WriteStringValue(instance.Role);
-        if (Optional.IsCollectionDefined(instance.Content))
+        writer.WriteStringValue(Role);
+        if (Optional.IsCollectionDefined(Content))
         {
             writer.WritePropertyName("content"u8);
-            writer.WriteStringValue(instance.Content[0].Text);
+            writer.WriteStringValue(Content[0].Text);
         }
-        writer.WriteSerializedAdditionalRawData(instance._serializedAdditionalRawData, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
         writer.WriteEndObject();
-    }
-
-    internal static ToolChatMessage DeserializeToolChatMessage(JsonElement element, ModelReaderWriterOptions options = null)
-    {
-        options ??= ModelSerializationExtensions.WireOptions;
-
-        if (element.ValueKind == JsonValueKind.Null)
-        {
-            return null;
-        }
-        string toolCallId = default;
-        string role = default;
-        IList<ChatMessageContentPart> content = default;
-        IDictionary<string, BinaryData> serializedAdditionalRawData = default;
-        Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
-        foreach (var property in element.EnumerateObject())
-        {
-            if (property.NameEquals("tool_call_id"u8))
-            {
-                toolCallId = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("role"u8))
-            {
-                role = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("content"u8))
-            {
-                List<ChatMessageContentPart> array = new List<ChatMessageContentPart>();
-                array.Add(ChatMessageContentPart.CreateTextMessageContentPart(property.Value.GetString()));
-                content = array;
-                continue;
-            }
-            if (true)
-            {
-                rawDataDictionary.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
-            }
-        }
-        serializedAdditionalRawData = rawDataDictionary;
-        return new ToolChatMessage(role, content ?? new ChangeTrackingList<ChatMessageContentPart>(), serializedAdditionalRawData, toolCallId);
     }
 }

--- a/src/Custom/Chat/UserChatMessage.Serialization.cs
+++ b/src/Custom/Chat/UserChatMessage.Serialization.cs
@@ -12,86 +12,36 @@ public partial class UserChatMessage : IJsonModel<UserChatMessage>
         => CustomSerializationHelpers.SerializeInstance(this, SerializeUserChatMessage, writer, options);
 
     internal static void SerializeUserChatMessage(UserChatMessage instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => instance.WriteCore(writer, options);
+
+    protected override void WriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         writer.WriteStartObject();
-        if (Optional.IsDefined(instance.ParticipantName))
+        if (Optional.IsDefined(ParticipantName))
         {
             writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(instance.ParticipantName);
+            writer.WriteStringValue(ParticipantName);
         }
         writer.WritePropertyName("role"u8);
-        writer.WriteStringValue(instance.Role);
-        if (Optional.IsCollectionDefined(instance.Content))
+        writer.WriteStringValue(Role);
+        if (Optional.IsCollectionDefined(Content))
         {
             writer.WritePropertyName("content"u8);
-            if (instance.Content.Count == 1 && !string.IsNullOrEmpty(instance.Content[0].Text))
+            if (Content.Count == 1 && !string.IsNullOrEmpty(Content[0].Text))
             {
-                writer.WriteStringValue(instance.Content[0].Text);
+                writer.WriteStringValue(Content[0].Text);
             }
             else
             {
                 writer.WriteStartArray();
-                foreach (var item in instance.Content)
+                foreach (var item in Content)
                 {
                     writer.WriteObjectValue(item, options);
                 }
                 writer.WriteEndArray();
             }
         }
-        writer.WriteSerializedAdditionalRawData(instance._serializedAdditionalRawData, options);
+        writer.WriteSerializedAdditionalRawData(_serializedAdditionalRawData, options);
         writer.WriteEndObject();
-    }
-
-    internal static UserChatMessage DeserializeUserChatMessage(JsonElement element, ModelReaderWriterOptions options = null)
-    {
-        options ??= ModelSerializationExtensions.WireOptions;
-
-        if (element.ValueKind == JsonValueKind.Null)
-        {
-            return null;
-        }
-        string name = default;
-        string role = default;
-        IList<ChatMessageContentPart> content = default;
-        IDictionary<string, BinaryData> serializedAdditionalRawData = default;
-        Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
-        foreach (var property in element.EnumerateObject())
-        {
-            if (property.NameEquals("name"u8))
-            {
-                name = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("role"u8))
-            {
-                role = property.Value.GetString();
-                continue;
-            }
-            if (property.NameEquals("content"u8))
-            {
-                if (property.Value.ValueKind == JsonValueKind.String)
-                {
-                    List<ChatMessageContentPart> array = new List<ChatMessageContentPart>();
-                    array.Add(ChatMessageContentPart.CreateTextMessageContentPart(property.Value.GetString()));
-                    continue;
-                }
-                else
-                {
-                    List<ChatMessageContentPart> array = new List<ChatMessageContentPart>();
-                    foreach (var item in property.Value.EnumerateArray())
-                    {
-                        array.Add(ChatMessageContentPart.DeserializeChatMessageContentPart(item, options));
-                    }
-                    content = array;
-                    continue;
-                }
-            }
-            if (true)
-            {
-                rawDataDictionary.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
-            }
-        }
-        serializedAdditionalRawData = rawDataDictionary;
-        return new UserChatMessage(role, content ?? new ChangeTrackingList<ChatMessageContentPart>(), serializedAdditionalRawData, name);
     }
 }

--- a/src/Custom/FineTuning/Internal/GeneratorStubs.cs
+++ b/src/Custom/FineTuning/Internal/GeneratorStubs.cs
@@ -88,15 +88,3 @@ internal partial class InternalFinetuneChatRequestInput { }
 
 [CodeGenModel("FineTuneChatCompletionRequestAssistantMessage")]
 internal partial class InternalFineTuneChatCompletionRequestAssistantMessage { }
-
-[CodeGenModel("FineTuneChatCompletionRequestAssistantMessageFunctionCall")]
-internal partial class InternalFineTuneChatCompletionRequestAssistantMessageFunctionCall { }
-
-[CodeGenModel("FineTuneChatCompletionRequestAssistantMessageRole")]
-internal readonly partial struct InternalFineTuneChatCompletionRequestAssistantMessageRole { }
-
-[CodeGenModel("FineTuneChatCompletionRequestAssistantMessageWeight")]
-internal readonly partial struct InternalFineTuneChatCompletionRequestAssistantMessageWeight { }
-
-[CodeGenModel("FineTuneChatCompletionRequestFunctionMessage")]
-internal partial class InternalFineTuneChatCompletionRequestFunctionMessage { }

--- a/src/Custom/VectorStores/VectorStoreClient.cs
+++ b/src/Custom/VectorStores/VectorStoreClient.cs
@@ -16,6 +16,10 @@ namespace OpenAI.VectorStores;
 /// The service client for OpenAI vector store operations.
 /// </summary>
 [CodeGenClient("VectorStores")]
+[CodeGenSuppress("CreateVectorStoreAsync", typeof(VectorStoreCreationOptions))]
+[CodeGenSuppress("CreateVectorStore", typeof(VectorStoreCreationOptions))]
+[CodeGenSuppress("DeleteVectorStoreAsync", typeof(string))]
+[CodeGenSuppress("DeleteVectorStore", typeof(string))]
 [CodeGenSuppress("GetVectorStoresAsync", typeof(int?), typeof(ListOrder?), typeof(string), typeof(string))]
 [CodeGenSuppress("GetVectorStores", typeof(int?), typeof(ListOrder?), typeof(string), typeof(string))]
 [CodeGenSuppress("GetVectorStoreFilesAsync", typeof(string), typeof(int?), typeof(ListOrder?), typeof(string), typeof(string), typeof(VectorStoreFileStatusFilter?))]

--- a/src/Generated/Models/AssistantChatMessage.Serialization.cs
+++ b/src/Generated/Models/AssistantChatMessage.Serialization.cs
@@ -5,6 +5,7 @@
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Text.Json;
 
 namespace OpenAI.Chat
@@ -21,6 +22,77 @@ namespace OpenAI.Chat
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
             return DeserializeAssistantChatMessage(document.RootElement, options);
+        }
+
+        internal static AssistantChatMessage DeserializeAssistantChatMessage(JsonElement element, ModelReaderWriterOptions options = null)
+        {
+            options ??= ModelSerializationExtensions.WireOptions;
+
+            if (element.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+            string name = default;
+            IList<ChatToolCall> toolCalls = default;
+            ChatFunctionCall functionCall = default;
+            string role = "assistant";
+            IList<ChatMessageContentPart> content = default;
+            IDictionary<string, BinaryData> serializedAdditionalRawData = default;
+            Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("name"u8))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("tool_calls"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    List<ChatToolCall> array = new List<ChatToolCall>();
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array.Add(ChatToolCall.DeserializeChatToolCall(item, options));
+                    }
+                    toolCalls = array;
+                    continue;
+                }
+                if (property.NameEquals("function_call"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        functionCall = null;
+                        continue;
+                    }
+                    functionCall = ChatFunctionCall.DeserializeChatFunctionCall(property.Value, options);
+                    continue;
+                }
+                if (property.NameEquals("role"u8))
+                {
+                    role = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("content"u8))
+                {
+                    DeserializeContentValue(property, ref content);
+                    continue;
+                }
+                if (true)
+                {
+                    rawDataDictionary.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
+                }
+            }
+            serializedAdditionalRawData = rawDataDictionary;
+            return new AssistantChatMessage(
+                role,
+                content ?? new ChangeTrackingList<ChatMessageContentPart>(),
+                serializedAdditionalRawData,
+                name,
+                toolCalls ?? new ChangeTrackingList<ChatToolCall>(),
+                functionCall);
         }
 
         BinaryData IPersistableModel<AssistantChatMessage>.Write(ModelReaderWriterOptions options)

--- a/src/Generated/Models/CodeInterpreterToolDefinition.Serialization.cs
+++ b/src/Generated/Models/CodeInterpreterToolDefinition.Serialization.cs
@@ -12,35 +12,6 @@ namespace OpenAI.Assistants
 {
     public partial class CodeInterpreterToolDefinition : IJsonModel<CodeInterpreterToolDefinition>
     {
-        void IJsonModel<CodeInterpreterToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<CodeInterpreterToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(CodeInterpreterToolDefinition)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(Type);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         CodeInterpreterToolDefinition IJsonModel<CodeInterpreterToolDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<CodeInterpreterToolDefinition>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/FileSearchToolDefinition.Serialization.cs
+++ b/src/Generated/Models/FileSearchToolDefinition.Serialization.cs
@@ -12,40 +12,6 @@ namespace OpenAI.Assistants
 {
     public partial class FileSearchToolDefinition : IJsonModel<FileSearchToolDefinition>
     {
-        void IJsonModel<FileSearchToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<FileSearchToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(FileSearchToolDefinition)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            if (Optional.IsDefined(_fileSearch))
-            {
-                writer.WritePropertyName("file_search"u8);
-                writer.WriteObjectValue<InternalAssistantToolsFileSearchFileSearch>(_fileSearch, options);
-            }
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(Type);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         FileSearchToolDefinition IJsonModel<FileSearchToolDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<FileSearchToolDefinition>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/FunctionToolDefinition.Serialization.cs
+++ b/src/Generated/Models/FunctionToolDefinition.Serialization.cs
@@ -12,37 +12,6 @@ namespace OpenAI.Assistants
 {
     public partial class FunctionToolDefinition : IJsonModel<FunctionToolDefinition>
     {
-        void IJsonModel<FunctionToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<FunctionToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(FunctionToolDefinition)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("function"u8);
-            writer.WriteObjectValue<InternalFunctionDefinition>(_internalFunction, options);
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(Type);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         FunctionToolDefinition IJsonModel<FunctionToolDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<FunctionToolDefinition>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/InternalFineTuneChatCompletionRequestAssistantMessage.Serialization.cs
+++ b/src/Generated/Models/InternalFineTuneChatCompletionRequestAssistantMessage.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using OpenAI.Chat;
 
-namespace OpenAI.Internal.FineTuning
+namespace OpenAI.FineTuning
 {
     internal partial class InternalFineTuneChatCompletionRequestAssistantMessage : IJsonModel<InternalFineTuneChatCompletionRequestAssistantMessage>
     {

--- a/src/Generated/Models/InternalFineTuneChatCompletionRequestAssistantMessage.cs
+++ b/src/Generated/Models/InternalFineTuneChatCompletionRequestAssistantMessage.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using OpenAI.Chat;
 
-namespace OpenAI.Internal.FineTuning
+namespace OpenAI.FineTuning
 {
     internal partial class InternalFineTuneChatCompletionRequestAssistantMessage : AssistantChatMessage
     {

--- a/src/Generated/Models/InternalFinetuneChatRequestInput.Serialization.cs
+++ b/src/Generated/Models/InternalFinetuneChatRequestInput.Serialization.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using OpenAI.Chat;
 
-namespace OpenAI.Internal.FineTuning
+namespace OpenAI.FineTuning
 {
     internal partial class InternalFinetuneChatRequestInput : IJsonModel<InternalFinetuneChatRequestInput>
     {

--- a/src/Generated/Models/InternalFinetuneChatRequestInput.cs
+++ b/src/Generated/Models/InternalFinetuneChatRequestInput.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using OpenAI.Chat;
 
-namespace OpenAI.Internal.FineTuning
+namespace OpenAI.FineTuning
 {
     internal partial class InternalFinetuneChatRequestInput
     {

--- a/src/Generated/Models/InternalMessageImageFileContent.Serialization.cs
+++ b/src/Generated/Models/InternalMessageImageFileContent.Serialization.cs
@@ -12,37 +12,6 @@ namespace OpenAI.Assistants
 {
     internal partial class InternalMessageImageFileContent : IJsonModel<InternalMessageImageFileContent>
     {
-        void IJsonModel<InternalMessageImageFileContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<InternalMessageImageFileContent>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(InternalMessageImageFileContent)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(_type);
-            writer.WritePropertyName("image_file"u8);
-            writer.WriteObjectValue<InternalMessageContentItemFileObjectImageFile>(_imageFile, options);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         InternalMessageImageFileContent IJsonModel<InternalMessageImageFileContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<InternalMessageImageFileContent>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/InternalMessageImageUrlContent.Serialization.cs
+++ b/src/Generated/Models/InternalMessageImageUrlContent.Serialization.cs
@@ -12,37 +12,6 @@ namespace OpenAI.Assistants
 {
     internal partial class InternalMessageImageUrlContent : IJsonModel<InternalMessageImageUrlContent>
     {
-        void IJsonModel<InternalMessageImageUrlContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<InternalMessageImageUrlContent>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(InternalMessageImageUrlContent)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(_type);
-            writer.WritePropertyName("image_url"u8);
-            writer.WriteObjectValue<InternalMessageContentImageUrlObjectImageUrl>(_imageUrl, options);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         InternalMessageImageUrlContent IJsonModel<InternalMessageImageUrlContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<InternalMessageImageUrlContent>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/InternalRequestMessageTextContent.Serialization.cs
+++ b/src/Generated/Models/InternalRequestMessageTextContent.Serialization.cs
@@ -12,37 +12,6 @@ namespace OpenAI.Assistants
 {
     internal partial class InternalRequestMessageTextContent : IJsonModel<InternalRequestMessageTextContent>
     {
-        void IJsonModel<InternalRequestMessageTextContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<InternalRequestMessageTextContent>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(InternalRequestMessageTextContent)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(Type.ToString());
-            writer.WritePropertyName("text"u8);
-            writer.WriteStringValue(InternalText);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         InternalRequestMessageTextContent IJsonModel<InternalRequestMessageTextContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<InternalRequestMessageTextContent>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/InternalResponseMessageTextContent.Serialization.cs
+++ b/src/Generated/Models/InternalResponseMessageTextContent.Serialization.cs
@@ -12,37 +12,6 @@ namespace OpenAI.Assistants
 {
     internal partial class InternalResponseMessageTextContent : IJsonModel<InternalResponseMessageTextContent>
     {
-        void IJsonModel<InternalResponseMessageTextContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<InternalResponseMessageTextContent>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(InternalResponseMessageTextContent)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(_type);
-            writer.WritePropertyName("text"u8);
-            writer.WriteObjectValue<MessageContentTextObjectText>(_text, options);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         InternalResponseMessageTextContent IJsonModel<InternalResponseMessageTextContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<InternalResponseMessageTextContent>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/MessageContent.Serialization.cs
+++ b/src/Generated/Models/MessageContent.Serialization.cs
@@ -11,33 +11,6 @@ namespace OpenAI.Assistants
 {
     public partial class MessageContent : IJsonModel<MessageContent>
     {
-        void IJsonModel<MessageContent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<MessageContent>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(MessageContent)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         MessageContent IJsonModel<MessageContent>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<MessageContent>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/SystemChatMessage.Serialization.cs
+++ b/src/Generated/Models/SystemChatMessage.Serialization.cs
@@ -5,6 +5,7 @@
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Text.Json;
 
 namespace OpenAI.Chat
@@ -21,6 +22,45 @@ namespace OpenAI.Chat
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
             return DeserializeSystemChatMessage(document.RootElement, options);
+        }
+
+        internal static SystemChatMessage DeserializeSystemChatMessage(JsonElement element, ModelReaderWriterOptions options = null)
+        {
+            options ??= ModelSerializationExtensions.WireOptions;
+
+            if (element.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+            string name = default;
+            string role = default;
+            IList<ChatMessageContentPart> content = default;
+            IDictionary<string, BinaryData> serializedAdditionalRawData = default;
+            Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("name"u8))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("role"u8))
+                {
+                    role = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("content"u8))
+                {
+                    DeserializeContentValue(property, ref content);
+                    continue;
+                }
+                if (true)
+                {
+                    rawDataDictionary.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
+                }
+            }
+            serializedAdditionalRawData = rawDataDictionary;
+            return new SystemChatMessage(role, content ?? new ChangeTrackingList<ChatMessageContentPart>(), serializedAdditionalRawData, name);
         }
 
         BinaryData IPersistableModel<SystemChatMessage>.Write(ModelReaderWriterOptions options)

--- a/src/Generated/Models/ToolDefinition.Serialization.cs
+++ b/src/Generated/Models/ToolDefinition.Serialization.cs
@@ -12,35 +12,6 @@ namespace OpenAI.Assistants
     [PersistableModelProxy(typeof(UnknownAssistantToolDefinition))]
     public partial class ToolDefinition : IJsonModel<ToolDefinition>
     {
-        void IJsonModel<ToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<ToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(ToolDefinition)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(Type);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         ToolDefinition IJsonModel<ToolDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<ToolDefinition>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/UnknownAssistantToolDefinition.Serialization.cs
+++ b/src/Generated/Models/UnknownAssistantToolDefinition.Serialization.cs
@@ -12,35 +12,6 @@ namespace OpenAI.Assistants
 {
     internal partial class UnknownAssistantToolDefinition : IJsonModel<ToolDefinition>
     {
-        void IJsonModel<ToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-        {
-            var format = options.Format == "W" ? ((IPersistableModel<ToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-            if (format != "J")
-            {
-                throw new FormatException($"The model {nameof(ToolDefinition)} does not support writing '{format}' format.");
-            }
-
-            writer.WriteStartObject();
-            writer.WritePropertyName("type"u8);
-            writer.WriteStringValue(Type);
-            if (true && _serializedAdditionalRawData != null)
-            {
-                foreach (var item in _serializedAdditionalRawData)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
-            writer.WriteEndObject();
-        }
-
         ToolDefinition IJsonModel<ToolDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             var format = options.Format == "W" ? ((IPersistableModel<ToolDefinition>)this).GetFormatFromOptions(options) : options.Format;

--- a/src/Generated/Models/UserChatMessage.Serialization.cs
+++ b/src/Generated/Models/UserChatMessage.Serialization.cs
@@ -5,6 +5,7 @@
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Text.Json;
 
 namespace OpenAI.Chat
@@ -21,6 +22,45 @@ namespace OpenAI.Chat
 
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
             return DeserializeUserChatMessage(document.RootElement, options);
+        }
+
+        internal static UserChatMessage DeserializeUserChatMessage(JsonElement element, ModelReaderWriterOptions options = null)
+        {
+            options ??= ModelSerializationExtensions.WireOptions;
+
+            if (element.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+            string name = default;
+            string role = default;
+            IList<ChatMessageContentPart> content = default;
+            IDictionary<string, BinaryData> serializedAdditionalRawData = default;
+            Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("name"u8))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("role"u8))
+                {
+                    role = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("content"u8))
+                {
+                    DeserializeContentValue(property, ref content);
+                    continue;
+                }
+                if (true)
+                {
+                    rawDataDictionary.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
+                }
+            }
+            serializedAdditionalRawData = rawDataDictionary;
+            return new UserChatMessage(role, content ?? new ChangeTrackingList<ChatMessageContentPart>(), serializedAdditionalRawData, name);
         }
 
         BinaryData IPersistableModel<UserChatMessage>.Write(ModelReaderWriterOptions options)

--- a/tests/GitHubTests.cs
+++ b/tests/GitHubTests.cs
@@ -7,6 +7,7 @@ public partial class GitHubTests
 {
     [Test(Description = "Test that we can use a GitHub secret")]
     [Category("Online")]
+    [Ignore("Placeholder")]
     public void CanUseGitHubSecret()
     {
         string gitHubSecretString = Environment.GetEnvironmentVariable("SECRET_VALUE");
@@ -15,6 +16,7 @@ public partial class GitHubTests
 
     [Test(Description = "That that we can run some tests without secrets")]
     [Category("Offline")]
+    [Ignore("Placeholder")]
     public void CanTestWithoutSecretAccess()
     {
         int result = 2 + 1;


### PR DESCRIPTION
As reported:
- fixes #30 

As described in this dotnet runtime issue, some environments encounter a peculiarity with explicit interface method implementations involving covariant generics:

https://github.com/dotnet/runtime/issues/103365

This manifests as several derived types, most notably the one used for chat messages, inappropriately invoking the serialization logic for the abstract base type rather than the intended derived type -- meaning we *don't* serialize the important `content` value and send invalid requests.

Pending runtime resolution, this change aligns this library's impacted request types with a better practice of managing serialization in an overrideable `WriteCore()`; this means that, even with the covariant oddity invoking the wrong instantiation of the explicit interface, we'll use the correct serialization logic from the downcast type.