### PR TITLE
Type-forward `IsExternalInit` on modern .NET.

### DIFF
--- a/src/Utility/Polyfill/System.Runtime.CompilerServices.IsExternalInit.cs
+++ b/src/Utility/Polyfill/System.Runtime.CompilerServices.IsExternalInit.cs
@@ -1,4 +1,8 @@
-#if !NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
+using System.Runtime.CompilerServices;
+
+[assembly:TypeForwardedTo(typeof(IsExternalInit))]
+#else
 
 using System.ComponentModel;
 namespace System.Runtime.CompilerServices;


### PR DESCRIPTION
Fixes compatibility between the .NET Standard 2.0 and modern .NET assemblies.

See https://github.com/Sergio0694/PolySharp/issues/98#issuecomment-2183071987 for more details.