### PR TITLE
Remove the virtual keyword from the Pipeline property across all clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@
 
 ### Breaking Changes
 
-- Refactored `ModerationResult` by merging `ModerationCategories` and `ModerationCategoryScores` into individual `ModerationCategory` properties, each with `Flagged` and `Score` properties. (commit_hash)
+- Refactored `ModerationResult` by merging `ModerationCategories` and `ModerationCategoryScores` into individual `ModerationCategory` properties, each with `Flagged` and `Score` properties. (commit_id)
 - Renamed type `OpenAIFileInfo` to `OpenAIFile` and `OpenAIFileInfoCollection` to `OpenAIFileCollection`. (commit_id)
 - Renamed type `OpenAIModelInfo` to `OpenAIModel` and `OpenAIModelInfoCollection` to `OpenAIModelCollection`. (commit_id)
 - Renamed type `Embedding` to `OpenAIEmbedding` and `EmbeddingCollection` to `OpenAIEmbeddingCollection`. (commit_id)
-- Renamed property `ImageUrl` to `ImageUri` and method `FromImageUrl` to `FromImageUri` in `MessageContent`. (commit_id)
-- Renamed property `ParallelToolCallsEnabled` to `AllowParallelToolCalls` in `RunCreationOptions`, `ThreadRun`, and `ChatCompletionOptions` types. (commit_id)
-- Renamed property `PromptTokens` to `InputTokenCount`, `CompletionTokens` to `OutputTokenCount`, and `TotalTokens` to `TotalTokenCount` in `RunTokenUsage`. (commit_id)
-- Renamed property `InputTokens` to `InputTokenCount` and `TotalTokens` to `TotalTokenCount` in `EmbeddingTokenUsage`. (commit_id)
+- Renamed property `ImageUrl` to `ImageUri` and method `FromImageUrl` to `FromImageUri` in the `MessageContent` type. (commit_id)
+- Renamed property `ParallelToolCallsEnabled` to `AllowParallelToolCalls` in the `RunCreationOptions`, `ThreadRun`, and `ChatCompletionOptions` types. (commit_id)
+- Renamed properties `PromptTokens` to `InputTokenCount`, `CompletionTokens` to `OutputTokenCount`, and `TotalTokens` to `TotalTokenCount` in the `RunTokenUsage` and `RunStepTokenUsage` types. (commit_id)
+- Renamed properties `InputTokens` to `InputTokenCount` and `TotalTokens` to `TotalTokenCount` in the `EmbeddingTokenUsage` type. (commit_id)
+- Renamed properties `MaxPromptTokens` to `MaxInputTokenCount` and `MaxCompletionTokens` to `MaxOutputTokenCount` in the `ThreadRun`, `RunCreationOptions`, and `RunIncompleteReason` types. (commit_id)
+- Removed the `virtual` keyword from the `Pipeline` property across all clients. (commit_id)
 
 ### Bugs Fixed
 

--- a/api/OpenAI.netstandard2.0.cs
+++ b/api/OpenAI.netstandard2.0.cs
@@ -6,7 +6,7 @@ namespace OpenAI {
         protected internal OpenAIClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public OpenAIClient(string apiKey, OpenAIClientOptions options);
         public OpenAIClient(string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual AssistantClient GetAssistantClient();
         public virtual AudioClient GetAudioClient(string model);
         public virtual BatchClient GetBatchClient();
@@ -53,7 +53,7 @@ namespace OpenAI.Assistants {
         protected internal AssistantClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public AssistantClient(string apiKey, OpenAIClientOptions options);
         public AssistantClient(string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult<ThreadRun> CancelRun(ThreadRun run);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult CancelRun(string threadId, string runId, RequestOptions options);
@@ -600,8 +600,8 @@ namespace OpenAI.Assistants {
         public IList<ThreadInitializationMessage> AdditionalMessages { get; }
         public bool? AllowParallelToolCalls { get; set; }
         public string InstructionsOverride { get; set; }
-        public int? MaxCompletionTokens { get; set; }
-        public int? MaxPromptTokens { get; set; }
+        public int? MaxInputTokenCount { get; set; }
+        public int? MaxOutputTokenCount { get; set; }
         public IDictionary<string, string> Metadata { get; }
         public string ModelOverride { get; set; }
         public float? NucleusSamplingFactor { get; set; }
@@ -654,8 +654,8 @@ namespace OpenAI.Assistants {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public RunIncompleteReason(string value);
-        public static RunIncompleteReason MaxCompletionTokens { get; }
-        public static RunIncompleteReason MaxPromptTokens { get; }
+        public static RunIncompleteReason MaxInputTokenCount { get; }
+        public static RunIncompleteReason MaxOutputTokenCount { get; }
         public readonly bool Equals(RunIncompleteReason other);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override readonly bool Equals(object obj);
@@ -826,9 +826,9 @@ namespace OpenAI.Assistants {
         public override readonly string ToString();
     }
     public class RunStepTokenUsage : IJsonModel<RunStepTokenUsage>, IPersistableModel<RunStepTokenUsage> {
-        public int CompletionTokens { get; }
-        public int PromptTokens { get; }
-        public int TotalTokens { get; }
+        public int InputTokenCount { get; }
+        public int OutputTokenCount { get; }
+        public int TotalTokenCount { get; }
         RunStepTokenUsage IJsonModel<RunStepTokenUsage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<RunStepTokenUsage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         RunStepTokenUsage IPersistableModel<RunStepTokenUsage>.Create(BinaryData data, ModelReaderWriterOptions options);
@@ -1022,8 +1022,8 @@ namespace OpenAI.Assistants {
         public RunIncompleteDetails IncompleteDetails { get; }
         public string Instructions { get; }
         public RunError LastError { get; }
-        public int? MaxCompletionTokens { get; }
-        public int? MaxPromptTokens { get; }
+        public int? MaxInputTokenCount { get; }
+        public int? MaxOutputTokenCount { get; }
         public IReadOnlyDictionary<string, string> Metadata { get; }
         public string Model { get; }
         public float? NucleusSamplingFactor { get; }
@@ -1114,7 +1114,7 @@ namespace OpenAI.Audio {
         public AudioClient(string model, ApiKeyCredential credential);
         public AudioClient(string model, string apiKey, OpenAIClientOptions options);
         public AudioClient(string model, string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult GenerateSpeech(BinaryContent content, RequestOptions options = null);
         public virtual ClientResult<BinaryData> GenerateSpeech(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default);
@@ -1306,7 +1306,7 @@ namespace OpenAI.Batch {
         protected internal BatchClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public BatchClient(string apiKey, OpenAIClientOptions options);
         public BatchClient(string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult CancelBatch(string batchId, RequestOptions options);
         public virtual Task<ClientResult> CancelBatchAsync(string batchId, RequestOptions options);
         public virtual ClientResult CreateBatch(BinaryContent content, RequestOptions options = null);
@@ -1343,7 +1343,7 @@ namespace OpenAI.Chat {
         public ChatClient(string model, ApiKeyCredential credential);
         public ChatClient(string model, string apiKey, OpenAIClientOptions options);
         public ChatClient(string model, string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult<ChatCompletion> CompleteChat(params ChatMessage[] messages);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult CompleteChat(BinaryContent content, RequestOptions options = null);
@@ -1660,10 +1660,10 @@ namespace OpenAI.Chat {
     }
     public static class OpenAIChatModelFactory {
         public static ChatCompletion ChatCompletion(string id = null, ChatFinishReason finishReason = ChatFinishReason.Stop, IEnumerable<ChatMessageContentPart> content = null, string refusal = null, IEnumerable<ChatToolCall> toolCalls = null, ChatMessageRole role = ChatMessageRole.System, ChatFunctionCall functionCall = null, IEnumerable<ChatTokenLogProbabilityDetails> contentTokenLogProbabilities = null, IEnumerable<ChatTokenLogProbabilityDetails> refusalTokenLogProbabilities = null, DateTimeOffset createdAt = default, string model = null, string systemFingerprint = null, ChatTokenUsage usage = null);
-        public static ChatOutputTokenUsageDetails ChatOutputTokenUsageDetails(int reasoningTokens = 0);
+        public static ChatOutputTokenUsageDetails ChatOutputTokenUsageDetails(int reasoningTokenCount = 0);
         public static ChatTokenLogProbabilityDetails ChatTokenLogProbabilityDetails(string token = null, float logProbability = 0, ReadOnlyMemory<byte>? utf8Bytes = null, IEnumerable<ChatTokenTopLogProbabilityDetails> topLogProbabilities = null);
         public static ChatTokenTopLogProbabilityDetails ChatTokenTopLogProbabilityDetails(string token = null, float logProbability = 0, ReadOnlyMemory<byte>? utf8Bytes = null);
-        public static ChatTokenUsage ChatTokenUsage(int outputTokens = 0, int inputTokens = 0, int totalTokens = 0, ChatOutputTokenUsageDetails outputTokenDetails = null);
+        public static ChatTokenUsage ChatTokenUsage(int outputTokenCount = 0, int inputTokenCount = 0, int totalTokenCount = 0, ChatOutputTokenUsageDetails outputTokenDetails = null);
         public static StreamingChatCompletionUpdate StreamingChatCompletionUpdate(string id = null, IEnumerable<ChatMessageContentPart> contentUpdate = null, StreamingChatFunctionCallUpdate functionCallUpdate = null, IEnumerable<StreamingChatToolCallUpdate> toolCallUpdates = null, ChatMessageRole? role = null, string refusalUpdate = null, IEnumerable<ChatTokenLogProbabilityDetails> contentTokenLogProbabilities = null, IEnumerable<ChatTokenLogProbabilityDetails> refusalTokenLogProbabilities = null, ChatFinishReason? finishReason = null, DateTimeOffset createdAt = default, string model = null, string systemFingerprint = null, ChatTokenUsage usage = null);
         [Obsolete("This class is obsolete. Please use StreamingChatToolCallUpdate instead.")]
         public static StreamingChatFunctionCallUpdate StreamingChatFunctionCallUpdate(string functionArgumentsUpdate = null, string functionName = null);
@@ -1754,7 +1754,7 @@ namespace OpenAI.Embeddings {
         public EmbeddingClient(string model, ApiKeyCredential credential);
         public EmbeddingClient(string model, string apiKey, OpenAIClientOptions options);
         public EmbeddingClient(string model, string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult<OpenAIEmbedding> GenerateEmbedding(string input, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIEmbedding>> GenerateEmbeddingAsync(string input, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1803,7 +1803,7 @@ namespace OpenAI.Embeddings {
         BinaryData IPersistableModel<OpenAIEmbeddingCollection>.Write(ModelReaderWriterOptions options);
     }
     public static class OpenAIEmbeddingsModelFactory {
-        public static EmbeddingTokenUsage EmbeddingTokenUsage(int inputTokens = 0, int totalTokens = 0);
+        public static EmbeddingTokenUsage EmbeddingTokenUsage(int inputTokenCount = 0, int totalTokenCount = 0);
         public static OpenAIEmbedding OpenAIEmbedding(int index = 0, IEnumerable<float> vector = null);
         public static OpenAIEmbeddingCollection OpenAIEmbeddingCollection(IEnumerable<OpenAIEmbedding> items = null, string model = null, EmbeddingTokenUsage usage = null);
     }
@@ -1816,7 +1816,7 @@ namespace OpenAI.Files {
         protected internal FileClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public FileClient(string apiKey, OpenAIClientOptions options);
         public FileClient(string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult AddUploadPart(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual Task<ClientResult> AddUploadPartAsync(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual ClientResult CancelUpload(string uploadId, RequestOptions options = null);
@@ -1965,7 +1965,7 @@ namespace OpenAI.FineTuning {
         protected internal FineTuningClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public FineTuningClient(string apiKey, OpenAIClientOptions options);
         public FineTuningClient(string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult CancelJob(string jobId, RequestOptions options);
         public virtual Task<ClientResult> CancelJobAsync(string jobId, RequestOptions options);
         public virtual ClientResult CreateJob(BinaryContent content, RequestOptions options = null);
@@ -2036,7 +2036,7 @@ namespace OpenAI.Images {
         public ImageClient(string model, ApiKeyCredential credential);
         public ImageClient(string model, string apiKey, OpenAIClientOptions options);
         public ImageClient(string model, string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult<GeneratedImage> GenerateImage(string prompt, ImageGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<GeneratedImage>> GenerateImageAsync(string prompt, ImageGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual ClientResult<GeneratedImage> GenerateImageEdit(Stream image, string imageFilename, string prompt, ImageEditOptions options = null, CancellationToken cancellationToken = default);
@@ -2123,7 +2123,7 @@ namespace OpenAI.Models {
         protected internal ModelClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public ModelClient(string apiKey, OpenAIClientOptions options);
         public ModelClient(string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult DeleteModel(string model, RequestOptions options);
         public virtual ClientResult<ModelDeletionResult> DeleteModel(string model, CancellationToken cancellationToken = default);
@@ -2187,7 +2187,7 @@ namespace OpenAI.Moderations {
         public ModerationClient(string model, ApiKeyCredential credential);
         public ModerationClient(string model, string apiKey, OpenAIClientOptions options);
         public ModerationClient(string model, string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions options = null);
         public virtual ClientResult<ModerationResultCollection> ClassifyText(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
@@ -2315,7 +2315,7 @@ namespace OpenAI.VectorStores {
         protected internal VectorStoreClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public VectorStoreClient(string apiKey, OpenAIClientOptions options);
         public VectorStoreClient(string apiKey);
-        public virtual ClientPipeline Pipeline { get; }
+        public ClientPipeline Pipeline { get; }
         public virtual ClientResult<VectorStoreFileAssociation> AddFileToVectorStore(VectorStore vectorStore, OpenAIFile file);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult AddFileToVectorStore(string vectorStoreId, BinaryContent content, RequestOptions options = null);

--- a/src/Custom/Assistants/AssistantClient.cs
+++ b/src/Custom/Assistants/AssistantClient.cs
@@ -30,6 +30,12 @@ public partial class AssistantClient
     private readonly InternalAssistantRunClient _runSubClient;
     private readonly InternalAssistantThreadClient _threadSubClient;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="AssistantClient">. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
@@ -1263,8 +1269,8 @@ public partial class AssistantClient
             runOptions.Temperature,
             runOptions.NucleusSamplingFactor,
             runOptions.Stream,
-            runOptions.MaxPromptTokens,
-            runOptions.MaxCompletionTokens,
+            runOptions.MaxInputTokenCount,
+            runOptions.MaxOutputTokenCount,
             runOptions.TruncationStrategy,
             runOptions.ToolConstraint,
             runOptions.AllowParallelToolCalls,

--- a/src/Custom/Assistants/GeneratorStubs.cs
+++ b/src/Custom/Assistants/GeneratorStubs.cs
@@ -35,10 +35,6 @@ public readonly partial struct RunErrorCode { }
 public partial class RunIncompleteDetails { }
 
 [Experimental("OPENAI001")]
-[CodeGenModel("RunObjectIncompleteDetailsReason")]
-public readonly partial struct RunIncompleteReason { }
-
-[Experimental("OPENAI001")]
 [CodeGenModel("RunStepObjectType")]
 public readonly partial struct RunStepType { }
 
@@ -53,10 +49,6 @@ public partial class RunStepError { }
 [Experimental("OPENAI001")]
 [CodeGenModel("RunStepObjectLastErrorCode")]
 public readonly partial struct RunStepErrorCode { }
-
-[Experimental("OPENAI001")]
-[CodeGenModel("RunStepCompletionUsage")]
-public partial class RunStepTokenUsage { }
 
 [Experimental("OPENAI001")]
 [CodeGenModel("RunStepDetailsToolCallsCodeObjectCodeInterpreterOutputsObject")]

--- a/src/Custom/Assistants/Internal/InternalAssistantMessageClient.cs
+++ b/src/Custom/Assistants/Internal/InternalAssistantMessageClient.cs
@@ -18,6 +18,12 @@ namespace OpenAI.Assistants;
 [CodeGenSuppress("DeleteMessage", typeof(string), typeof(string))]
 internal partial class InternalAssistantMessageClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.

--- a/src/Custom/Assistants/Internal/InternalAssistantRunClient.cs
+++ b/src/Custom/Assistants/Internal/InternalAssistantRunClient.cs
@@ -26,6 +26,12 @@ namespace OpenAI.Assistants;
 [CodeGenSuppress("GetRunStep", typeof(string), typeof(string), typeof(string))]
 internal partial class InternalAssistantRunClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.

--- a/src/Custom/Assistants/Internal/InternalAssistantThreadClient.cs
+++ b/src/Custom/Assistants/Internal/InternalAssistantThreadClient.cs
@@ -16,6 +16,12 @@ namespace OpenAI.Assistants;
 [CodeGenSuppress("DeleteThread", typeof(string))]
 internal partial class InternalAssistantThreadClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.

--- a/src/Custom/Assistants/RunCreationOptions.cs
+++ b/src/Custom/Assistants/RunCreationOptions.cs
@@ -115,10 +115,12 @@ public partial class RunCreationOptions
     public float? NucleusSamplingFactor { get; set; }
 
     /// <summary> The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info. </summary>
-    public int? MaxPromptTokens { get; set; }
+    [CodeGenMember("MaxPromptTokens")]
+    public int? MaxInputTokenCount { get; set; }
 
     /// <summary> The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info. </summary>
-    public int? MaxCompletionTokens { get; set; }
+    [CodeGenMember("MaxCompletionTokens")]
+    public int? MaxOutputTokenCount { get; set; }
 
     /// <summary> Gets or sets the truncation strategy. </summary>
     public RunTruncationStrategy TruncationStrategy { get; set; }

--- a/src/Custom/Assistants/RunIncompleteReason.cs
+++ b/src/Custom/Assistants/RunIncompleteReason.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace OpenAI.Assistants
+{
+    [Experimental("OPENAI001")]
+    [CodeGenModel("RunObjectIncompleteDetailsReason")]
+    public readonly partial struct RunIncompleteReason
+    {
+        // CUSTOM: Renamed.
+        [CodeGenMember("MaxCompletionTokens")]
+        public static RunIncompleteReason MaxOutputTokenCount { get; } = new RunIncompleteReason(MaxOutputTokenCountValue);
+
+        // CUSTOM: Renamed.
+        [CodeGenMember("MaxPromptTokens")]
+        public static RunIncompleteReason MaxInputTokenCount { get; } = new RunIncompleteReason(MaxInputTokenCountValue);
+    }
+}

--- a/src/Custom/Assistants/RunStepTokenUsage.cs
+++ b/src/Custom/Assistants/RunStepTokenUsage.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Assistants
+{
+    [Experimental("OPENAI001")]
+    [CodeGenModel("RunStepCompletionUsage")]
+    public partial class RunStepTokenUsage
+    {
+        // CUSTOM: Renamed.
+        [CodeGenMember("CompletionTokens")]
+        public int OutputTokenCount { get; }
+
+        // CUSTOM: Renamed.
+        [CodeGenMember("PromptTokens")]
+        public int InputTokenCount { get; }
+
+        // CUSTOM: Renamed.
+        [CodeGenMember("TotalTokens")]
+        public int TotalTokenCount { get; }
+    }
+}

--- a/src/Custom/Assistants/ThreadRun.cs
+++ b/src/Custom/Assistants/ThreadRun.cs
@@ -23,7 +23,7 @@ public partial class ThreadRun
     internal readonly InternalRunRequiredAction _internalRequiredAction;
 
     // CUSTOM: Removed null check for `toolConstraint` and `responseFormat`.
-    internal ThreadRun(string id, DateTimeOffset createdAt, string threadId, string assistantId, RunStatus status, InternalRunRequiredAction internalRequiredAction, RunError lastError, DateTimeOffset? expiresAt, DateTimeOffset? startedAt, DateTimeOffset? cancelledAt, DateTimeOffset? failedAt, DateTimeOffset? completedAt, RunIncompleteDetails incompleteDetails, string model, string instructions, IEnumerable<ToolDefinition> tools, IReadOnlyDictionary<string, string> metadata, RunTokenUsage usage, int? maxPromptTokens, int? maxCompletionTokens, RunTruncationStrategy truncationStrategy, ToolConstraint toolConstraint, bool? allowParallelToolCalls, AssistantResponseFormat responseFormat)
+    internal ThreadRun(string id, DateTimeOffset createdAt, string threadId, string assistantId, RunStatus status, InternalRunRequiredAction internalRequiredAction, RunError lastError, DateTimeOffset? expiresAt, DateTimeOffset? startedAt, DateTimeOffset? cancelledAt, DateTimeOffset? failedAt, DateTimeOffset? completedAt, RunIncompleteDetails incompleteDetails, string model, string instructions, IEnumerable<ToolDefinition> tools, IReadOnlyDictionary<string, string> metadata, RunTokenUsage usage, int? maxInputTokenCount, int? maxOutputTokenCount, RunTruncationStrategy truncationStrategy, ToolConstraint toolConstraint, bool? allowParallelToolCalls, AssistantResponseFormat responseFormat)
     {
         Argument.AssertNotNull(id, nameof(id));
         Argument.AssertNotNull(threadId, nameof(threadId));
@@ -50,8 +50,8 @@ public partial class ThreadRun
         Tools = tools.ToList();
         Metadata = metadata;
         Usage = usage;
-        MaxPromptTokens = maxPromptTokens;
-        MaxCompletionTokens = maxCompletionTokens;
+        MaxInputTokenCount = maxInputTokenCount;
+        MaxOutputTokenCount = maxOutputTokenCount;
         TruncationStrategy = truncationStrategy;
         ToolConstraint = toolConstraint;
         AllowParallelToolCalls = allowParallelToolCalls;
@@ -95,4 +95,11 @@ public partial class ThreadRun
     [CodeGenMember("ParallelToolCalls")]
     public bool? AllowParallelToolCalls { get; }
 
+    // CUSTOM: Renamed.
+    [CodeGenMember("MaxPromptTokens")]
+    public int? MaxInputTokenCount { get; }
+
+    // CUSTOM: Renamed.
+    [CodeGenMember("MaxCompletionTokens")]
+    public int? MaxOutputTokenCount { get; }
 }

--- a/src/Custom/Audio/AudioClient.cs
+++ b/src/Custom/Audio/AudioClient.cs
@@ -24,6 +24,12 @@ public partial class AudioClient
 {
     private readonly string _model;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="AudioClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>

--- a/src/Custom/Batch/BatchClient.cs
+++ b/src/Custom/Batch/BatchClient.cs
@@ -24,6 +24,12 @@ namespace OpenAI.Batch;
 [CodeGenSuppress("GetBatchesAsync", typeof(string), typeof(int?))]
 public partial class BatchClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="BatchClient">. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>

--- a/src/Custom/Chat/ChatClient.cs
+++ b/src/Custom/Chat/ChatClient.cs
@@ -23,6 +23,12 @@ public partial class ChatClient
     private readonly string _model;
     private readonly OpenTelemetrySource _telemetry;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="ChatClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>

--- a/src/Custom/Chat/OpenAIChatModelFactory.cs
+++ b/src/Custom/Chat/OpenAIChatModelFactory.cs
@@ -90,21 +90,21 @@ public static partial class OpenAIChatModelFactory
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Chat.ChatTokenUsage"/>. </summary>
     /// <returns> A new <see cref="OpenAI.Chat.ChatTokenUsage"/> instance for mocking. </returns>
-    public static ChatTokenUsage ChatTokenUsage(int outputTokens = default, int inputTokens = default, int totalTokens = default, ChatOutputTokenUsageDetails outputTokenDetails = default)
+    public static ChatTokenUsage ChatTokenUsage(int outputTokenCount = default, int inputTokenCount = default, int totalTokenCount = default, ChatOutputTokenUsageDetails outputTokenDetails = null)
     {
         return new ChatTokenUsage(
-            outputTokens,
-            inputTokens,
-            totalTokens,
+            outputTokenCount,
+            inputTokenCount,
+            totalTokenCount,
             outputTokenDetails,
             serializedAdditionalRawData: null);
     }
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Chat.ChatOutputTokenUsageDetails"/>. </summary>
     /// <returns> A new <see cref="OpenAI.Chat.ChatOutputTokenusageDetails"/> instance for mocking. </returns>
-    public static ChatOutputTokenUsageDetails ChatOutputTokenUsageDetails(int reasoningTokens = default)
+    public static ChatOutputTokenUsageDetails ChatOutputTokenUsageDetails(int reasoningTokenCount = default)
     {
-        return new ChatOutputTokenUsageDetails(reasoningTokens, serializedAdditionalRawData: null);
+        return new ChatOutputTokenUsageDetails(reasoningTokenCount, serializedAdditionalRawData: null);
     }
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Chat.StreamingChatCompletionUpdate"/>. </summary>

--- a/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/src/Custom/Embeddings/EmbeddingClient.cs
@@ -21,6 +21,12 @@ public partial class EmbeddingClient
 {
     private readonly string _model;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="EmbeddingClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>

--- a/src/Custom/Embeddings/OpenAIEmbeddingsModelFactory.cs
+++ b/src/Custom/Embeddings/OpenAIEmbeddingsModelFactory.cs
@@ -33,11 +33,11 @@ public static partial class OpenAIEmbeddingsModelFactory
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Embeddings.EmbeddingTokenUsage"/>. </summary>
     /// <returns> A new <see cref="OpenAI.Embeddings.EmbeddingTokenUsage"/> instance for mocking. </returns>
-    public static EmbeddingTokenUsage EmbeddingTokenUsage(int inputTokens = default, int totalTokens = default)
+    public static EmbeddingTokenUsage EmbeddingTokenUsage(int inputTokenCount = default, int totalTokenCount = default)
     {
         return new EmbeddingTokenUsage(
-            inputTokens,
-            totalTokens,
+            inputTokenCount,
+            totalTokenCount,
             serializedAdditionalRawData: null);
     }
 }

--- a/src/Custom/Files/FileClient.cs
+++ b/src/Custom/Files/FileClient.cs
@@ -27,6 +27,12 @@ public partial class FileClient
 {
     private InternalUploadsClient _internalUploadsClient;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>

--- a/src/Custom/Files/Internal/InternalUploadsClient.cs
+++ b/src/Custom/Files/Internal/InternalUploadsClient.cs
@@ -8,6 +8,12 @@ namespace OpenAI.Files;
 [CodeGenSuppress("InternalUploadsClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 internal partial class InternalUploadsClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.

--- a/src/Custom/FineTuning/FineTuningClient.cs
+++ b/src/Custom/FineTuning/FineTuningClient.cs
@@ -27,6 +27,12 @@ namespace OpenAI.FineTuning;
 [CodeGenSuppress("GetFineTuningJobCheckpoints", typeof(string), typeof(string), typeof(int?))]
 public partial class FineTuningClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="FineTuningClient">. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>

--- a/src/Custom/Images/ImageClient.cs
+++ b/src/Custom/Images/ImageClient.cs
@@ -25,6 +25,12 @@ public partial class ImageClient
 {
     private readonly string _model;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="ImageClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>

--- a/src/Custom/LegacyCompletions/Internal/LegacyCompletionClient.cs
+++ b/src/Custom/LegacyCompletions/Internal/LegacyCompletionClient.cs
@@ -15,6 +15,12 @@ internal partial class LegacyCompletionClient
 {
     private readonly string _model;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="LegacyCompletionClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>

--- a/src/Custom/Models/ModelClient.cs
+++ b/src/Custom/Models/ModelClient.cs
@@ -22,6 +22,12 @@ namespace OpenAI.Models;
 
 public partial class ModelClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>

--- a/src/Custom/Moderations/ModerationClient.cs
+++ b/src/Custom/Moderations/ModerationClient.cs
@@ -21,6 +21,12 @@ public partial class ModerationClient
 {
     private readonly string _model;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="ModerationClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>

--- a/src/Custom/OpenAIClient.cs
+++ b/src/Custom/OpenAIClient.cs
@@ -74,6 +74,12 @@ public partial class OpenAIClient
 
     private readonly OpenAIClientOptions _options;
 
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="OpenAIClient">. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>

--- a/src/Custom/VectorStores/VectorStoreClient.cs
+++ b/src/Custom/VectorStores/VectorStoreClient.cs
@@ -43,6 +43,12 @@ namespace OpenAI.VectorStores;
 [Experimental("OPENAI001")]
 public partial class VectorStoreClient
 {
+    // CUSTOM: Remove virtual keyword.
+    /// <summary>
+    /// The HTTP pipeline for sending and receiving REST requests and responses.
+    /// </summary>
+    public ClientPipeline Pipeline => _pipeline;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="VectorStoreClient">. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>

--- a/src/Generated/AssistantClient.cs
+++ b/src/Generated/AssistantClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Assistants
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected AssistantClient()
         {
         }

--- a/src/Generated/AudioClient.cs
+++ b/src/Generated/AudioClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Audio
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected AudioClient()
         {
         }

--- a/src/Generated/BatchClient.cs
+++ b/src/Generated/BatchClient.cs
@@ -19,8 +19,6 @@ namespace OpenAI.Batch
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected BatchClient()
         {
         }

--- a/src/Generated/ChatClient.cs
+++ b/src/Generated/ChatClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Chat
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected ChatClient()
         {
         }

--- a/src/Generated/EmbeddingClient.cs
+++ b/src/Generated/EmbeddingClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Embeddings
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected EmbeddingClient()
         {
         }

--- a/src/Generated/FileClient.cs
+++ b/src/Generated/FileClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Files
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected FileClient()
         {
         }

--- a/src/Generated/FineTuningClient.cs
+++ b/src/Generated/FineTuningClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.FineTuning
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected FineTuningClient()
         {
         }

--- a/src/Generated/ImageClient.cs
+++ b/src/Generated/ImageClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Images
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected ImageClient()
         {
         }

--- a/src/Generated/InternalAssistantMessageClient.cs
+++ b/src/Generated/InternalAssistantMessageClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Assistants
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected InternalAssistantMessageClient()
         {
         }

--- a/src/Generated/InternalAssistantRunClient.cs
+++ b/src/Generated/InternalAssistantRunClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Assistants
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected InternalAssistantRunClient()
         {
         }

--- a/src/Generated/InternalAssistantThreadClient.cs
+++ b/src/Generated/InternalAssistantThreadClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Assistants
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected InternalAssistantThreadClient()
         {
         }

--- a/src/Generated/InternalUploadsClient.cs
+++ b/src/Generated/InternalUploadsClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Files
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected InternalUploadsClient()
         {
         }

--- a/src/Generated/LegacyCompletionClient.cs
+++ b/src/Generated/LegacyCompletionClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.LegacyCompletions
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected LegacyCompletionClient()
         {
         }

--- a/src/Generated/ModelClient.cs
+++ b/src/Generated/ModelClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Models
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected ModelClient()
         {
         }

--- a/src/Generated/Models/RunCreationOptions.Serialization.cs
+++ b/src/Generated/Models/RunCreationOptions.Serialization.cs
@@ -150,24 +150,24 @@ namespace OpenAI.Assistants
                     writer.WriteNull("stream");
                 }
             }
-            if (SerializedAdditionalRawData?.ContainsKey("max_prompt_tokens") != true && Optional.IsDefined(MaxPromptTokens))
+            if (SerializedAdditionalRawData?.ContainsKey("max_prompt_tokens") != true && Optional.IsDefined(MaxInputTokenCount))
             {
-                if (MaxPromptTokens != null)
+                if (MaxInputTokenCount != null)
                 {
                     writer.WritePropertyName("max_prompt_tokens"u8);
-                    writer.WriteNumberValue(MaxPromptTokens.Value);
+                    writer.WriteNumberValue(MaxInputTokenCount.Value);
                 }
                 else
                 {
                     writer.WriteNull("max_prompt_tokens");
                 }
             }
-            if (SerializedAdditionalRawData?.ContainsKey("max_completion_tokens") != true && Optional.IsDefined(MaxCompletionTokens))
+            if (SerializedAdditionalRawData?.ContainsKey("max_completion_tokens") != true && Optional.IsDefined(MaxOutputTokenCount))
             {
-                if (MaxCompletionTokens != null)
+                if (MaxOutputTokenCount != null)
                 {
                     writer.WritePropertyName("max_completion_tokens"u8);
-                    writer.WriteNumberValue(MaxCompletionTokens.Value);
+                    writer.WriteNumberValue(MaxOutputTokenCount.Value);
                 }
                 else
                 {

--- a/src/Generated/Models/RunCreationOptions.cs
+++ b/src/Generated/Models/RunCreationOptions.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Assistants
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal RunCreationOptions(string assistantId, string modelOverride, string instructionsOverride, string additionalInstructions, IList<MessageCreationOptions> internalMessages, IList<ToolDefinition> toolsOverride, IDictionary<string, string> metadata, float? temperature, float? nucleusSamplingFactor, bool? stream, int? maxPromptTokens, int? maxCompletionTokens, RunTruncationStrategy truncationStrategy, ToolConstraint toolConstraint, bool? allowParallelToolCalls, AssistantResponseFormat responseFormat, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal RunCreationOptions(string assistantId, string modelOverride, string instructionsOverride, string additionalInstructions, IList<MessageCreationOptions> internalMessages, IList<ToolDefinition> toolsOverride, IDictionary<string, string> metadata, float? temperature, float? nucleusSamplingFactor, bool? stream, int? maxInputTokenCount, int? maxOutputTokenCount, RunTruncationStrategy truncationStrategy, ToolConstraint toolConstraint, bool? allowParallelToolCalls, AssistantResponseFormat responseFormat, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             AssistantId = assistantId;
             ModelOverride = modelOverride;
@@ -23,8 +23,8 @@ namespace OpenAI.Assistants
             Temperature = temperature;
             NucleusSamplingFactor = nucleusSamplingFactor;
             Stream = stream;
-            MaxPromptTokens = maxPromptTokens;
-            MaxCompletionTokens = maxCompletionTokens;
+            MaxInputTokenCount = maxInputTokenCount;
+            MaxOutputTokenCount = maxOutputTokenCount;
             TruncationStrategy = truncationStrategy;
             ToolConstraint = toolConstraint;
             AllowParallelToolCalls = allowParallelToolCalls;

--- a/src/Generated/Models/RunIncompleteReason.cs
+++ b/src/Generated/Models/RunIncompleteReason.cs
@@ -16,11 +16,8 @@ namespace OpenAI.Assistants
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        private const string MaxCompletionTokensValue = "max_completion_tokens";
-        private const string MaxPromptTokensValue = "max_prompt_tokens";
-
-        public static RunIncompleteReason MaxCompletionTokens { get; } = new RunIncompleteReason(MaxCompletionTokensValue);
-        public static RunIncompleteReason MaxPromptTokens { get; } = new RunIncompleteReason(MaxPromptTokensValue);
+        private const string MaxOutputTokenCountValue = "max_completion_tokens";
+        private const string MaxInputTokenCountValue = "max_prompt_tokens";
         public static bool operator ==(RunIncompleteReason left, RunIncompleteReason right) => left.Equals(right);
         public static bool operator !=(RunIncompleteReason left, RunIncompleteReason right) => !left.Equals(right);
         public static implicit operator RunIncompleteReason(string value) => new RunIncompleteReason(value);

--- a/src/Generated/Models/RunStepTokenUsage.Serialization.cs
+++ b/src/Generated/Models/RunStepTokenUsage.Serialization.cs
@@ -24,17 +24,17 @@ namespace OpenAI.Assistants
             if (SerializedAdditionalRawData?.ContainsKey("completion_tokens") != true)
             {
                 writer.WritePropertyName("completion_tokens"u8);
-                writer.WriteNumberValue(CompletionTokens);
+                writer.WriteNumberValue(OutputTokenCount);
             }
             if (SerializedAdditionalRawData?.ContainsKey("prompt_tokens") != true)
             {
                 writer.WritePropertyName("prompt_tokens"u8);
-                writer.WriteNumberValue(PromptTokens);
+                writer.WriteNumberValue(InputTokenCount);
             }
             if (SerializedAdditionalRawData?.ContainsKey("total_tokens") != true)
             {
                 writer.WritePropertyName("total_tokens"u8);
-                writer.WriteNumberValue(TotalTokens);
+                writer.WriteNumberValue(TotalTokenCount);
             }
             if (SerializedAdditionalRawData != null)
             {

--- a/src/Generated/Models/RunStepTokenUsage.cs
+++ b/src/Generated/Models/RunStepTokenUsage.cs
@@ -10,27 +10,23 @@ namespace OpenAI.Assistants
     public partial class RunStepTokenUsage
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
-        internal RunStepTokenUsage(int completionTokens, int promptTokens, int totalTokens)
+        internal RunStepTokenUsage(int outputTokenCount, int inputTokenCount, int totalTokenCount)
         {
-            CompletionTokens = completionTokens;
-            PromptTokens = promptTokens;
-            TotalTokens = totalTokens;
+            OutputTokenCount = outputTokenCount;
+            InputTokenCount = inputTokenCount;
+            TotalTokenCount = totalTokenCount;
         }
 
-        internal RunStepTokenUsage(int completionTokens, int promptTokens, int totalTokens, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal RunStepTokenUsage(int outputTokenCount, int inputTokenCount, int totalTokenCount, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
-            CompletionTokens = completionTokens;
-            PromptTokens = promptTokens;
-            TotalTokens = totalTokens;
+            OutputTokenCount = outputTokenCount;
+            InputTokenCount = inputTokenCount;
+            TotalTokenCount = totalTokenCount;
             SerializedAdditionalRawData = serializedAdditionalRawData;
         }
 
         internal RunStepTokenUsage()
         {
         }
-
-        public int CompletionTokens { get; }
-        public int PromptTokens { get; }
-        public int TotalTokens { get; }
     }
 }

--- a/src/Generated/Models/ThreadRun.Serialization.cs
+++ b/src/Generated/Models/ThreadRun.Serialization.cs
@@ -223,10 +223,10 @@ namespace OpenAI.Assistants
             }
             if (SerializedAdditionalRawData?.ContainsKey("max_prompt_tokens") != true)
             {
-                if (MaxPromptTokens != null)
+                if (MaxInputTokenCount != null)
                 {
                     writer.WritePropertyName("max_prompt_tokens"u8);
-                    writer.WriteNumberValue(MaxPromptTokens.Value);
+                    writer.WriteNumberValue(MaxInputTokenCount.Value);
                 }
                 else
                 {
@@ -235,10 +235,10 @@ namespace OpenAI.Assistants
             }
             if (SerializedAdditionalRawData?.ContainsKey("max_completion_tokens") != true)
             {
-                if (MaxCompletionTokens != null)
+                if (MaxOutputTokenCount != null)
                 {
                     writer.WritePropertyName("max_completion_tokens"u8);
-                    writer.WriteNumberValue(MaxCompletionTokens.Value);
+                    writer.WriteNumberValue(MaxOutputTokenCount.Value);
                 }
                 else
                 {

--- a/src/Generated/Models/ThreadRun.cs
+++ b/src/Generated/Models/ThreadRun.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Assistants
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal ThreadRun(string id, InternalRunObjectObject @object, DateTimeOffset createdAt, string threadId, string assistantId, RunStatus status, InternalRunRequiredAction internalRequiredAction, RunError lastError, DateTimeOffset? expiresAt, DateTimeOffset? startedAt, DateTimeOffset? cancelledAt, DateTimeOffset? failedAt, DateTimeOffset? completedAt, RunIncompleteDetails incompleteDetails, string model, string instructions, IReadOnlyList<ToolDefinition> tools, IReadOnlyDictionary<string, string> metadata, RunTokenUsage usage, float? temperature, float? nucleusSamplingFactor, int? maxPromptTokens, int? maxCompletionTokens, RunTruncationStrategy truncationStrategy, ToolConstraint toolConstraint, bool? allowParallelToolCalls, AssistantResponseFormat responseFormat, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal ThreadRun(string id, InternalRunObjectObject @object, DateTimeOffset createdAt, string threadId, string assistantId, RunStatus status, InternalRunRequiredAction internalRequiredAction, RunError lastError, DateTimeOffset? expiresAt, DateTimeOffset? startedAt, DateTimeOffset? cancelledAt, DateTimeOffset? failedAt, DateTimeOffset? completedAt, RunIncompleteDetails incompleteDetails, string model, string instructions, IReadOnlyList<ToolDefinition> tools, IReadOnlyDictionary<string, string> metadata, RunTokenUsage usage, float? temperature, float? nucleusSamplingFactor, int? maxInputTokenCount, int? maxOutputTokenCount, RunTruncationStrategy truncationStrategy, ToolConstraint toolConstraint, bool? allowParallelToolCalls, AssistantResponseFormat responseFormat, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Id = id;
             Object = @object;
@@ -35,8 +35,8 @@ namespace OpenAI.Assistants
             Usage = usage;
             Temperature = temperature;
             NucleusSamplingFactor = nucleusSamplingFactor;
-            MaxPromptTokens = maxPromptTokens;
-            MaxCompletionTokens = maxCompletionTokens;
+            MaxInputTokenCount = maxInputTokenCount;
+            MaxOutputTokenCount = maxOutputTokenCount;
             TruncationStrategy = truncationStrategy;
             ToolConstraint = toolConstraint;
             AllowParallelToolCalls = allowParallelToolCalls;
@@ -67,8 +67,6 @@ namespace OpenAI.Assistants
         public IReadOnlyDictionary<string, string> Metadata { get; }
         public RunTokenUsage Usage { get; }
         public float? Temperature { get; }
-        public int? MaxPromptTokens { get; }
-        public int? MaxCompletionTokens { get; }
         public RunTruncationStrategy TruncationStrategy { get; }
     }
 }

--- a/src/Generated/ModerationClient.cs
+++ b/src/Generated/ModerationClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.Moderations
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected ModerationClient()
         {
         }

--- a/src/Generated/OpenAIClient.cs
+++ b/src/Generated/OpenAIClient.cs
@@ -30,8 +30,6 @@ namespace OpenAI
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected OpenAIClient()
         {
         }

--- a/src/Generated/OpenAIModelFactory.cs
+++ b/src/Generated/OpenAIModelFactory.cs
@@ -53,9 +53,9 @@ namespace OpenAI
             return new RunStepError(code, message, serializedAdditionalRawData: null);
         }
 
-        public static RunStepTokenUsage RunStepTokenUsage(int completionTokens = default, int promptTokens = default, int totalTokens = default)
+        public static RunStepTokenUsage RunStepTokenUsage(int outputTokenCount = default, int inputTokenCount = default, int totalTokenCount = default)
         {
-            return new RunStepTokenUsage(completionTokens, promptTokens, totalTokens, serializedAdditionalRawData: null);
+            return new RunStepTokenUsage(outputTokenCount, inputTokenCount, totalTokenCount, serializedAdditionalRawData: null);
         }
 
         public static ModerationResultCollection ModerationResultCollection(string id = null, string model = null, IEnumerable<ModerationResult> results = null)

--- a/src/Generated/VectorStoreClient.cs
+++ b/src/Generated/VectorStoreClient.cs
@@ -18,8 +18,6 @@ namespace OpenAI.VectorStores
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        public virtual ClientPipeline Pipeline => _pipeline;
-
         protected VectorStoreClient()
         {
         }

--- a/tests/Chat/OpenAIChatModelFactoryTests.cs
+++ b/tests/Chat/OpenAIChatModelFactoryTests.cs
@@ -326,7 +326,7 @@ public partial class OpenAIChatModelFactoryTests
     [Test]
     public void ChatCompletionWithUsageWorks()
     {
-        ChatTokenUsage usage = OpenAIChatModelFactory.ChatTokenUsage(outputTokens: 20);
+        ChatTokenUsage usage = OpenAIChatModelFactory.ChatTokenUsage(outputTokenCount: 20);
         ChatCompletion chatCompletion = OpenAIChatModelFactory.ChatCompletion(usage: usage);
 
         Assert.That(chatCompletion.Id, Is.Null);
@@ -465,7 +465,7 @@ public partial class OpenAIChatModelFactoryTests
     public void ChatTokenUsageWithOutputTokensWorks()
     {
         int outputTokens = 271828;
-        ChatTokenUsage chatTokenUsage = OpenAIChatModelFactory.ChatTokenUsage(outputTokens: outputTokens);
+        ChatTokenUsage chatTokenUsage = OpenAIChatModelFactory.ChatTokenUsage(outputTokenCount: outputTokens);
 
         Assert.That(chatTokenUsage.OutputTokenCount, Is.EqualTo(outputTokens));
         Assert.That(chatTokenUsage.InputTokenCount, Is.EqualTo(0));
@@ -476,7 +476,7 @@ public partial class OpenAIChatModelFactoryTests
     public void ChatTokenUsageWithInputTokensWorks()
     {
         int inputTokens = 271828;
-        ChatTokenUsage chatTokenUsage = OpenAIChatModelFactory.ChatTokenUsage(inputTokens: inputTokens);
+        ChatTokenUsage chatTokenUsage = OpenAIChatModelFactory.ChatTokenUsage(inputTokenCount: inputTokens);
 
         Assert.That(chatTokenUsage.OutputTokenCount, Is.EqualTo(0));
         Assert.That(chatTokenUsage.InputTokenCount, Is.EqualTo(inputTokens));
@@ -487,7 +487,7 @@ public partial class OpenAIChatModelFactoryTests
     public void ChatTokenUsageWithTotalTokensWorks()
     {
         int totalTokens = 271828;
-        ChatTokenUsage chatTokenUsage = OpenAIChatModelFactory.ChatTokenUsage(totalTokens: totalTokens);
+        ChatTokenUsage chatTokenUsage = OpenAIChatModelFactory.ChatTokenUsage(totalTokenCount: totalTokens);
 
         Assert.That(chatTokenUsage.OutputTokenCount, Is.EqualTo(0));
         Assert.That(chatTokenUsage.InputTokenCount, Is.EqualTo(0));
@@ -809,7 +809,7 @@ public partial class OpenAIChatModelFactoryTests
     [Test]
     public void StreamingChatCompletionUpdateWithUsageWorks()
     {
-        ChatTokenUsage usage = OpenAIChatModelFactory.ChatTokenUsage(outputTokens: 20);
+        ChatTokenUsage usage = OpenAIChatModelFactory.ChatTokenUsage(outputTokenCount: 20);
         StreamingChatCompletionUpdate streamingChatCompletionUpdate = OpenAIChatModelFactory.StreamingChatCompletionUpdate(usage: usage);
 
         Assert.That(streamingChatCompletionUpdate.Id, Is.Null);

--- a/tests/Embeddings/OpenAIEmbeddingsModelFactoryTests.cs
+++ b/tests/Embeddings/OpenAIEmbeddingsModelFactoryTests.cs
@@ -77,7 +77,7 @@ public class OpenAIEmbeddingsModelFactoryTests
     [Test]
     public void EmbeddingCollectionWithUsageWorks()
     {
-        EmbeddingTokenUsage usage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokens: 10);
+        EmbeddingTokenUsage usage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokenCount: 10);
         OpenAIEmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.OpenAIEmbeddingCollection(usage: usage);
 
         Assert.That(embeddingCollection.Count, Is.EqualTo(0));
@@ -98,7 +98,7 @@ public class OpenAIEmbeddingsModelFactoryTests
     public void EmbeddingTokenUsageWithInputTokensWorks()
     {
         int inputTokens = 10;
-        EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokens: inputTokens);
+        EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokenCount: inputTokens);
 
         Assert.That(embeddingTokenUsage.InputTokenCount, Is.EqualTo(10));
         Assert.That(embeddingTokenUsage.TotalTokenCount, Is.EqualTo(default(int)));
@@ -108,7 +108,7 @@ public class OpenAIEmbeddingsModelFactoryTests
     public void EmbeddingTokenUsageWithTotalTokensWorks()
     {
         int totalTokens = 10;
-        EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(totalTokens: totalTokens);
+        EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(totalTokenCount: totalTokens);
 
         Assert.That(embeddingTokenUsage.InputTokenCount, Is.EqualTo(default(int)));
         Assert.That(embeddingTokenUsage.TotalTokenCount, Is.EqualTo(totalTokens));


### PR DESCRIPTION
Based on the below arch board discussion, removing the `virtual` keyword from the `Pipeline` property across all clients.

![image](https://github.com/user-attachments/assets/d0f1510b-60dc-4d32-9245-2956b7b8b908)


This PR also updates the token count property names.