### PR TITLE
fix: should set _isSendingAudio to false after sending audio BinaryData

### DIFF
--- a/src/Custom/RealtimeConversation/RealtimeConversationSession.cs
+++ b/src/Custom/RealtimeConversation/RealtimeConversationSession.cs
@@ -139,9 +139,19 @@ public partial class RealtimeConversationSession : IDisposable
             _isSendingAudio = true;
         }
         // TODO: consider automatically limiting/breaking size of chunk (as with streaming)
-        InternalRealtimeClientEventInputAudioBufferAppend internalCommand = new(audio);
-        BinaryData requestData = ModelReaderWriter.Write(internalCommand);
-        await SendCommandAsync(requestData, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        try
+        {
+            InternalRealtimeClientEventInputAudioBufferAppend internalCommand = new(audio);
+            BinaryData requestData = ModelReaderWriter.Write(internalCommand);
+            await SendCommandAsync(requestData, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_sendingAudioLock)
+            {
+                _isSendingAudio = false;
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
`_isSendingAudio` was not set back to `false` and will cause exception when calling the `SendInputAudioAsync` with `BinaryData` repeatedly.