### PR TITLE
[Wofkflow] Add "needs-triage" to new issues

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,0 +1,64 @@
+---
+name: Add needs-triage label
+
+'on':
+  issues:
+    types: [opened]
+
+jobs:
+  add-needs-triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      repository-projects: read
+    steps:
+      - name: Check if issue already has labels
+        id: check-labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const hasLabels = issue.labels && issue.labels.length > 0;
+            core.setOutput('has-labels', hasLabels);
+            return hasLabels;
+
+      - name: Check if author has write permissions
+        id: check-permissions
+        if: steps.check-labels.outputs.has-labels == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const author = issue.user.login;
+
+            try {
+              const { data: permission } = await github.rest.repos
+                .getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: author
+                });
+
+              const hasWriteAccess = ['write', 'admin', 'maintain']
+                .includes(permission.permission);
+              core.setOutput('has-write-access', hasWriteAccess);
+              return hasWriteAccess;
+            } catch (error) {
+              // If user is not a collaborator, they don't have write access
+              core.setOutput('has-write-access', false);
+              return false;
+            }
+
+      - name: Add needs-triage label
+        if: >-
+          steps.check-labels.outputs.has-labels == 'false' &&
+          steps.check-permissions.outputs.has-write-access == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['needs-triage']
+            });


### PR DESCRIPTION
# Summary

The focus of these changes is to introduce a new GitHub Actions workflow that automatically labels new issues with `needs-triage`.  New issues are not labeled if:

  - The issue is created by someone with write permissions
  - The issue is created with a set of labels