### PR TITLE
Add simple embedding example using protocol method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - ([#49](https://github.com/openai/openai-dotnet/issues/49)) Fixed a bug with extensible enums implementing case-insensitive equality but case-sensitive hash codes. (commit_hash)
-- ([#57](https://github.com/openai/openai-dotnet/issues/57)) Fixed a bug with requests URIs with query string parameter potentially containing a malformed double question mark (`??`) on .NET Framework (net481).
+- ([#57](https://github.com/openai/openai-dotnet/issues/57)) Fixed a bug with requests URIs with query string parameter potentially containing a malformed double question mark (`??`) on .NET Framework (net481). (commit_hash)
 
 ### Other Changes
 

--- a/examples/Chat/Example06_SimpleChatProtocol.cs
+++ b/examples/Chat/Example06_SimpleChatProtocol.cs
@@ -13,7 +13,7 @@ public partial class ChatExamples
     {
         ChatClient client = new("gpt-4o", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
 
-        BinaryData input = BinaryData.FromString("""
+        BinaryData input = BinaryData.FromBytes("""
             {
                "model": "gpt-4o",
                "messages": [
@@ -23,7 +23,7 @@ public partial class ChatExamples
                    }
                ]
             }
-            """);
+            """u8.ToArray());
 
         using BinaryContent content = BinaryContent.Create(input);
         ClientResult result = client.CompleteChat(content);
@@ -31,9 +31,9 @@ public partial class ChatExamples
 
         using JsonDocument outputAsJson = JsonDocument.Parse(output.ToString());
         string message = outputAsJson.RootElement
-            .GetProperty("choices")[0]
-            .GetProperty("message")
-            .GetProperty("content")
+            .GetProperty("choices"u8)[0]
+            .GetProperty("message"u8)
+            .GetProperty("content"u8)
             .GetString();
 
         Console.WriteLine($"[ASSISTANT]:");

--- a/examples/Chat/Example06_SimpleChatProtocolAsync.cs
+++ b/examples/Chat/Example06_SimpleChatProtocolAsync.cs
@@ -14,7 +14,7 @@ public partial class ChatExamples
     {
         ChatClient client = new("gpt-4o", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
 
-        BinaryData input = BinaryData.FromString("""
+        BinaryData input = BinaryData.FromBytes("""
             {
                "model": "gpt-4o",
                "messages": [
@@ -24,7 +24,7 @@ public partial class ChatExamples
                    }
                ]
             }
-            """);
+            """u8.ToArray());
 
         using BinaryContent content = BinaryContent.Create(input);
         ClientResult result = await client.CompleteChatAsync(content);
@@ -32,9 +32,9 @@ public partial class ChatExamples
 
         using JsonDocument outputAsJson = JsonDocument.Parse(output.ToString());
         string message = outputAsJson.RootElement
-            .GetProperty("choices")[0]
-            .GetProperty("message")
-            .GetProperty("content")
+            .GetProperty("choices"u8)[0]
+            .GetProperty("message"u8)
+            .GetProperty("content"u8)
             .GetString();
 
         Console.WriteLine($"[ASSISTANT]:");

--- a/examples/Embeddings/Example04_SimpleEmbeddingProtocol.cs
+++ b/examples/Embeddings/Example04_SimpleEmbeddingProtocol.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using OpenAI.Embeddings;
+using System;
+using System.ClientModel;
+using System.Text.Json;
+
+namespace OpenAI.Examples;
+
+public partial class EmbeddingExamples
+{
+    [Test]
+    public void Example04_SimpleEmbeddingProtocol()
+    {
+        EmbeddingClient client = new("text-embedding-3-small", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+
+        string description = "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa,"
+            + " and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist"
+            + " attractions. We highly recommend this hotel.";
+
+        BinaryData input = BinaryData.FromObjectAsJson(new {
+               model = "text-embedding-3-small",
+               input = description,
+               encoding_format = "float"
+            });
+
+        using BinaryContent content = BinaryContent.Create(input);
+        ClientResult result = client.GenerateEmbeddings(content);
+        BinaryData output = result.GetRawResponse().Content;
+
+        using JsonDocument outputAsJson = JsonDocument.Parse(output.ToString());
+        JsonElement vector = outputAsJson.RootElement
+            .GetProperty("data"u8)[0]
+            .GetProperty("embedding"u8);
+
+        Console.WriteLine($"Dimension: {vector.GetArrayLength()}");
+        Console.WriteLine($"Floats: ");
+        int i = 0;
+        foreach (JsonElement element in vector.EnumerateArray())
+        {
+            Console.WriteLine($"  [{i++,4}] = {element.GetDouble()}");
+        }
+    }
+}

--- a/examples/Embeddings/Example04_SimpleEmbeddingProtocolAsync.cs
+++ b/examples/Embeddings/Example04_SimpleEmbeddingProtocolAsync.cs
@@ -1,0 +1,45 @@
+﻿using NUnit.Framework;
+using OpenAI.Embeddings;
+using System;
+using System.ClientModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace OpenAI.Examples;
+
+public partial class EmbeddingExamples
+{
+    [Test]
+    public async Task Example04_SimpleEmbeddingProtocolAsync()
+    {
+        EmbeddingClient client = new("text-embedding-3-small", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+
+        string description = "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa,"
+            + " and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist"
+            + " attractions. We highly recommend this hotel.";
+
+        BinaryData input = BinaryData.FromObjectAsJson(new
+        {
+            model = "text-embedding-3-small",
+            input = description,
+            encoding_format = "float"
+        });
+
+        using BinaryContent content = BinaryContent.Create(input);
+        ClientResult result = await client.GenerateEmbeddingsAsync(content);
+        BinaryData output = result.GetRawResponse().Content;
+
+        using JsonDocument outputAsJson = JsonDocument.Parse(output.ToString());
+        JsonElement vector = outputAsJson.RootElement
+            .GetProperty("data"u8)[0]
+            .GetProperty("embedding"u8);
+
+        Console.WriteLine($"Dimension: {vector.GetArrayLength()}");
+        Console.WriteLine($"Floats: ");
+        int i = 0;
+        foreach (JsonElement element in vector.EnumerateArray())
+        {
+            Console.WriteLine($"  [{i++,4}] = {element.GetDouble()}");
+        }
+    }
+}


### PR DESCRIPTION
- Add an example illustrating how to use the `EmbeddingClient`'s `GenerateEmbeddings` protocol method
- Modify `Example06_SimpleChatProtocol` and `Example06_SimpleChatProtocolAsync` to use UTF-8 string literals for correctness