### PR TITLE
Updating issue templates and configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_question.yaml
+++ b/.github/ISSUE_TEMPLATE/01_question.yaml
@@ -1,0 +1,16 @@
+name: Question
+description: Ask a question about this library or its usage
+title: "[QUESTION]"
+labels: ['needs-triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to ask your question!
+  - type: textarea
+    id: background
+    attributes:
+      label: How can we help?
+      description: A clear and concise description of the question that you would like answered.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report.yaml
@@ -1,21 +1,12 @@
 name: Bug report
 description: Report an issue or bug with this library
-labels: ['bug']
+title: "[BUG]"
+labels: ['needs-triage']
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
-  - type: dropdown
-    id: service-kind
-    attributes:
-      label: Service
-      description: Select whether you are using OpenAI or Azure OpenAI
-      options:
-        - OpenAI
-        - Azure OpenAI
-    validations:
-      required: true
   - type: textarea
     id: what-happened
     attributes:
@@ -47,7 +38,7 @@ body:
     id: os
     attributes:
       label: OS
-      placeholder: winOS
+      placeholder: Windows, macOS, Linux, etc.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/03_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/03_feature_request.yaml
@@ -1,19 +1,12 @@
 name: Feature request
 description: Suggest an idea for this library
-labels: ['feature-request']
+title: "[FEATURE REQ]"
+labels: ['needs-triage']
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time to fill out this feature request!
-  - type: checkboxes
-    id: non_api
-    attributes:
-      label: Confirm this is a feature request for the .NET library and not the underlying OpenAI API
-      description: Feature requests for the underlying OpenAI API should be reported on our [Developer Community](https://community.openai.com/c/api/7)
-      options:
-        - label: This is a feature request for the .NET library
-          required: true
   - type: textarea
     id: feature
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: OpenAI support
     url: https://help.openai.com/


### PR DESCRIPTION
# Summary

Updating the issue templates to:

  - Only add the `needs-triage` label to all submissions
  - Add a format slug to the title
  - Add a "question" type issue
  - Enable blank issues