### PR TITLE
chore: set license in nuget package

### DIFF
--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -5,6 +5,8 @@
     </Description>
     <AssemblyTitle>SDK Code Generation OpenAI</AssemblyTitle>
     <PackageTags>OpenAI;openai-dotnet;ChatGPT;Dall-E</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>Copyright (c) 2024 OpenAI (https://openai.com)</Copyright>
 
     <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>


### PR DESCRIPTION
set the license in the nuget package according to the `LICENSE` file in the repository.