### PR TITLE
Throw exception when streaming is used with unsupported whisper-1 model

### DIFF
--- a/src/Custom/Audio/AudioClient.cs
+++ b/src/Custom/Audio/AudioClient.cs
@@ -229,10 +229,7 @@ public partial class AudioClient
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNullOrEmpty(audioFilename, nameof(audioFilename));
 
-        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
-        }
+        EnsureModelSupportsStreaming();
 
         MultiPartFormDataBinaryContent content
             = CreatePerCallTranscriptionOptions(options, stream: true)
@@ -250,10 +247,7 @@ public partial class AudioClient
     {
         Argument.AssertNotNullOrEmpty(audioFilePath, nameof(audioFilePath));
 
-        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
-        }
+        EnsureModelSupportsStreaming();
 
         FileStream inputStream = File.OpenRead(audioFilePath);
 
@@ -276,10 +270,7 @@ public partial class AudioClient
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNullOrEmpty(audioFilename, nameof(audioFilename));
 
-        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
-        }
+        EnsureModelSupportsStreaming();
 
         MultiPartFormDataBinaryContent content
             = CreatePerCallTranscriptionOptions(options, stream: true)
@@ -297,10 +288,7 @@ public partial class AudioClient
     {
         Argument.AssertNotNullOrEmpty(audioFilePath, nameof(audioFilePath));
 
-        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
-        }
+        EnsureModelSupportsStreaming();
 
         FileStream inputStream = File.OpenRead(audioFilePath);
 
@@ -314,6 +302,20 @@ public partial class AudioClient
             cancellationToken);
         result.AdditionalDisposalActions.Add(() => inputStream?.Dispose());
         return result;
+    }
+
+    private void EnsureModelSupportsStreaming()
+    {
+        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
+        {
+            string isEnabled = Environment.GetEnvironmentVariable("OPENAI_ENABLE_WHISPER_1_STREAMING");
+            if (!string.Equals(isEnabled, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new NotSupportedException(
+                    "The selected model 'whisper-1' does not support streaming transcription. " +
+                    "Please use a compatible model or set the environment variable 'OPENAI_ENABLE_WHISPER_1_STREAMING=true' to bypass this check.");
+            }
+        }
     }
 
     #endregion

--- a/src/Custom/Audio/AudioClient.cs
+++ b/src/Custom/Audio/AudioClient.cs
@@ -229,6 +229,11 @@ public partial class AudioClient
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNullOrEmpty(audioFilename, nameof(audioFilename));
 
+        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
+        }
+
         MultiPartFormDataBinaryContent content
             = CreatePerCallTranscriptionOptions(options, stream: true)
                 .ToMultipartContent(audio, audioFilename);
@@ -244,6 +249,11 @@ public partial class AudioClient
     public virtual AsyncCollectionResult<StreamingAudioTranscriptionUpdate> TranscribeAudioStreamingAsync(string audioFilePath, AudioTranscriptionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(audioFilePath, nameof(audioFilePath));
+
+        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
+        }
 
         FileStream inputStream = File.OpenRead(audioFilePath);
 
@@ -266,6 +276,11 @@ public partial class AudioClient
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNullOrEmpty(audioFilename, nameof(audioFilename));
 
+        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
+        }
+
         MultiPartFormDataBinaryContent content
             = CreatePerCallTranscriptionOptions(options, stream: true)
                 .ToMultipartContent(audio, audioFilename);
@@ -281,6 +296,11 @@ public partial class AudioClient
     public virtual CollectionResult<StreamingAudioTranscriptionUpdate> TranscribeAudioStreaming(string audioFilePath, AudioTranscriptionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(audioFilePath, nameof(audioFilePath));
+
+        if (string.Equals(_model, "whisper-1", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"The selected model {_model} does not support streaming transcription. Please use a compatible model.");
+        }
 
         FileStream inputStream = File.OpenRead(audioFilePath);
 

--- a/tests/Audio/TranscriptionTests.cs
+++ b/tests/Audio/TranscriptionTests.cs
@@ -322,4 +322,30 @@ public partial class TranscriptionTests : SyncAsyncTestBase
 
         inputStream?.Dispose();
     }
+
+    [Test]
+    [TestCase(AudioSourceKind.UsingStream)]
+    [TestCase(AudioSourceKind.UsingFilePath)]
+    public void StreamingTranscriptionThrowsForWhisperModel(AudioSourceKind audioSourceKind)
+    {
+        AudioClient client = GetTestClient<AudioClient>(TestScenario.Audio_Whisper);
+        string filename = "audio_hello_world.mp3";
+        string path = Path.Combine("Assets", filename);
+
+        if (audioSourceKind == AudioSourceKind.UsingStream)
+        {
+            using FileStream inputStream = File.OpenRead(path);
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                _ = client.TranscribeAudioStreamingAsync(inputStream, filename);
+            });
+        }
+        else if (audioSourceKind == AudioSourceKind.UsingFilePath)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                _ = client.TranscribeAudioStreamingAsync(path);
+            });
+        }
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/openai/openai-dotnet/issues/513

This PR adds a check to all `TranscribeAudioStreaming` methods to prevent usage with the `whisper-1` model, which does not support streaming.

According to [OpenAI's documentation](https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-stream), the `stream` parameter is ignored when `whisper-1` is used, resulting in confusing behavior for users expecting streaming updates.
