### PR TITLE
* GenericActionPipelinePolicy - ConfigureAwait(false) for ProcessAsync method

### DIFF
--- a/src/Utility/GenericActionPipelinePolicy.cs
+++ b/src/Utility/GenericActionPipelinePolicy.cs
@@ -28,7 +28,7 @@ internal partial class GenericActionPipelinePolicy : PipelinePolicy
         _processMessageAction(message);
         if (currentIndex < pipeline.Count - 1)
         {
-            await pipeline[currentIndex + 1].ProcessAsync(message, pipeline, currentIndex + 1);
+            await pipeline[currentIndex + 1].ProcessAsync(message, pipeline, currentIndex + 1).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
If this was not intentional, it might be better to add ConfigureAwait(false) to this method. In my case, there was dedlock with Blazor Server.
I think it would be better if the synchronization context was not captured inside the library