### PR TITLE
add eos finish reason that maps to Stop for llama models

### DIFF
--- a/src/Generated/Models/ChatFinishReason.Serialization.cs
+++ b/src/Generated/Models/ChatFinishReason.Serialization.cs
@@ -25,6 +25,7 @@ namespace OpenAI.Chat
             if (StringComparer.OrdinalIgnoreCase.Equals(value, "tool_calls")) return ChatFinishReason.ToolCalls;
             if (StringComparer.OrdinalIgnoreCase.Equals(value, "content_filter")) return ChatFinishReason.ContentFilter;
             if (StringComparer.OrdinalIgnoreCase.Equals(value, "function_call")) return ChatFinishReason.FunctionCall;
+            if (StringComparer.OrdinalIgnoreCase.Equals(value, "eos")) return ChatFinishReason.Stop;
             throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown ChatFinishReason value.");
         }
     }


### PR DESCRIPTION
I got this error below when using SemanticKernel with Together.ai as an open ai compatible endpoint. It seems like they return `eos` instead of the normal `stop` string thowing an exception just before completion.

System.ArgumentOutOfRangeException: Unknown ChatFinishReason value. (Parameter 'value')\nActual value was eos.\n   at OpenAI.Chat.ChatFinishReasonExtensions.ToChatFinishReason(String value)\n   at OpenAI.Chat.InternalCreateChatCompletionStreamResponseChoice.DeserializeInternalCreateChatCompletionStreamResponseChoice(JsonElement element, ModelReaderWriterOptions options)\n   at OpenAI.Chat.StreamingChatCompletionUpdate.DeserializeStreamingChatCompletionUpdate(JsonElement element, ModelReaderWriterOptions options)\n   at 