### PR TITLE
Add ASP.NET Core example and update README

### DIFF
--- a/examples/ASP.NET Core/ASP.NET Core.sln
+++ b/examples/ASP.NET Core/ASP.NET Core.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "client-di", "client-di.csproj", "{F3F2E48A-807D-4AC2-064F-2417457154CA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F3F2E48A-807D-4AC2-064F-2417457154CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3F2E48A-807D-4AC2-064F-2417457154CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3F2E48A-807D-4AC2-064F-2417457154CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3F2E48A-807D-4AC2-064F-2417457154CA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {33398145-928F-4A73-A7AE-4B3ED3CE96C2}
+	EndGlobalSection
+EndGlobal

--- a/examples/ASP.NET Core/Program.cs
+++ b/examples/ASP.NET Core/Program.cs
@@ -1,0 +1,41 @@
+using System.ClientModel;
+using OpenAI.Chat;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddSingleton<ChatClient>(serviceProvider => new ChatClient(builder.Configuration["OpenAI:Model"],
+    new ApiKeyCredential(builder.Configuration["OpenAI:ApiKey"]
+        ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY")
+        ?? throw new InvalidOperationException("OpenAI API key not found")))
+);
+
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+// Chat completion endpoint using injected ChatClient client
+app.MapPost("/chat/complete", async (ChatRequest request, ChatClient client) =>
+{
+    var completion = await client.CompleteChatAsync(request.Message);
+
+    return new ChatResponse(completion.Value.Content[0].Text);
+});
+
+app.Run();
+
+record ChatRequest(string Message);
+record ChatResponse(string Response);
+record EmbeddingRequest(string Text);
+record EmbeddingResponse(float[] Vector);

--- a/examples/ASP.NET Core/README.md
+++ b/examples/ASP.NET Core/README.md
@@ -1,0 +1,118 @@
+# OpenAI ASP.NET Core Example
+
+This example demonstrates how to use the OpenAI .NET client library with ASP.NET Core's dependency injection container, registering a ChatClient as a singleton for optimal performance and resource usage.
+
+## Features
+
+- **Singleton Registration**: ChatClient registered as singleton in DI container
+- **Thread-Safe**: Demonstrates concurrent usage for chat completion endpoints
+- **Configurable Model**: Model selection via configuration (appsettings.json)
+- **Modern ASP.NET Core**: Uses minimal APIs with async/await patterns
+
+## Prerequisites
+
+- .NET 8.0 or later
+- OpenAI API key
+
+## Setup
+
+1. **Set your OpenAI API key** using one of these methods:
+
+   **Environment Variable (Recommended):**
+
+   ```bash
+   export OPENAI_API_KEY="your-api-key-here"
+   ```
+
+   **Configuration (appsettings.json):**
+
+   ```json
+   {
+     "OpenAI": {
+       "Model": "gpt-4o-mini",
+       "ApiKey": "your-api-key-here"
+     }
+   }
+   ```
+
+2. **Install dependencies:**
+
+   ```bash
+   dotnet restore
+   ```
+
+3. **Run the application:**
+
+   ```bash
+   dotnet run
+   ```
+
+## API Endpoints
+
+### Chat Completion
+
+- **POST** `/chat/complete`
+- **Request Body:**
+
+  ```json
+  {
+    "message": "Hello, how are you?"
+  }
+  ```
+
+- **Response:**
+
+  ```json
+  {
+    "response": "I'm doing well, thank you for asking! How can I help you today?"
+  }
+  ```
+
+## Testing with cURL
+
+**Chat Completion:**
+
+```bash
+curl -X POST "https://localhost:7071/chat/complete" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What is the capital of France?"}'
+```
+
+## Key Implementation Details
+
+### Singleton Registration
+
+```csharp
+builder.Services.AddSingleton<ChatClient>(serviceProvider => new ChatClient(
+    builder.Configuration["OpenAI:Model"],
+    new ApiKeyCredential(builder.Configuration["OpenAI:ApiKey"] 
+        ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY")
+        ?? throw new InvalidOperationException("OpenAI API key not found")))
+);
+```
+
+### Dependency Injection Usage
+
+```csharp
+app.MapPost("/chat/complete", async (ChatRequest request, ChatClient client) =>
+{
+    var completion = await client.CompleteChatAsync(request.Message);
+    
+    return new ChatResponse(completion.Value.Content[0].Text);
+});
+```
+
+## Why Singleton?
+
+- **Thread-Safe**: ChatClient is thread-safe and can handle concurrent requests
+- **Resource Efficient**: Reuses HTTP connections and avoids creating multiple instances
+- **Performance**: Reduces object allocation overhead
+- **Stateless**: Clients don't maintain per-request state
+
+## Swagger UI
+
+When running in development mode, you can access the Swagger UI at:
+
+- `https://localhost:7071/swagger`
+
+This provides an interactive interface to test the API endpoints.

--- a/examples/ASP.NET Core/appsettings.Development.json
+++ b/examples/ASP.NET Core/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/examples/ASP.NET Core/appsettings.json
+++ b/examples/ASP.NET Core/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "OpenAI":
+  {
+    "Model": "gpt-4.1-mini",
+    "ApiKey": "YOUR_API_KEY"
+  }
+}

--- a/examples/ASP.NET Core/client-di.csproj
+++ b/examples/ASP.NET Core/client-di.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>ASP.NET_Core</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenAI" Version="2.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Hi team,

This PR adds a concrete example showing how to properly register and use the OpenAIClient with dependency injection in an ASP.NET Core application. It also includes a short highlighted section in the main README.md under the heading "How to use dependency injection".

PR for issue #498