### PR TITLE
Bugfix missing internal options set

### DIFF
--- a/src/Custom/OpenAIClient.cs
+++ b/src/Custom/OpenAIClient.cs
@@ -98,6 +98,7 @@ public partial class OpenAIClient
 
         _pipeline = OpenAIClient.CreatePipeline(credential, options);
         _endpoint = OpenAIClient.GetEndpoint(options);
+        _options = options;
     }
 
     // CUSTOM: Added protected internal constructor that takes a ClientPipeline.


### PR DESCRIPTION
# Motivation
When creating `OpenAIClient` using `ApiKey` + `Options` the options are not persisted and passed when creating the specialized clients `Chat`, `Embedding`, etc resetting unintentionally the options for the specialized clients, including the `Endpoint`.

# Fix

The fix set the internal options restoring the desired behavior.

Resolve #184 