### PR TITLE
Fix NullReferenceException thrown in CreateAddCustomHeadersPolicy when OpenAIClientOptions is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.0-beta.7 (Unreleased)
+
+## Bugs Fixed
+
+- ([#84](https://github.com/openai/openai-dotnet/issues/84)) Fixed a `NullReferenceException` thrown when adding the custom headers policy while `OpenAIClientOptions` is null (commit_hash)
+
 ## 2.0.0-beta.6 (2024-06-21)
 
 ## Features Added

--- a/src/Custom/OpenAIClient.cs
+++ b/src/Custom/OpenAIClient.cs
@@ -277,11 +277,11 @@ public partial class OpenAIClient
                 message.Request.Headers.Set(UserAgentHeaderName, telemetryDetails.ToString());
             }
 
-            if (!string.IsNullOrEmpty(options.OrganizationId))
+            if (!string.IsNullOrEmpty(options?.OrganizationId))
             {
                 message.Request.Headers.Set(OpenAIOrganizationHeaderName, options.OrganizationId);
             }
-            if (!string.IsNullOrEmpty(options.ProjectId))
+            if (!string.IsNullOrEmpty(options?.ProjectId))
             {
                 message.Request.Headers.Set(OpenAIProjectHeaderName, options.ProjectId);
             }

--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -5,7 +5,7 @@
     <PackageTags>OpenAI</PackageTags>
 
     <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>beta.6</VersionSuffix>
+    <VersionSuffix>beta.7</VersionSuffix>
 
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
This change adds a necessary null check to the `CreateAddCustomHeadersPolicy` method in the `OpenAIClient` for the cases when the `OpenAIClientOptions` argument is null.