### PR TITLE
Fix casing of MessageImageDetail in MessageContent factory methods

### DIFF
--- a/src/Custom/Assistants/MessageContent.cs
+++ b/src/Custom/Assistants/MessageContent.cs
@@ -19,7 +19,7 @@ public partial class MessageContent
             => new InternalMessageContentImageFileObject(
                 imageFile: new(
                     fileId: imageFileId,
-                    detail: detail?.ToString(),
+                    detail: detail?.ToString().ToLowerInvariant(),
                     additionalBinaryDataProperties: null));
 
     /// <summary>
@@ -33,7 +33,7 @@ public partial class MessageContent
         => new InternalMessageContentImageUrlObject(
             imageUrl: new(
                 url: imageUri,
-                detail: detail?.ToString(),
+                detail: detail?.ToString().ToLowerInvariant(),
                 additionalBinaryDataProperties: null));
 
     /// <summary>

--- a/src/Custom/Assistants/MessageContent.cs
+++ b/src/Custom/Assistants/MessageContent.cs
@@ -19,7 +19,7 @@ public partial class MessageContent
             => new InternalMessageContentImageFileObject(
                 imageFile: new(
                     fileId: imageFileId,
-                    detail: detail?.ToString().ToLowerInvariant(),
+                    detail: detail?.ToSerialString(),
                     additionalBinaryDataProperties: null));
 
     /// <summary>
@@ -33,7 +33,7 @@ public partial class MessageContent
         => new InternalMessageContentImageUrlObject(
             imageUrl: new(
                 url: imageUri,
-                detail: detail?.ToString().ToLowerInvariant(),
+                detail: detail?.ToSerialString(),
                 additionalBinaryDataProperties: null));
 
     /// <summary>


### PR DESCRIPTION
Lowercased `MessageImageDetail` enum values in all `MessageContent` factory methods to match API requirements and fix a 400 error. Also, added a test to verify.

Fixes: https://github.com/openai/openai-dotnet/issues/542
