### PR TITLE
[FEATURE] Add prompt parameter support for stored prompts in Responses API

### DIFF
--- a/examples/Responses/Example03_StoredPrompts.cs
+++ b/examples/Responses/Example03_StoredPrompts.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using OpenAI.Responses;
+using System;
+
+namespace OpenAI.Examples;
+
+public partial class ResponseExamples
+{
+    [Test]
+    public void Example03_StoredPrompts()
+    {
+        OpenAIResponseClient client = new(model: "gpt-4o", apiKey: Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+
+        // Create options using a stored prompt
+        ResponseCreationOptions options = new()
+        {
+            Prompt = new ResponsePrompt
+            {
+                Id = "your-stored-prompt-id",
+                Version = "v1.0"
+            }
+        };
+
+        // Add variables to substitute in the prompt template
+        options.Prompt.Variables["location"] = "San Francisco";
+        options.Prompt.Variables["unit"] = "celsius";
+
+        OpenAIResponse response = client.CreateResponse([], options);
+
+        Console.WriteLine($"[ASSISTANT]: {response.GetOutputText()}");
+    }
+}

--- a/examples/Responses/Example03_StoredPromptsAsync.cs
+++ b/examples/Responses/Example03_StoredPromptsAsync.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using OpenAI.Responses;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenAI.Examples;
+
+public partial class ResponseExamples
+{
+    [Test]
+    public async Task Example03_StoredPromptsAsync()
+    {
+        OpenAIResponseClient client = new(model: "gpt-4o", apiKey: Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+
+        // Create options using a stored prompt
+        ResponseCreationOptions options = new()
+        {
+            Prompt = new ResponsePrompt
+            {
+                Id = "your-stored-prompt-id",
+                Version = "v1.0"
+            }
+        };
+
+        // Add variables to substitute in the prompt template
+        options.Prompt.Variables["location"] = "San Francisco";
+        options.Prompt.Variables["unit"] = "celsius";
+
+        OpenAIResponse response = await client.CreateResponseAsync([], options);
+
+        Console.WriteLine($"[ASSISTANT]: {response.GetOutputText()}");
+    }
+}

--- a/src/Custom/Responses/ResponseCreationOptions.cs
+++ b/src/Custom/Responses/ResponseCreationOptions.cs
@@ -29,6 +29,10 @@ public partial class ResponseCreationOptions
     // CUSTOM: Made internal. This value comes from a parameter on the client method.
     internal bool? Stream { get; set; }
 
+    // CUSTOM: Added prompt parameter support for stored prompts.
+    [CodeGenMember("Prompt")]
+    public ResponsePrompt Prompt { get; set; }
+
     // CUSTOM: Added public default constructor now that there are no required properties.
     public ResponseCreationOptions()
     {

--- a/src/Custom/Responses/ResponsePrompt.Serialization.cs
+++ b/src/Custom/Responses/ResponsePrompt.Serialization.cs
@@ -1,0 +1,99 @@
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Responses;
+
+public partial class ResponsePrompt : IJsonModel<ResponsePrompt>
+{
+    void IJsonModel<ResponsePrompt>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, SerializeResponsePrompt, writer, options);
+
+    ResponsePrompt IJsonModel<ResponsePrompt>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.DeserializeNewInstance(this, DeserializeResponsePrompt, ref reader, options);
+
+    BinaryData IPersistableModel<ResponsePrompt>.Write(ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.SerializeInstance(this, options);
+
+    ResponsePrompt IPersistableModel<ResponsePrompt>.Create(BinaryData data, ModelReaderWriterOptions options)
+        => CustomSerializationHelpers.DeserializeNewInstance(this, DeserializeResponsePrompt, data, options);
+
+    string IPersistableModel<ResponsePrompt>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+
+    internal static void SerializeResponsePrompt(ResponsePrompt instance, Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        writer.WriteStartObject();
+        
+        if (instance.Id != null)
+        {
+            writer.WritePropertyName("id");
+            writer.WriteStringValue(instance.Id);
+        }
+        
+        if (instance.Version != null)
+        {
+            writer.WritePropertyName("version");
+            writer.WriteStringValue(instance.Version);
+        }
+        
+        if (instance.Variables != null && instance.Variables.Count > 0)
+        {
+            writer.WritePropertyName("variables");
+            writer.WriteStartObject();
+            foreach (var variable in instance.Variables)
+            {
+                writer.WritePropertyName(variable.Key);
+                JsonSerializer.Serialize(writer, variable.Value, options.Format == "W" ? null : (JsonSerializerOptions)null);
+            }
+            writer.WriteEndObject();
+        }
+        
+        writer.WriteEndObject();
+    }
+
+    internal static ResponsePrompt DeserializeResponsePrompt(JsonElement element, ModelReaderWriterOptions options = null)
+    {
+        if (element.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        string id = null;
+        string version = null;
+        Dictionary<string, object> variables = new Dictionary<string, object>();
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (property.NameEquals("id"))
+            {
+                id = property.Value.GetString();
+            }
+            else if (property.NameEquals("version"))
+            {
+                version = property.Value.GetString();
+            }
+            else if (property.NameEquals("variables"))
+            {
+                foreach (var variable in property.Value.EnumerateObject())
+                {
+                    variables[variable.Name] = JsonSerializer.Deserialize<object>(variable.Value.GetRawText());
+                }
+            }
+        }
+
+        var result = new ResponsePrompt();
+        result.Id = id;
+        result.Version = version;
+        
+        if (variables.Count > 0)
+        {
+            foreach (var variable in variables)
+            {
+                result.Variables[variable.Key] = variable.Value;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Custom/Responses/ResponsePrompt.cs
+++ b/src/Custom/Responses/ResponsePrompt.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace OpenAI.Responses;
+
+[CodeGenType("ResponsesPrompt")]
+public partial class ResponsePrompt
+{
+    [CodeGenMember("Id")]
+    public string Id { get; set; }
+
+    [CodeGenMember("Version")]
+    public string Version { get; set; }
+
+    [CodeGenMember("Variables")]
+    public IDictionary<string, object> Variables { get; }
+
+    public ResponsePrompt()
+    {
+        Variables = new Dictionary<string, object>();
+    }
+}

--- a/tests/Responses/ResponsesTests.cs
+++ b/tests/Responses/ResponsesTests.cs
@@ -791,6 +791,57 @@ public partial class ResponsesTests : SyncAsyncTestBase
                 """),
             false);
 
+    [Test]
+    public void ResponsePromptSerializationWorks()
+    {
+        ResponsePrompt prompt = new ResponsePrompt
+        {
+            Id = "test-prompt-id",
+            Version = "v1.0"
+        };
+        prompt.Variables["location"] = "San Francisco";
+        prompt.Variables["unit"] = "celsius";
+
+        string json = BinaryData.FromObjectAsJson(prompt).ToString();
+        JsonDocument document = JsonDocument.Parse(json);
+        
+        Assert.IsTrue(document.RootElement.TryGetProperty("id", out JsonElement idElement));
+        Assert.AreEqual("test-prompt-id", idElement.GetString());
+        
+        Assert.IsTrue(document.RootElement.TryGetProperty("version", out JsonElement versionElement));
+        Assert.AreEqual("v1.0", versionElement.GetString());
+        
+        Assert.IsTrue(document.RootElement.TryGetProperty("variables", out JsonElement variablesElement));
+        Assert.IsTrue(variablesElement.TryGetProperty("location", out JsonElement locationElement));
+        Assert.AreEqual("San Francisco", locationElement.GetString());
+        
+        Assert.IsTrue(variablesElement.TryGetProperty("unit", out JsonElement unitElement));
+        Assert.AreEqual("celsius", unitElement.GetString());
+    }
+
+    [Test]
+    public void ResponsePromptDeserializationWorks()
+    {
+        string json = """
+        {
+            "id": "test-prompt-id",
+            "version": "v1.0",
+            "variables": {
+                "location": "San Francisco",
+                "unit": "celsius"
+            }
+        }
+        """;
+
+        ResponsePrompt prompt = BinaryData.FromString(json).ToObjectFromJson<ResponsePrompt>();
+        
+        Assert.AreEqual("test-prompt-id", prompt.Id);
+        Assert.AreEqual("v1.0", prompt.Version);
+        Assert.AreEqual(2, prompt.Variables.Count);
+        Assert.AreEqual("San Francisco", prompt.Variables["location"].ToString());
+        Assert.AreEqual("celsius", prompt.Variables["unit"].ToString());
+    }
+
     private static OpenAIResponseClient GetTestClient(string overrideModel = null)
         => GetTestClient<OpenAIResponseClient>(TestScenario.Responses, overrideModel);
 }


### PR DESCRIPTION
## Description

Adds support for the `prompt` parameter in the Responses API, enabling the use of stored prompts with variable substitution, as requested in issue #500.

## Changes

### New Classes
- **`ResponsePrompt`** - Represents a stored prompt with ID, version, and variables
- **`ResponsePrompt.Serialization`** - JSON serialization support following existing patterns

### Modified Classes
- **`ResponseCreationOptions`** - Added `Prompt` property to support stored prompts

### Tests
- Added unit tests for `ResponsePrompt` serialization and deserialization
- Tests verify proper JSON structure and data integrity

### Examples
- **`Example03_StoredPrompts.cs`** - Shows how to use stored prompts (sync)
- **`Example03_StoredPromptsAsync.cs`** - Shows how to use stored prompts (async)

## Usage

```csharp
ResponseCreationOptions options = new()
{
    Prompt = new ResponsePrompt
    {
        Id = "your-stored-prompt-id",
        Version = "v1.0"
    }
};

// Add variables for template substitution
options.Prompt.Variables["location"] = "San Francisco";
options.Prompt.Variables["unit"] = "celsius";

OpenAIResponse response = client.CreateResponse([], options);
```

## API Compatibility

This implementation matches the JavaScript SDK's prompt parameter functionality:

```javascript
const response = await client.responses.create({
    model: "gpt-4.1",
    prompt: {
        id: "pmpt_abc123",
        version: "2",
        variables: {
            customer_name: "Jane Doe",
            product: "40oz juice box"
        }
    }
});
```

## Implementation Details

- Follows existing codebase patterns (no XML documentation, CUSTOM comments)
- Uses `CodeGenMember` attributes for proper API mapping
- Implements `IJsonModel<T>` for serialization
- Uses `CustomSerializationHelpers` following established patterns
- Variables stored as `IDictionary<string, object>` for flexibility

Closes #500