### PR TITLE
Assistant - Fix null-reference exception when accessing `RunStepDetailsUpdate.FunctionName`

### DIFF
--- a/src/Custom/Assistants/Streaming/RunStepDetailsUpdate.cs
+++ b/src/Custom/Assistants/Streaming/RunStepDetailsUpdate.cs
@@ -45,7 +45,7 @@ public class RunStepDetailsUpdate : StreamingUpdate
         => _asCodeCall?.CodeInterpreter?.Outputs;
 
     /// <inheritdoc cref="InternalRunStepDeltaStepDetailsToolCallsFunctionObjectFunction.Name"/>
-    public string FunctionName => _asFunctionCall.Function?.Name;
+    public string FunctionName => _asFunctionCall?.Function?.Name;
 
     /// <inheritdoc cref="InternalRunStepDeltaStepDetailsToolCallsFunctionObjectFunction.Arguments"/>
     public string FunctionArguments => _asFunctionCall?.Function?.Arguments;

--- a/tests/Assistants/AssistantsTests.cs
+++ b/tests/Assistants/AssistantsTests.cs
@@ -1015,6 +1015,12 @@ public class AssistantsTests : SyncAsyncTestBase
                 {
                     message += $"{contentUpdate.Text}";
                 }
+                else if (update is RunStepDetailsUpdate detailUpdate)
+                {
+                    string? functionName = "none"; // expect null assignment on next line
+                    Assert.DoesNotThrow(() => functionName = detailUpdate.FunctionName);
+                    Assert.Null(functionName);
+                }
             }
         }
         else


### PR DESCRIPTION
The propertis for `RunStepDetailsUpdate` all fall-through for null internal definitions, except for `FunctionName`...which results in a `NullReferenceException`.  This is inconsistent with the expected behavior.

This complicates inspection when _file-search_ and _functions_ are both enabled.