### PR TITLE
Add GenerateSpeechStreamingAsync() for streaming TTS responses.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    //"version": "8.0.100",
     "rollForward": "feature"
   }
 }

--- a/src/Custom/Audio/AudioClient.cs
+++ b/src/Custom/Audio/AudioClient.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Buffers;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -108,7 +111,45 @@ public partial class AudioClient
 
         using BinaryContent content = options;
         ClientResult result = await GenerateSpeechAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        await result.GetRawResponse().BufferContentAsync(cancellationToken).ConfigureAwait(false);
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
+    }
+
+    /// <summary> Generates a life-like, spoken audio recording of the input text. </summary>
+    /// <remarks>
+    ///     The default format of the generated audio is <see cref="GeneratedSpeechFormat.Mp3"/> unless otherwise specified
+    ///     via <see cref="SpeechGenerationOptions.ResponseFormat"/>.
+    /// </remarks>
+    /// <param name="text"> The text to generate audio for. </param>
+    /// <param name="voice"> The voice to use in the generated audio. </param>
+    /// <param name="options"> The options to configure the audio generation. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="text"/> is null. </exception>
+    /// <returns> Streaming chunks of the generated audio in the specified output format. </returns>
+    public virtual async IAsyncEnumerable<BinaryData> GenerateSpeechStreamingAsync(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Argument.AssertNotNull(text, nameof(text));
+
+        options ??= new();
+        CreateSpeechGenerationOptions(text, voice, ref options);
+
+        using BinaryContent content = options;
+        ClientResult result = await GenerateSpeechAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        var stream = result.GetRawResponse().ContentStream;
+
+        var buffer = ArrayPool<byte>.Shared.Rent(1024 * 16);
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) != 0)
+            {
+                yield return BinaryData.FromBytes(buffer.AsMemory(0, bytesRead));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     /// <summary> Generates a life-like, spoken audio recording of the input text. </summary>
@@ -130,7 +171,8 @@ public partial class AudioClient
         CreateSpeechGenerationOptions(text, voice, ref options);
 
         using BinaryContent content = options;
-        ClientResult result = GenerateSpeech(content, cancellationToken.ToRequestOptions()); ;
+        ClientResult result = GenerateSpeech(content, cancellationToken.ToRequestOptions());
+        result.GetRawResponse().BufferContent(cancellationToken);
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
     }
 

--- a/src/Custom/Audio/SpeechGenerationOptions.cs
+++ b/src/Custom/Audio/SpeechGenerationOptions.cs
@@ -37,4 +37,11 @@ public partial class SpeechGenerationOptions
     [CodeGenMember("Speed")]
 
     public float? SpeedRatio { get; set; }
+
+    // CUSTOM:
+    /// <summary>
+    ///     Control the voice of your generated audio with additional instructions. Does not work with tts-1 or tts-1-hd.
+    /// </summary>
+    [CodeGenMember("Instructions")]
+    public string Instructions { get; set; }
 }

--- a/src/Generated/AudioClient.RestClient.cs
+++ b/src/Generated/AudioClient.RestClient.cs
@@ -18,6 +18,7 @@ namespace OpenAI.Audio
         {
             PipelineMessage message = Pipeline.CreateMessage();
             message.ResponseClassifier = PipelineMessageClassifier200;
+            message.BufferResponse = false;
             PipelineRequest request = message.Request;
             request.Method = "POST";
             ClientUriBuilder uri = new ClientUriBuilder();

--- a/src/Generated/Models/SpeechGenerationOptions.Serialization.cs
+++ b/src/Generated/Models/SpeechGenerationOptions.Serialization.cs
@@ -52,6 +52,11 @@ namespace OpenAI.Audio
                 writer.WritePropertyName("speed"u8);
                 writer.WriteNumberValue(SpeedRatio.Value);
             }
+            if (Optional.IsDefined(Instructions) && _additionalBinaryDataProperties?.ContainsKey("instructions") != true)
+            {
+                writer.WritePropertyName("instructions"u8);
+                writer.WriteStringValue(Instructions);
+            }
             if (_additionalBinaryDataProperties != null)
             {
                 foreach (var item in _additionalBinaryDataProperties)
@@ -97,6 +102,7 @@ namespace OpenAI.Audio
             string input = default;
             GeneratedSpeechVoice voice = default;
             float? speedRatio = default;
+            string instructions = default;
             IDictionary<string, BinaryData> additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
             foreach (var prop in element.EnumerateObject())
             {
@@ -133,6 +139,11 @@ namespace OpenAI.Audio
                     speedRatio = prop.Value.GetSingle();
                     continue;
                 }
+                if (prop.NameEquals("instructions"u8))
+                {
+                    instructions = prop.Value.GetString();
+                    continue;
+                }
                 additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
             }
             return new SpeechGenerationOptions(
@@ -141,6 +152,7 @@ namespace OpenAI.Audio
                 input,
                 voice,
                 speedRatio,
+                instructions,
                 additionalBinaryDataProperties);
         }
 

--- a/src/Generated/Models/SpeechGenerationOptions.cs
+++ b/src/Generated/Models/SpeechGenerationOptions.cs
@@ -11,13 +11,14 @@ namespace OpenAI.Audio
     {
         private protected IDictionary<string, BinaryData> _additionalBinaryDataProperties;
 
-        internal SpeechGenerationOptions(GeneratedSpeechFormat? responseFormat, InternalCreateSpeechRequestModel model, string input, GeneratedSpeechVoice voice, float? speedRatio, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        internal SpeechGenerationOptions(GeneratedSpeechFormat? responseFormat, InternalCreateSpeechRequestModel model, string input, GeneratedSpeechVoice voice, float? speedRatio, string instructions, IDictionary<string, BinaryData> additionalBinaryDataProperties)
         {
             ResponseFormat = responseFormat;
             Model = model;
             Input = input;
             Voice = voice;
             SpeedRatio = speedRatio;
+            Instructions = instructions;
             _additionalBinaryDataProperties = additionalBinaryDataProperties;
         }
 

--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -11,7 +11,7 @@
     <VersionPrefix>2.2.0</VersionPrefix>
     <VersionSuffix>beta.4</VersionSuffix>
 
-    <TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
     <!-- Generate an XML documentation file for the project. -->


### PR DESCRIPTION
This PR adds GenerateSpeechStreamingAsync(), which returns the stream of audio chunks from the TTS API.
This differs from the existing GenerateSpeechAsync(), which returns only the entire audio file after it has completed downloading.

Feel free to make it your own.