### PR TITLE
Allow ChatCompletionOption properties to be set/changed after instantiation

### DIFF
--- a/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/src/Custom/Chat/ChatCompletionOptions.cs
@@ -59,12 +59,12 @@ public partial class ChatCompletionOptions
     // CUSTOM: Renamed.
     /// <summary> Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the message content. </summary>
     [CodeGenMember("Logprobs")]
-    public bool? IncludeLogProbabilities { get; init; }
+    public bool? IncludeLogProbabilities { get; set; }
 
     // CUSTOM: Renamed.
     /// <summary> An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. <see cref="IncludeLogProbabilities"/> must be set to <see langword="true"/> if this property is used. </summary>
     [CodeGenMember("TopLogprobs")]
-    public int? TopLogProbabilityCount { get; init; }
+    public int? TopLogProbabilityCount { get; set; }
 
     // CUSTOM:
     // - Renamed.
@@ -91,7 +91,7 @@ public partial class ChatCompletionOptions
     /// </remarks>
     /// </summary>
     [CodeGenMember("ToolChoice")]
-    public ChatToolChoice ToolChoice { get; init; }
+    public ChatToolChoice ToolChoice { get; set; }
 
     // CUSTOM:
     // - Renamed.
@@ -100,7 +100,7 @@ public partial class ChatCompletionOptions
     /// Deprecated in favor of <see cref="ToolChoice"/>.
     /// </summary>
     [CodeGenMember("FunctionCall")]
-    public ChatFunctionChoice FunctionChoice { get; init; }
+    public ChatFunctionChoice FunctionChoice { get; set; }
 
     /// <summary>
     /// Whether to enable parallel function calling during tool use. 
@@ -109,5 +109,5 @@ public partial class ChatCompletionOptions
     /// Assumed <c>true</c> if not otherwise specified.
     /// </remarks>
     [CodeGenMember("ParallelToolCalls")]
-    public bool? ParallelToolCallsEnabled { get; init; }
+    public bool? ParallelToolCallsEnabled { get; set; }
 }


### PR DESCRIPTION
The same way we can change Tools and other Properties in the Options class for long running Chats we normally need to change the `ToolChoice`, and as well as other properties of the chat iteration.

Currently that is only possible allocating (deep cloning) a new Option instance with those few options with the desired value.