### PR TITLE
2.0.0-beta.10: release preparation part 2 (changelog, csproj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Release History
 
+## 2.0.0-beta.10 (2024-08-26)
+
+### Breaking Changes
+
+- Renamed `AudioClient`'s `GenerateSpeechFromText` methods to simply `GenerateSpeech`. ([d84bf54](https://github.com/openai/openai-dotnet/commit/d84bf54df14ddac4c49f6efd61467b600d34ecd7))
+- Changed the type of `OpenAIFileInfo`'s `SizeInBytes` property from `long?` to `int?`. ([d84bf54](https://github.com/openai/openai-dotnet/commit/d84bf54df14ddac4c49f6efd61467b600d34ecd7)) 
+
+### Bugs Fixed
+
+- Fixed a newly introduced bug ([#185](https://github.com/openai/openai-dotnet/pull/185)) where providing `OpenAIClientOptions` to a top-level `OpenAIClient` did not carry over to scenario clients (e.g. `ChatClient`) created via that top-level client ([d84bf54](https://github.com/openai/openai-dotnet/commit/d84bf54df14ddac4c49f6efd61467b600d34ecd7))
+
+### Other Changes
+
+- Removed the version path parameter "v1" from the default endpoint URL. ([d84bf54](https://github.com/openai/openai-dotnet/commit/d84bf54df14ddac4c49f6efd61467b600d34ecd7))
+
 ## 2.0.0-beta.9 (2024-08-23)
 
 ### Features Added

--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -5,7 +5,7 @@
     <PackageTags>OpenAI</PackageTags>
 
     <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>beta.9</VersionSuffix>
+    <VersionSuffix>beta.10</VersionSuffix>
 
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/tests/Chat/ChatSmokeTests.cs
+++ b/tests/Chat/ChatSmokeTests.cs
@@ -594,13 +594,12 @@ public partial class ChatSmokeTests : SyncAsyncTestBase
         OpenAIClientOptions options = new()
         {
             Transport = mockTransport,
-            Endpoint = new Uri("https://api.openai.com/expected/test/endpoint"),
+            Endpoint = new Uri("https://my.custom.com/expected/test/endpoint"),
         };
         Uri observedEndpoint = null;
         options.AddPolicy(new TestPipelinePolicy(message =>
         {
             observedEndpoint = message?.Request?.Uri;
-            Console.WriteLine($"foo: {message.Request.Uri.AbsoluteUri}");
         }),
         PipelinePosition.PerCall);
 
@@ -609,6 +608,6 @@ public partial class ChatSmokeTests : SyncAsyncTestBase
         ClientResult first = firstClient.CompleteChat("Hello, world");
 
         Assert.That(observedEndpoint, Is.Not.Null);
-        Assert.That(observedEndpoint.AbsoluteUri, Does.Contain("expected/test/endpoint"));
+        Assert.That(observedEndpoint.AbsoluteUri, Does.Contain("my.custom.com/expected/test/endpoint"));
     }
 }


### PR DESCRIPTION
Also includes a post-PR test suggestion from #186 to further validate the fix in this release.