### PR TITLE
Add 'smoke' category and parallelism to tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Test
         run: dotnet test
           --configuration Release
-          --filter="TestCategory~${{ github.event_name == 'pull_request' && 'Offline' || 'Online' }}"
+          --filter="TestCategory~${{ github.event_name == 'pull_request' && 'Offline' || 'Online' }}|TestCategory~smoke"
           --logger "trx;LogFileName=${{github.workspace}}/artifacts/test-results/full.trx"
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/src/Custom/OpenAIClient.cs
+++ b/src/Custom/OpenAIClient.cs
@@ -16,6 +16,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace OpenAI;
 
+// CUSTOM:
+// - Suppressed cached clients. Clients are not singletons, and users can create multiple clients of the same type
+//   if needed (e.g., to target different OpenAI models). The Get*Client methods return new client instances.
 /// <summary>
 /// A top-level client factory that enables convenient creation of scenario-specific sub-clients while reusing shared
 /// configuration details like endpoint, authentication, and pipeline customization.
@@ -23,6 +26,21 @@ namespace OpenAI;
 [CodeGenModel("OpenAIClient")]
 [CodeGenSuppress("OpenAIClient", typeof(ApiKeyCredential))]
 [CodeGenSuppress("OpenAIClient", typeof(Uri), typeof(ApiKeyCredential), typeof(OpenAIClientOptions))]
+[CodeGenSuppress("_cachedAssistantClient")]
+[CodeGenSuppress("_cachedAudioClient")]
+[CodeGenSuppress("_cachedBatchClient")]
+[CodeGenSuppress("_cachedChatClient")]
+[CodeGenSuppress("_cachedEmbeddingClient")]
+[CodeGenSuppress("_cachedFileClient")]
+[CodeGenSuppress("_cachedFineTuningClient")]
+[CodeGenSuppress("_cachedImageClient")]
+[CodeGenSuppress("_cachedInternalAssistantMessageClient")]
+[CodeGenSuppress("_cachedInternalAssistantRunClient")]
+[CodeGenSuppress("_cachedInternalAssistantThreadClient")]
+[CodeGenSuppress("_cachedLegacyCompletionClient")]
+[CodeGenSuppress("_cachedModelClient")]
+[CodeGenSuppress("_cachedModerationClient")]
+[CodeGenSuppress("_cachedVectorStoreClient")]
 [CodeGenSuppress("GetAssistantClientClient")]
 [CodeGenSuppress("GetAudioClientClient")]
 [CodeGenSuppress("GetBatchClientClient")]

--- a/src/Generated/LegacyCompletionClient.cs
+++ b/src/Generated/LegacyCompletionClient.cs
@@ -31,20 +31,20 @@ namespace OpenAI.LegacyCompletions
             _endpoint = endpoint;
         }
 
-        public virtual async Task<ClientResult<InternalCreateCompletionResponse>> CreateCompletionAsync(InternalCreateCompletionRequest internalCreateCompletionRequest)
+        public virtual async Task<ClientResult<InternalCreateCompletionResponse>> CreateCompletionAsync(InternalCreateCompletionRequest requestBody)
         {
-            Argument.AssertNotNull(internalCreateCompletionRequest, nameof(internalCreateCompletionRequest));
+            Argument.AssertNotNull(requestBody, nameof(requestBody));
 
-            using BinaryContent content = internalCreateCompletionRequest.ToBinaryContent();
+            using BinaryContent content = requestBody.ToBinaryContent();
             ClientResult result = await CreateCompletionAsync(content, null).ConfigureAwait(false);
             return ClientResult.FromValue(InternalCreateCompletionResponse.FromResponse(result.GetRawResponse()), result.GetRawResponse());
         }
 
-        public virtual ClientResult<InternalCreateCompletionResponse> CreateCompletion(InternalCreateCompletionRequest internalCreateCompletionRequest)
+        public virtual ClientResult<InternalCreateCompletionResponse> CreateCompletion(InternalCreateCompletionRequest requestBody)
         {
-            Argument.AssertNotNull(internalCreateCompletionRequest, nameof(internalCreateCompletionRequest));
+            Argument.AssertNotNull(requestBody, nameof(requestBody));
 
-            using BinaryContent content = internalCreateCompletionRequest.ToBinaryContent();
+            using BinaryContent content = requestBody.ToBinaryContent();
             ClientResult result = CreateCompletion(content, null);
             return ClientResult.FromValue(InternalCreateCompletionResponse.FromResponse(result.GetRawResponse()), result.GetRawResponse());
         }

--- a/src/Generated/Models/EmbeddingCollection.cs
+++ b/src/Generated/Models/EmbeddingCollection.cs
@@ -2,7 +2,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/src/Generated/Models/ModerationCollection.cs
+++ b/src/Generated/Models/ModerationCollection.cs
@@ -2,7 +2,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/src/Generated/Models/OpenAIFileInfoCollection.cs
+++ b/src/Generated/Models/OpenAIFileInfoCollection.cs
@@ -2,7 +2,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/src/Generated/Models/OpenAIModelInfoCollection.cs
+++ b/src/Generated/Models/OpenAIModelInfoCollection.cs
@@ -2,7 +2,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/tests/Assistants/AssistantTests.cs
+++ b/tests/Assistants/AssistantTests.cs
@@ -817,6 +817,12 @@ public partial class AssistantTests
     [OneTimeTearDown]
     protected void Cleanup()
     {
+        // Skip cleanup if there is no API key (e.g., if we are not running live tests).
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OPEN_API_KEY")))
+        {
+            return;
+        }
+
         AssistantClient client = new();
         FileClient fileClient = new();
         VectorStoreClient vectorStoreClient = new();

--- a/tests/Assistants/AssistantTests.cs
+++ b/tests/Assistants/AssistantTests.cs
@@ -15,6 +15,8 @@ using static OpenAI.Tests.TestHelpers;
 namespace OpenAI.Tests.Assistants;
 
 #pragma warning disable OPENAI001
+
+[Parallelizable(ParallelScope.Fixtures)]
 public partial class AssistantTests
 {
     [Test]
@@ -759,6 +761,7 @@ public partial class AssistantTests
     }
 
     [Test]
+    [Category("smoke")]
     public void RunStepDeserialization()
     {
         BinaryData runStepData = BinaryData.FromString(
@@ -811,7 +814,7 @@ public partial class AssistantTests
         Assert.That(deserializedRunStep.Details.ToolCalls[0].CodeInterpreterOutputs[0].Logs, Is.Not.Null.And.Not.Empty);
     }
 
-    [TearDown]
+    [OneTimeTearDown]
     protected void Cleanup()
     {
         AssistantClient client = new();

--- a/tests/Assistants/VectorStoreTests.cs
+++ b/tests/Assistants/VectorStoreTests.cs
@@ -16,6 +16,8 @@ using static OpenAI.Tests.TestHelpers;
 namespace OpenAI.Tests.VectorStores;
 
 #pragma warning disable OPENAI001
+
+[Parallelizable(ParallelScope.Fixtures)]
 public partial class VectorStoreTests
 {
     [Test]

--- a/tests/Audio/TextToSpeechTests.cs
+++ b/tests/Audio/TextToSpeechTests.cs
@@ -11,6 +11,7 @@ namespace OpenAI.Tests.Audio;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class TextToSpeechTests : SyncAsyncTestBase
 {
     public TextToSpeechTests(bool isAsync)

--- a/tests/Audio/TranscriptionTests.cs
+++ b/tests/Audio/TranscriptionTests.cs
@@ -13,6 +13,7 @@ namespace OpenAI.Tests.Audio;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class TranscriptionTests : SyncAsyncTestBase
 {
     public TranscriptionTests(bool isAsync)

--- a/tests/Audio/TranslationTests.cs
+++ b/tests/Audio/TranslationTests.cs
@@ -9,6 +9,7 @@ namespace OpenAI.Tests.Audio;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class TranslationTests : SyncAsyncTestBase
 {
     public TranslationTests(bool isAsync)

--- a/tests/Batch/BatchTests.cs
+++ b/tests/Batch/BatchTests.cs
@@ -13,6 +13,7 @@ namespace OpenAI.Tests.Batch;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class BatchTests : SyncAsyncTestBase
 {
     public BatchTests(bool isAsync)

--- a/tests/Chat/ChatToolTests.cs
+++ b/tests/Chat/ChatToolTests.cs
@@ -14,6 +14,7 @@ namespace OpenAI.Tests.Chat;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class ChatToolTests : SyncAsyncTestBase
 {
     public ChatToolTests(bool isAsync)

--- a/tests/Chat/ChatWithVision.cs
+++ b/tests/Chat/ChatWithVision.cs
@@ -12,6 +12,7 @@ namespace OpenAI.Tests.Chat;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class ChatWithVision : SyncAsyncTestBase
 {
     public ChatWithVision(bool isAsync)

--- a/tests/Embeddings/EmbeddingTests.cs
+++ b/tests/Embeddings/EmbeddingTests.cs
@@ -11,6 +11,7 @@ namespace OpenAI.Tests.Embeddings;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class EmbeddingTests : SyncAsyncTestBase
 {
     public EmbeddingTests(bool isAsync)

--- a/tests/Files/FileTests.cs
+++ b/tests/Files/FileTests.cs
@@ -37,45 +37,72 @@ public partial class FileTests : SyncAsyncTestBase
     }
 
     [Test]
-    public async Task UploadAndDelete()
+    public async Task UploadAndRetrieve()
     {
         FileClient client = GetTestClient();
-        using Stream file = BinaryData.FromString("Hello! This is a test text file. Please delete me.").ToStream();
+        string fileContent = "Hello! This is a test text file. Please delete me.";
+        using Stream file = BinaryData.FromString(fileContent).ToStream();
         string filename = "test-file-delete-me.txt";
 
+        // Upload file.
         OpenAIFileInfo uploadedFile = IsAsync
             ? await client.UploadFileAsync(file, filename, FileUploadPurpose.Assistants)
             : client.UploadFile(file, filename, FileUploadPurpose.Assistants);
         Assert.That(uploadedFile, Is.Not.Null);
-        Assert.That(uploadedFile.Filename, Is.EqualTo(filename));
-        Assert.That(uploadedFile.Purpose, Is.EqualTo(OpenAIFilePurpose.Assistants));
 
-        OpenAIFileInfo fileInfo = IsAsync
-            ? await client.GetFileAsync(uploadedFile.Id)
-            : client.GetFile(uploadedFile.Id);
-        Assert.That(fileInfo.Id, Is.EqualTo(uploadedFile.Id));
-        Assert.That(fileInfo.Filename, Is.EqualTo(uploadedFile.Filename));
+        try
+        {
+            Assert.That(uploadedFile.Filename, Is.EqualTo(filename));
+            Assert.That(uploadedFile.Purpose, Is.EqualTo(OpenAIFilePurpose.Assistants));
 
-        bool deleted = IsAsync
-            ? await client.DeleteFileAsync(uploadedFile.Id)
-            : client.DeleteFile(uploadedFile.Id);
-        Assert.That(deleted, Is.True);
+            // Retrieve file.
+            OpenAIFileInfo retrievedFile = IsAsync
+                ? await client.GetFileAsync(uploadedFile.Id)
+                : client.GetFile(uploadedFile.Id);
+            Assert.That(retrievedFile.Id, Is.EqualTo(uploadedFile.Id));
+            Assert.That(retrievedFile.Filename, Is.EqualTo(uploadedFile.Filename));
+        }
+        finally
+        {
+            // Delete file.
+            bool deleted = IsAsync
+                ? await client.DeleteFileAsync(uploadedFile.Id)
+                : client.DeleteFile(uploadedFile.Id);
+            Assert.That(deleted, Is.True);
+        }
     }
 
     [Test]
-    public async Task DownloadContent()
+    public async Task UploadAndDownloadContent()
     {
         FileClient client = GetTestClient();
+        string imagePath = Path.Combine("Assets", "images_dog_and_cat.png");
 
-        OpenAIFileInfo fileInfo = IsAsync
-            ? await client.GetFileAsync("file-S7roYWamZqfMK9D979HU4q6m")
-            : client.GetFile("file-S7roYWamZqfMK9D979HU4q6m");
-        Assert.That(fileInfo, Is.Not.Null);
+        // Upload file.
+        OpenAIFileInfo uploadedFile = IsAsync
+            ? await client.UploadFileAsync(imagePath, FileUploadPurpose.Vision)
+            : client.UploadFile(imagePath, FileUploadPurpose.Vision);
+        Assert.That(uploadedFile, Is.Not.Null);
 
-        BinaryData downloadedContent = IsAsync
-            ? await client.DownloadFileAsync("file-S7roYWamZqfMK9D979HU4q6m")
-            : client.DownloadFile("file-S7roYWamZqfMK9D979HU4q6m");
-        Assert.That(downloadedContent, Is.Not.Null);
+        try
+        {
+            Assert.That(uploadedFile.Filename, Is.EqualTo(imagePath));
+            Assert.That(uploadedFile.Purpose, Is.EqualTo(OpenAIFilePurpose.Vision));
+
+            // Download file content.
+            BinaryData downloadedContent = IsAsync
+                ? await client.DownloadFileAsync(uploadedFile.Id)
+                : client.DownloadFile(uploadedFile.Id);
+            Assert.That(downloadedContent, Is.Not.Null);
+        }
+        finally
+        {
+            // Delete file.
+            bool deleted = IsAsync
+                ? await client.DeleteFileAsync(uploadedFile.Id)
+                : client.DeleteFile(uploadedFile.Id);
+            Assert.That(deleted, Is.True);
+        }
     }
 
     [Test]

--- a/tests/Files/FileTests.cs
+++ b/tests/Files/FileTests.cs
@@ -10,6 +10,7 @@ namespace OpenAI.Tests.Files;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.Fixtures)]
 public partial class FileTests : SyncAsyncTestBase
 {
     public FileTests(bool isAsync) 

--- a/tests/Images/ImageGenerationTests.cs
+++ b/tests/Images/ImageGenerationTests.cs
@@ -22,6 +22,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task BasicGenerationWorks()
     {
         ImageClient client = GetTestClient();
@@ -39,6 +40,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task GenerationWithOptionsWorks()
     {
         ImageClient client = GetTestClient();
@@ -58,6 +60,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task GenerationWithBytesResponseWorks()
     {
         ImageClient client = GetTestClient();
@@ -79,6 +82,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task GenerateImageEditWorks()
     {
         ImageClient client = GetTestClient<ImageClient>(TestScenario.Images, "dall-e-2");
@@ -98,6 +102,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task GenerateImageEditWithMaskFileWorks()
     {
         ImageClient client = GetTestClient<ImageClient>(TestScenario.Images, "dall-e-2");
@@ -118,6 +123,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task GenerateImageEditWithBytesResponseWorks()
     {
         ImageClient client = GetTestClient<ImageClient>(TestScenario.Images, "dall-e-2");
@@ -140,6 +146,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task GenerateImageVariationWorks()
     {
         ImageClient client = GetTestClient<ImageClient>(TestScenario.Images, "dall-e-2");
@@ -157,6 +164,7 @@ public partial class ImageGenerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task GenerateImageVariationWithBytesResponseWorks()
     {
         ImageClient client = GetTestClient<ImageClient>(TestScenario.Images, "dall-e-2");

--- a/tests/Images/ImageGenerationTests.cs
+++ b/tests/Images/ImageGenerationTests.cs
@@ -13,6 +13,7 @@ namespace OpenAI.Tests.Images;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class ImageGenerationTests : SyncAsyncTestBase
 {
     public ImageGenerationTests(bool isAsync)

--- a/tests/Models/ModelTests.cs
+++ b/tests/Models/ModelTests.cs
@@ -9,6 +9,7 @@ namespace OpenAI.Tests.Models;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class ModelTests : SyncAsyncTestBase
 {
     public ModelTests(bool isAsync)

--- a/tests/Moderations/ModerationTests.cs
+++ b/tests/Moderations/ModerationTests.cs
@@ -17,6 +17,7 @@ public partial class ModerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task ClassifySingleInput()
     {
         ModerationClient client = new("text-moderation-stable");
@@ -33,6 +34,7 @@ public partial class ModerationTests : SyncAsyncTestBase
     }
 
     [Test]
+    [Category("skipInCI")]
     public async Task ClassifyMultipleInputs()
     {
         ModerationClient client = new("text-moderation-stable");

--- a/tests/Moderations/ModerationTests.cs
+++ b/tests/Moderations/ModerationTests.cs
@@ -8,6 +8,7 @@ namespace OpenAI.Tests.Moderations;
 
 [TestFixture(true)]
 [TestFixture(false)]
+[Parallelizable(ParallelScope.All)]
 public partial class ModerationTests : SyncAsyncTestBase
 {
     public ModerationTests(bool isAsync)

--- a/tests/Utility/MockPipelineMessage.cs
+++ b/tests/Utility/MockPipelineMessage.cs
@@ -1,0 +1,17 @@
+﻿using System.ClientModel.Primitives;
+
+#nullable enable
+
+namespace OpenAI.Tests;
+
+public class MockPipelineMessage : PipelineMessage
+{
+    protected internal MockPipelineMessage(PipelineRequest request) : base(request)
+    {
+    }
+
+    public void SetResponse(MockPipelineResponse response)
+    {
+        Response = response;
+    }
+}

--- a/tests/Utility/MockPipelineRequest.cs
+++ b/tests/Utility/MockPipelineRequest.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+
+namespace OpenAI.Tests;
+
+public class MockPipelineRequest : PipelineRequest
+{
+    protected override string MethodCore { get; set; } = "POST";
+
+    protected override Uri UriCore { get; set; }
+
+    protected override PipelineRequestHeaders HeadersCore { get; } = new MockPipelineRequestHeaders();
+
+    protected override BinaryContent ContentCore { get; set; }
+
+    public MockPipelineRequest(BinaryData requestData)
+    {
+        ContentCore = BinaryContent.Create(requestData);
+    }
+
+    public override void Dispose()
+    {
+        ContentCore?.Dispose();
+    }
+}

--- a/tests/Utility/MockPipelineRequestHeaders.cs
+++ b/tests/Utility/MockPipelineRequestHeaders.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace OpenAI.Tests;
+
+public class MockPipelineRequestHeaders : PipelineRequestHeaders
+{
+    private readonly Dictionary<string, string> _headers = [];
+    public override void Add(string name, string value) => _headers[name] = value;
+    public override IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _headers.GetEnumerator();
+    public override bool Remove(string name) => _headers.Remove(name);
+    public override void Set(string name, string value) => _headers[name] = value;
+    public override bool TryGetValue(string name, out string value) => _headers.TryGetValue(name, out value!);
+    public override bool TryGetValues(string name, out IEnumerable<string> values)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tests/Utility/MockPipelineTransport.cs
+++ b/tests/Utility/MockPipelineTransport.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.ClientModel.Primitives;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace OpenAI.Tests;
+
+public class MockPipelineTransport : PipelineTransport
+{
+    public MockPipelineRequest MockRequest { get; set; }
+    public MockPipelineResponse MockResponse { get; set; }
+
+    public MockPipelineTransport(BinaryData requestData, BinaryData responseData)
+    {
+        MockRequest = new MockPipelineRequest(requestData);
+        MockResponse = new MockPipelineResponse(200);
+        MockResponse.SetContent(responseData.ToArray(), bufferImmediately: true);
+    }
+
+    protected override PipelineMessage CreateMessageCore()
+    {
+        return new MockPipelineMessage(MockRequest);
+    }
+
+    protected override void ProcessCore(PipelineMessage message)
+    {
+        (message as MockPipelineMessage)!.SetResponse(MockResponse);
+    }
+
+    protected override ValueTask ProcessCoreAsync(PipelineMessage message)
+    {
+        (message as MockPipelineMessage)!.SetResponse(MockResponse);
+        return ValueTask.CompletedTask;
+    }
+}
+

--- a/tests/Utility/TestHelpers.cs
+++ b/tests/Utility/TestHelpers.cs
@@ -1,4 +1,5 @@
-﻿using OpenAI.Assistants;
+﻿using NUnit.Framework;
+using OpenAI.Assistants;
 using OpenAI.Audio;
 using OpenAI.Batch;
 using OpenAI.Chat;
@@ -11,6 +12,8 @@ using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+
+[assembly: LevelOfParallelism(8)]
 
 namespace OpenAI.Tests;
 


### PR DESCRIPTION
From @trrwilson:
- An informal "smoke test" category is added and applied to tests that are extremely fast and require no auth/credentials -- perfect for ensuring client creation, serialization, etc. work
- A couple of new mock chat tests -- including one that would have caught last weekend's regression -- are included in this category
- The "smoke" category is added to the CI workflow; this only adds 2-3s to the test task
- NUnit Parallelization is enabled (degree: 8) to speed up live test runs; this currently reduces a ~10m run to ~1.5m
  - As written, we're bottlenecked by Assistants and VectorStore tests, as they exercise several stateful assumptions and have to be kept serial with respect to themselves; this is likely unnecessarily fragile to begin with and can be fixed with rewrites later
  - I didn't encounter any rate limit issues, but it's easy to adjust the degree of parallelism and/or per-fixture parallelization as needed 