### PR TITLE
Fix #433, #358, #342.

### DIFF
--- a/src/Custom/Chat/ChatFinishReason.cs
+++ b/src/Custom/Chat/ChatFinishReason.cs
@@ -84,4 +84,12 @@ public enum ChatFinishReason
     /// </remarks>
     [CodeGenMember("FunctionCall")]
     FunctionCall,
+
+    /// <summary>
+    /// Indicates that the model returns unknown finish reason (or null).
+    /// We interpret this as a stop sequence.
+    /// </summary>
+    [CodeGenMember("Stop")]
+    Unknown
+
 }

--- a/src/Custom/Chat/Internal/InternalChatCompletionMessageToolCallFunction.Serialization.cs
+++ b/src/Custom/Chat/Internal/InternalChatCompletionMessageToolCallFunction.Serialization.cs
@@ -25,6 +25,15 @@ internal partial class InternalChatCompletionMessageToolCallFunction : IJsonMode
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void DeserializeArgumentsValue(JsonProperty property, ref BinaryData arguments, ModelReaderWriterOptions options = null)
     {
-        arguments = BinaryData.FromString(property.Value.GetString());
+        //for a tool calls without arguments there will be an Object instead of String.
+        var obj = property.Value.GetObject();
+        if (obj is string s)
+        {
+            arguments = BinaryData.FromString(s);
+        }
+        else
+        {
+            arguments = BinaryData.FromString(string.Empty);
+        }
     }
 }

--- a/src/Custom/Chat/Streaming/InternalChatCompletionMessageToolCallChunkFunction.Serialization.cs
+++ b/src/Custom/Chat/Streaming/InternalChatCompletionMessageToolCallChunkFunction.Serialization.cs
@@ -26,6 +26,16 @@ internal partial class InternalChatCompletionMessageToolCallChunkFunction : IJso
         {
             return;
         }
-        arguments = BinaryData.FromString(property.Value.GetString());
+
+        //for a tool calls without arguments there will be an Object instead of String.
+        var obj = property.Value.GetObject();
+        if (obj is string s)
+        {
+            arguments = BinaryData.FromString(s);
+        }
+        else
+        {
+            arguments = BinaryData.FromString(string.Empty);
+        }
     }
 }

--- a/src/Generated/Models/ChatFinishReason.Serialization.cs
+++ b/src/Generated/Models/ChatFinishReason.Serialization.cs
@@ -40,7 +40,7 @@ namespace OpenAI.Chat
             {
                 return ChatFinishReason.FunctionCall;
             }
-            throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown ChatFinishReason value.");
+            return ChatFinishReason.Unknown;
         }
     }
 }


### PR DESCRIPTION
Here is fixed:

1. #433 For a functions without arguments `DeserializeArgumentsValue` fails to deserialize.
2. #342 and perhaps #358 Sometimes LLMs returns invalid value for a chat finish reason (even `null` can returns). So preferred behavior is to return `Unknown` finish reason, not to raise exception.