### PR TITLE
Fixed spelling error in ChatMessageContentPart comment.

### DIFF
--- a/src/Custom/Chat/ChatMessageContentPart.cs
+++ b/src/Custom/Chat/ChatMessageContentPart.cs
@@ -153,7 +153,7 @@ public partial class ChatMessageContentPart
     }
 
     /// <summary>
-    ///     Implicitly intantiates a new <see cref="ChatMessageContentPart"/> from a <see cref="string"/>. As such,
+    ///     Implicitly instantiates a new <see cref="ChatMessageContentPart"/> from a <see cref="string"/>. As such,
     ///     using a <see cref="string"/> in place of a <see cref="ChatMessageContentPart"/> is equivalent to calling the
     ///     <see cref="CreateTextPart(string)"/> method.
     /// </summary>


### PR DESCRIPTION
Fixes the misspelling of instantiates (#265).