### PR TITLE
Address non-ASCII filename support for files, audio, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - ([#72](https://github.com/openai/openai-dotnet/issues/72)) Fixed `filename` request encoding in operations using `multipart/form-data`, including `files` and `audio`
 
-## Breaking Changes
-
-- To properly support non-ASCII filenames, `multipart/form-data` requests now use the default behavior of `System.Net.Http.MultipartFormDataContent` for `Content-Disposition` content part headers; this will now include the `filename*` header, aligned with [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266#section-4.3) but contrary to [RFC 7578](https://www.rfc-editor.org/rfc/rfc7578#section-4.2). This has no adverse impact with the OpenAI V1 endpoint but could affect API gateways or other intermediaries. `filename` continues to be provided.
-
 ## 2.0.0-beta.5 (2024-06-14)
 
 ## Features Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.0-beta.6 (Unreleased)
+
+## Bugs Fixed
+
+- ([#72](https://github.com/openai/openai-dotnet/issues/72)) Fixed `filename` request encoding in operations using `multipart/form-data`, including `files` and `audio`
+
+## Breaking Changes
+
+- To properly support non-ASCII filenames, `multipart/form-data` requests now use the default behavior of `System.Net.Http.MultipartFormDataContent` for `Content-Disposition` content part headers; this will now include the `filename*` header, aligned with [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266#section-4.3) but contrary to [RFC 7578](https://www.rfc-editor.org/rfc/rfc7578#section-4.2). This has no adverse impact with the OpenAI V1 endpoint but could affect API gateways or other intermediaries. `filename` continues to be provided.
+
 ## 2.0.0-beta.5 (2024-06-14)
 
 ## Features Added

--- a/src/Utility/MultipartFormDataBinaryContent.cs
+++ b/src/Utility/MultipartFormDataBinaryContent.cs
@@ -75,14 +75,14 @@ internal class MultipartFormDataBinaryContent : BinaryContent
         Add(new ByteArrayContent(content.ToArray()), name, fileName);
     }
 
-    private void Add(HttpContent content, string name, string filename)
+    private void Add(HttpContent content, string name, string fileName)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNull(name, nameof(name));
 
-        if (filename is not null)
+        if (fileName is not null)
         {
-            _multipartContent.Add(content, name, filename);
+            _multipartContent.Add(content, name, fileName);
         }
         else
         {

--- a/tests/Files/FileTests.cs
+++ b/tests/Files/FileTests.cs
@@ -83,5 +83,17 @@ public partial class FileTests : SyncAsyncTestBase
         // TODO: Add this test.
     }
 
+    [Test]
+    public async Task NonAsciiFilename()
+    {
+        FileClient client = GetTestClient();
+        string filename = "你好.txt";
+        BinaryData fileContent = BinaryData.FromString("世界您好！这是个测试。");
+        OpenAIFileInfo uploadedFile = IsAsync
+            ? await client.UploadFileAsync(fileContent, filename, FileUploadPurpose.Assistants)
+            : client.UploadFile(fileContent, filename, FileUploadPurpose.Assistants);
+        Assert.That(uploadedFile?.Filename, Is.EqualTo(filename));
+    }
+
     private static FileClient GetTestClient() => GetTestClient<FileClient>(TestScenario.Files);
 }


### PR DESCRIPTION
Fixes #72.

The library's `multipart/form-data` implementation uses custom logic to bypass the use of the `filename*` `Content-Disposition` parameter, which is [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266#section-4.3)'s method of encoding non-ASCII filenames in `multipart/form-data` requests. This bypass was made in deference to an interpretation of [RFC 7578](https://www.rfc-editor.org/rfc/rfc7578#section-4.2) wherein the use of `filename*` is disallowed.

This PR removes the restriction by directly using `System.Net.Http.MultipartFormDataContent.Add()`'s `filename*` behavior.

Although pending discussion with the Base Common Library team is still needed to clarify best interoperability practices, this is a better current state because:

- It aligns with the existing language type in `System.Net.Http`
- The interpretation of the competing RFC is ambiguous; it appears it may not be making a statement about the `filename*` parameter itself, but rather on the use of the *encoding scheme* of the newer `filename*` in the older `filename`
- Most importantly, it fixes the readily observable issue against the OpenAI V1 endpoint -- and still leaves the older `filename` intact for any unanticipated backwards compatibility issues with API gateways or other intermediaries