### PR TITLE
Fixed some code formatting in the Structured Output section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,19 +320,19 @@ ChatCompletionOptions options = new()
             {
                 "type": "object",
                 "properties": {
-                "steps": {
-                    "type": "array",
-                    "items": {
-                    "type": "object",
-                    "properties": {
-                        "explanation": { "type": "string" },
-                        "output": { "type": "string" }
+                    "steps": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "explanation": { "type": "string" },
+                                "output": { "type": "string" }
+                            },
+                            "required": ["explanation", "output"],
+                            "additionalProperties": false
+                        }
                     },
-                    "required": ["explanation", "output"],
-                    "additionalProperties": false
-                    }
-                },
-                "final_answer": { "type": "string" }
+                    "final_answer": { "type": "string" }
                 },
                 "required": ["steps", "final_answer"],
                 "additionalProperties": false


### PR DESCRIPTION
The code sample in the Structured Output section of the README had a couple layers of nested properties were not indented. I adjusted that formatting to help make the sample code a bit easier to read.