### PR TITLE
Remove net6.0 multitarget for improved compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Release History
 
-## 2.0.0-beta.7 (Unreleased)
+## 2.0.0-beta.8 (Unreleased)
 
 ## Bugs Fixed
 
-- ([#84](https://github.com/openai/openai-dotnet/issues/84)) Fixed a `NullReferenceException` thrown when adding the custom headers policy while `OpenAIClientOptions` is null (commit_hash)
+- Removed the project's multi-target to net6.0 to improve compatibility when calling via a netstandard2.x class library (commit_hash)
+
+## 2.0.0-beta.7 (2024-06-24)
+
+## Bugs Fixed
+
+- ([#84](https://github.com/openai/openai-dotnet/issues/84)) Fixed a `NullReferenceException` thrown when adding the custom headers policy while `OpenAIClientOptions` is null ([0b97311](https://github.com/openai/openai-dotnet/commit/0b97311f58dfb28bd883d990f68d548da040a807))
 
 ## 2.0.0-beta.6 (2024-06-21)
 

--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>beta.7</VersionSuffix>
 
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
     <!-- Sign the assembly with the specified key file. -->


### PR DESCRIPTION
As described at:
https://github.com/Azure/azure-sdk-for-net/issues/44709

These problems are specific to using the OpenAI library via an intermediate class library targeting `netstandard2.0`; in that case, the multi-target is causing the executing project to pick up the uplevel framework target that's incompatible with downlevel intermediate library.

Although there may be other approaches to mitigate, it seems reasonable to not expressly multi-target net6.0 if netstandard2.0 is sufficient.