### PR TITLE
Preliminary Support for gpt-image-1

### DIFF
--- a/examples/CombinationExamples.cs
+++ b/examples/CombinationExamples.cs
@@ -21,7 +21,7 @@ public partial class CombinationExamples
             new()
             {
                 Style = GeneratedImageStyle.Vivid,
-                Quality = GeneratedImageQuality.High,
+                Quality = GeneratedImageQuality.Hd,
                 Size = GeneratedImageSize.W1792xH1024,
             });
         GeneratedImage imageGeneration = imageResult.Value;
@@ -109,7 +109,7 @@ public partial class CombinationExamples
             new ImageGenerationOptions()
             {
                 Size = GeneratedImageSize.W1792xH1024,
-                Quality = GeneratedImageQuality.High,
+                Quality = GeneratedImageQuality.Hd,
             });
         Uri imageLocation = imageGenerationResult.Value.ImageUri;
         Console.WriteLine($"Creature image available at:\n{imageLocation.AbsoluteUri}");

--- a/examples/Images/Example01_SimpleImageGeneration.cs
+++ b/examples/Images/Example01_SimpleImageGeneration.cs
@@ -22,7 +22,7 @@ public partial class ImageExamples
 
         ImageGenerationOptions options = new()
         {
-            Quality = GeneratedImageQuality.High,
+            Quality = GeneratedImageQuality.Hd,
             Size = GeneratedImageSize.W1792xH1024,
             Style = GeneratedImageStyle.Vivid,
             ResponseFormat = GeneratedImageFormat.Bytes

--- a/examples/Images/Example01_SimpleImageGenerationAsync.cs
+++ b/examples/Images/Example01_SimpleImageGenerationAsync.cs
@@ -23,7 +23,7 @@ public partial class ImageExamples
 
         ImageGenerationOptions options = new()
         {
-            Quality = GeneratedImageQuality.High,
+            Quality = GeneratedImageQuality.Hd,
             Size = GeneratedImageSize.W1792xH1024,
             Style = GeneratedImageStyle.Vivid,
             ResponseFormat = GeneratedImageFormat.Bytes

--- a/src/Custom/Images/GeneratedImageQuality.cs
+++ b/src/Custom/Images/GeneratedImageQuality.cs
@@ -29,7 +29,7 @@ public readonly partial struct GeneratedImageQuality
     /// </summary>
     /// 
     [CodeGenMember("High")]
-    public static GeneratedImageQuality High { get; } = new GeneratedImageQuality(HdValue);
+    public static GeneratedImageQuality High { get; } = new GeneratedImageQuality(HighValue);
     /// <summary>
     /// Medium quality level.
     /// <para>

--- a/src/Custom/Images/GeneratedImageQuality.cs
+++ b/src/Custom/Images/GeneratedImageQuality.cs
@@ -2,12 +2,58 @@ namespace OpenAI.Images;
 
 // CUSTOM: Renamed.
 /// <summary>
-///     The quality of the image that will be generated. <see cref="High"/> creates images with finer details and
+///     The quality of the image that will be generated. <see cref="Hd"/> creates images with finer details and
 ///     greater consistency across the image.
+///     <para>
+///     High, medium and low qualities are only supported for gpt-image-1.
+///     </para>
+///     <para>
+///     dall-e-2 only supports standard quality.
+///     </para>
+///     <para>
+///     Defaults to auto.
+///     </para>
 /// </summary>
 [CodeGenType("CreateImageRequestQuality")]
 public readonly partial struct GeneratedImageQuality
 {
+
     [CodeGenMember("Hd")]
+    public static GeneratedImageQuality Hd { get; } = new GeneratedImageQuality(HdValue);
+
+    /// <summary>
+    /// High quality level - creates images with finer details and greater consistency.
+    /// <para>
+    /// Only supported for <c>gpt-image-1</c>.
+    /// </para>
+    /// </summary>
+    /// 
+    [CodeGenMember("High")]
     public static GeneratedImageQuality High { get; } = new GeneratedImageQuality(HdValue);
+    /// <summary>
+    /// Medium quality level.
+    /// <para>
+    /// Only supported for <c>gpt-image-1</c>.
+    /// </para>
+    /// </summary>
+    [CodeGenMember("Medium")]
+    public static GeneratedImageQuality Medium { get; } = new GeneratedImageQuality(MediumValue);
+
+    /// <summary>
+    /// Low quality level.
+    /// <para>
+    /// Only supported for <c>gpt-image-1</c>.
+    /// </para>
+    /// </summary>
+    [CodeGenMember("Low")]
+    public static GeneratedImageQuality Low { get; } = new GeneratedImageQuality(LowValue);
+
+    /// <summary>
+    /// Auto quality level - the system will automatically choose the appropriate quality level.
+    /// <para>
+    /// This is the default value.
+    /// </para>
+    /// </summary>
+    [CodeGenMember("Auto")]
+    public static GeneratedImageQuality Auto { get; } = new GeneratedImageQuality(AutoValue);
 }

--- a/src/Custom/Images/GeneratedImageSize.cs
+++ b/src/Custom/Images/GeneratedImageSize.cs
@@ -52,7 +52,7 @@ public readonly partial struct GeneratedImageSize : IEquatable<GeneratedImageSiz
     /// <summary>
     /// A square image with 1024 pixels of both width and height.
     /// <para>
-    /// <b>Supported</b> and <b>default</b> for both <c>dall-e-2</c> and <c>dall-e-3</c> models.
+    /// <b>Supported</b> and <b>default</b> for both <c>dall-e-2</c>, <c>dall-e-3</c> and <c>gpt-image-1</c> models.
     /// </para>
     /// </summary>
     [CodeGenMember("_1024x1024")]
@@ -75,4 +75,22 @@ public readonly partial struct GeneratedImageSize : IEquatable<GeneratedImageSiz
     /// </summary>
     [CodeGenMember("_1024x1792")]
     public static readonly GeneratedImageSize W1792xH1024 = new(1792, 1024);
+
+    /// <summary>
+    /// A landscape rectangular image with 1536 pixels of width and 1024 pixels of height.
+    /// <para>
+    /// Supported <b>only</b> for the newer <c>gpt-image-1</c> model.
+    /// </para>
+    /// </summary>
+    [CodeGenMember("_1536x1024")]
+    public static readonly GeneratedImageSize W1536xH1024 = new(1536, 1024);
+
+    /// <summary>
+    /// A portrait rectangular image with 1024 pixels of width and 1536 pixels of height.
+    /// <para>
+    /// Supported <b>only</b> for the newer <c>gpt-image-1</c> model.
+    /// </para>
+    /// </summary>
+    [CodeGenMember("1024x_1536")]
+    public static readonly GeneratedImageSize W1024xH1536 = new(1024, 1536);
 }

--- a/src/Custom/Images/ImageEditOptions.cs
+++ b/src/Custom/Images/ImageEditOptions.cs
@@ -73,10 +73,34 @@ public partial class ImageEditOptions
     {
     }
 
-    // CUSTOM: Changed property type.
-    /// <summary> The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`. </summary>
+    // CUSTOM: Changed property type and updated documentation.
+    /// <summary> 
+    /// The size of the generated images. 
+    /// <para>
+    /// For gpt-image-1, must be one of 1024x1024, 1536x1024 (landscape), 1024x1536 (portrait), or auto (default value).
+    /// </para>
+    /// <para>
+    /// For dall-e-2, must be one of 256x256, 512x512, or 1024x1024.
+    /// </para>
+    /// </summary>
     [CodeGenMember("Size")]
     public GeneratedImageSize? Size { get; set; }
+
+    // CUSTOM: Added Quality property
+    /// <summary> 
+    /// Quality of the image that will be generated.
+    /// <para>
+    /// High, medium and low are only supported for gpt-image-1.
+    /// </para>
+    /// <para>
+    /// dall-e-2 only supports standard quality.
+    /// </para>
+    /// <para>
+    /// Defaults to auto.
+    /// </para>
+    /// </summary>
+    [CodeGenMember("Quality")]
+    public GeneratedImageQuality? Quality { get; set; }
 
     // CUSTOM: Changed property type.
     /// <summary> The format in which the generated images are returned. Must be one of `url` or `b64_json`. </summary>
@@ -117,6 +141,11 @@ public partial class ImageEditOptions
         if (Size is not null)
         {
             content.Add(Size.ToString(), "size");
+        }
+
+        if (Quality is not null)
+        {
+            content.Add(Quality.ToString(), "quality");
         }
 
         if (EndUserId is not null)

--- a/src/Generated/Models/GeneratedImageQuality.cs
+++ b/src/Generated/Models/GeneratedImageQuality.cs
@@ -14,6 +14,11 @@ namespace OpenAI.Images
         private const string StandardValue = "standard";
         private const string HdValue = "hd";
 
+        private const string HighValue = "high";
+        private const string MediumValue = "medium";
+        private const string LowValue = "low";
+        private const string AutoValue = "auto";
+
         public GeneratedImageQuality(string value)
         {
             Argument.AssertNotNull(value, nameof(value));

--- a/src/Generated/Models/GeneratedImageSize.cs
+++ b/src/Generated/Models/GeneratedImageSize.cs
@@ -15,6 +15,8 @@ namespace OpenAI.Images
         private const string _1024x1024Value = "1024x1024";
         private const string _1792x1024Value = "1792x1024";
         private const string _1024x1792Value = "1024x1792";
+        private const string _1536x1024Value = "1536x1024";
+        private const string _1024x1536Value = "1024x1536";
 
         public static bool operator ==(GeneratedImageSize left, GeneratedImageSize right) => left.Equals(right);
 

--- a/src/Generated/Models/InternalCreateResponsesRequestModel.cs
+++ b/src/Generated/Models/InternalCreateResponsesRequestModel.cs
@@ -11,6 +11,8 @@ namespace OpenAI.Responses
     internal readonly partial struct InternalCreateResponsesRequestModel : IEquatable<InternalCreateResponsesRequestModel>
     {
         private readonly string _value;
+        private const string O4MiniValue = "o4-mini";
+        private const string O3Value = "o3";
         private const string O3MiniValue = "o3-mini";
         private const string O3Mini20250131Value = "o3-mini-2025-01-31";
         private const string O1Value = "o1";

--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -11,7 +11,10 @@
     <VersionPrefix>2.2.0</VersionPrefix>
     <VersionSuffix>beta.4</VersionSuffix>
 
-    <TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
+		<!-- Disable central package management -->
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+
+		<TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
     <!-- Generate an XML documentation file for the project. -->


### PR DESCRIPTION
Adds Supported Resolutions of 1024x1536 and 1536x1024 
Adds Supported Qualities of High, Medium and Low. 

**Breaking Change**
High has been renamed to Hd reflecting the name of it's value.

Note: Addition of Quality has been added specifically _src/Generated/Models/GeneratedImageSize.cs_