### PR TITLE
Add Experimental attribute to public APIs in Batch and Fine-Tuning namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@
 ### Other Changes
 
 - Reverted the removal of the version path parameter "v1" from the default endpoint URL. (commit_hash)
-- Added the `Experimental` attribute to all public APIs in the `OpenAI.Assistants` namespace. (commit_hash)
-- Added the `Experimental` attribute to all public APIs in the `OpenAI.VectorStores` namespace. (commit_hash)
-
+- Added the `Experimental` attribute to the following APIs:
+  - All public APIs in the `OpenAI.Assistants` namespace. (commit_hash)
+  - All public APIs in the `OpenAI.VectorStores` namespace. (commit_hash)
+  - All public APIs in the `OpenAI.Batch` namespace. (commit_hash)
+  - All public APIs in the `OpenAI.FineTuning` namespace. (commit_hash)
+  - The `ChatCompletionOptions.Seed` property. (commit_hash) 
 
 ## 2.0.0-beta.10 (2024-08-26)
 

--- a/src/Custom/Batch/BatchClient.cs
+++ b/src/Custom/Batch/BatchClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenAI.Batch;
 
@@ -10,6 +11,7 @@ namespace OpenAI.Batch;
 // - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
 // - Suppressed convenience methods for now.
 /// <summary> The service client for OpenAI batch operations. </summary>
+[Experimental("OPENAI001")]
 [CodeGenClient("Batches")]
 [CodeGenSuppress("BatchClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateBatch", typeof(string), typeof(InternalCreateBatchRequestEndpoint), typeof(InternalBatchCompletionTimeframe), typeof(IDictionary<string, string>))]

--- a/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/src/Custom/Chat/ChatCompletionOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenAI.Chat;
 
@@ -136,4 +137,11 @@ public partial class ChatCompletionOptions
     /// </summary>
     [CodeGenMember("User")]
     public string EndUserId { get; set; }
+
+    // CUSTOM: Added the Experimental attribute
+    /// <summary>
+    /// If specified, our system will make a best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result.
+    /// </summary>
+    [Experimental("OPENAI001")]
+    public long? Seed { get; set; }
 }

--- a/src/Custom/FineTuning/FineTuningClient.cs
+++ b/src/Custom/FineTuning/FineTuningClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenAI.FineTuning;
 
@@ -9,6 +10,7 @@ namespace OpenAI.FineTuning;
 // - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
 // - Suppressed convenience methods for now.
 /// <summary> The service client for OpenAI fine-tuning operations. </summary>
+[Experimental("OPENAI001")]
 [CodeGenClient("FineTuning")]
 [CodeGenSuppress("FineTuningClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateFineTuningJobAsync", typeof(InternalCreateFineTuningJobRequest))]

--- a/src/Custom/OpenAIClient.cs
+++ b/src/Custom/OpenAIClient.cs
@@ -148,6 +148,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="BatchClient"/>. </returns>
+    [Experimental("OPENAI001")]
     public virtual BatchClient GetBatchClient() => new(_pipeline, _options);
 
     /// <summary>
@@ -192,6 +193,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="FineTuningClient"/>. </returns>
+    [Experimental("OPENAI001")]
     public virtual FineTuningClient GetFineTuningClient() => new(_pipeline, _options);
 
     /// <summary>

--- a/src/Generated/Models/ChatCompletionOptions.cs
+++ b/src/Generated/Models/ChatCompletionOptions.cs
@@ -43,7 +43,6 @@ namespace OpenAI.Chat
         public int? MaxTokens { get; set; }
         public float? PresencePenalty { get; set; }
         public ChatResponseFormat ResponseFormat { get; set; }
-        public long? Seed { get; set; }
         public float? Temperature { get; set; }
         public float? TopP { get; set; }
         public IList<ChatTool> Tools { get; }

--- a/tests/OpenAI.Tests.csproj
+++ b/tests/OpenAI.Tests.csproj
@@ -1,8 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+
     <!--Ignore XML doc comments on test types and members-->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+   <!-- OPENAI001 - Ignore experimental warnings-->
+    <NoWarn>$(NoWarn);OPENAI001;</NoWarn>
+
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR adds the `[Experimental("OPENAI001")]` attribute to all public APIs within the `OpenAI.Batch` and `OpenAI.FineTuning` namespaces, marking them as experimental features.