### PR TITLE
Simplify structured outputs sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,12 +342,12 @@ ChatCompletion completion = client.CompleteChat(messages, options);
 
 using JsonDocument structuredJson = JsonDocument.Parse(completion.Content[0].Text);
 
-Console.WriteLine($"Final answer: {structuredJson.RootElement.GetProperty("final_answer").GetString()}");
+Console.WriteLine($"Final answer: {structuredJson.RootElement.GetProperty("final_answer")}");
 Console.WriteLine("Reasoning steps:");
 
 foreach (JsonElement stepElement in structuredJson.RootElement.GetProperty("steps").EnumerateArray())
 {
-    Console.WriteLine($"  - Explanation: {stepElement.GetProperty("explanation").GetString()}");
+    Console.WriteLine($"  - Explanation: {stepElement.GetProperty("explanation")}");
     Console.WriteLine($"    Output: {stepElement.GetProperty("output")}");
 }
 ```

--- a/examples/Chat/Example06_StructuredOutputs.cs
+++ b/examples/Chat/Example06_StructuredOutputs.cs
@@ -51,12 +51,12 @@ public partial class ChatExamples
 
         using JsonDocument structuredJson = JsonDocument.Parse(completion.Content[0].Text);
 
-        Console.WriteLine($"Final answer: {structuredJson.RootElement.GetProperty("final_answer").GetString()}");
+        Console.WriteLine($"Final answer: {structuredJson.RootElement.GetProperty("final_answer")}");
         Console.WriteLine("Reasoning steps:");
 
         foreach (JsonElement stepElement in structuredJson.RootElement.GetProperty("steps").EnumerateArray())
         {
-            Console.WriteLine($"  - Explanation: {stepElement.GetProperty("explanation").GetString()}");
+            Console.WriteLine($"  - Explanation: {stepElement.GetProperty("explanation")}");
             Console.WriteLine($"    Output: {stepElement.GetProperty("output")}");
         }
     }

--- a/examples/Chat/Example06_StructuredOutputsAsync.cs
+++ b/examples/Chat/Example06_StructuredOutputsAsync.cs
@@ -52,12 +52,12 @@ public partial class ChatExamples
 
         using JsonDocument structuredJson = JsonDocument.Parse(completion.Content[0].Text);
 
-        Console.WriteLine($"Final answer: {structuredJson.RootElement.GetProperty("final_answer").GetString()}");
+        Console.WriteLine($"Final answer: {structuredJson.RootElement.GetProperty("final_answer")}");
         Console.WriteLine("Reasoning steps:");
 
         foreach (JsonElement stepElement in structuredJson.RootElement.GetProperty("steps").EnumerateArray())
         {
-            Console.WriteLine($"  - Explanation: {stepElement.GetProperty("explanation").GetString()}");
+            Console.WriteLine($"  - Explanation: {stepElement.GetProperty("explanation")}");
             Console.WriteLine($"    Output: {stepElement.GetProperty("output")}");
         }
     }


### PR DESCRIPTION
When C# string interpolation is used, the `ToString()` method is automatically invoked. The `ToString()` method on `System.Text.Json.JsonElement` already invokes `GetString()`: https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs#L1424-L1425. This behavior is also publicly documented at https://learn.microsoft.com/dotnet/api/system.text.json.jsonelement.tostring?view=net-8.0#remarks.