### PR TITLE
Fix call id argument validation

### DIFF
--- a/src/Custom/Chat/ChatToolCall.cs
+++ b/src/Custom/Chat/ChatToolCall.cs
@@ -50,7 +50,7 @@ public partial class ChatToolCall
     /// <exception cref="ArgumentException"> <paramref name="id"/> or <paramref name="functionName"/> is an empty string, and was expected to be non-empty. </exception>
     public static ChatToolCall CreateFunctionToolCall(string id, string functionName, BinaryData functionArguments)
     {
-        Argument.AssertNotNullOrEmpty(id, nameof(id));
+        Argument.AssertNotNull(id, nameof(id));
         Argument.AssertNotNullOrEmpty(functionName, nameof(functionName));
         Argument.AssertNotNull(functionArguments, nameof(functionArguments));
 

--- a/src/Custom/Chat/Messages/ToolChatMessage.cs
+++ b/src/Custom/Chat/Messages/ToolChatMessage.cs
@@ -37,7 +37,7 @@ public partial class ToolChatMessage : ChatMessage
     public ToolChatMessage(string toolCallId, IEnumerable<ChatMessageContentPart> contentParts)
         : base(ChatMessageRole.Tool, contentParts)
     {
-        Argument.AssertNotNullOrEmpty(toolCallId, nameof(toolCallId));
+        Argument.AssertNotNull(toolCallId, nameof(toolCallId));
         Argument.AssertNotNullOrEmpty(contentParts, nameof(contentParts));
 
         ToolCallId = toolCallId;
@@ -56,7 +56,7 @@ public partial class ToolChatMessage : ChatMessage
     public ToolChatMessage(string toolCallId, params ChatMessageContentPart[] contentParts)
         : base(ChatMessageRole.Tool, contentParts)
     {
-        Argument.AssertNotNullOrEmpty(toolCallId, nameof(toolCallId));
+        Argument.AssertNotNull(toolCallId, nameof(toolCallId));
         Argument.AssertNotNullOrEmpty(contentParts, nameof(contentParts));
 
         ToolCallId = toolCallId;
@@ -72,7 +72,7 @@ public partial class ToolChatMessage : ChatMessage
     public ToolChatMessage(string toolCallId, string content)
         : base(ChatMessageRole.Tool, content)
     {
-        Argument.AssertNotNullOrEmpty(toolCallId, nameof(toolCallId));
+        Argument.AssertNotNull(toolCallId, nameof(toolCallId));
         Argument.AssertNotNull(content, nameof(content));
 
         ToolCallId = toolCallId;


### PR DESCRIPTION
Some "OpenAI compatible" endpoints use empty tool call IDs.

Fixes https://github.com/openai/openai-dotnet/issues/428