### PR TITLE
Added net8.0 as a supported target framework for OpenAI #272

### DIFF
--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -9,7 +9,7 @@
     <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix>beta.1</VersionSuffix>
 
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
     <!-- Generate an XML documentation file for the project. -->


### PR DESCRIPTION
I honestly do not know why this has not been done by now. NET 8 is the latest dotnet version and is also LTS.

All the examples and tests projects are already targeting `net8.0` so basically the only the thing needing to be done is add it to the supported target frameworks in the OpenAI.csproj

Besides, from what I understood, this would help with #272 and the change proposed in this PR was also suggested by @RogerBarreto in #98, however that PR was never updated since August.