### PR TITLE
Downgrade the diagnostics source package to fix version mismatch issues

### DIFF
--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the OpenAI client library for developing .NET applications with rich experience.</Description>
     <AssemblyTitle>SDK Code Generation OpenAI</AssemblyTitle>
@@ -72,6 +72,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.ClientModel" Version="1.1.0-beta.5" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Version 8.0.1 of `System.Diagnostics.DiagnosticSource` causes Nuget package version mismatch issues with the Azure OpenAI library. This downgrades the version to 6.0.1 to match that used in the Azure OpenAI repo. This also resolves some version mismatch issues with `System.Memory`