### PR TITLE
Add ExtraBody property to ChatCompletionOptions

### DIFF
--- a/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/src/Custom/Chat/ChatCompletionOptions.cs
@@ -151,6 +151,25 @@ public partial class ChatCompletionOptions
     [CodeGenMember("Store")]
     public bool? StoredOutputEnabled { get; set; }
 
+    /// <summary>
+    /// Additional properties to send with the request body. This can be used to add custom fields.
+    /// Values can be any JSON-serializable type (string, number, boolean, object, array).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new ChatCompletionOptions();
+    /// options.ExtraBody["custom_parameter"] = BinaryData.FromString("\"custom_value\"");
+    /// options.ExtraBody["experimental_feature"] = BinaryData.FromObjectAsJson(new { enabled = true, threshold = 0.8 });
+    /// options.ExtraBody["numeric_param"] = BinaryData.FromObjectAsJson(42);
+    /// options.ExtraBody["boolean_param"] = BinaryData.FromObjectAsJson(true);
+    /// </code>
+    /// </example>
+    public IDictionary<string, BinaryData> ExtraBody
+    {
+        get => SerializedAdditionalRawData ??= new Dictionary<string, BinaryData>();
+        set => SerializedAdditionalRawData = value;
+    }
+
     // CUSTOM:
     // - Added Experimental attribute.
     // - Renamed.


### PR DESCRIPTION
# Add ExtraBody property to ChatCompletionOptions

## Summary
This PR adds support for the `ExtraBody` property to `ChatCompletionOptions`, bringing .NET SDK feature parity with the Python SDK's `extra_body` parameter. This allows developers to include additional custom fields in chat completion requests that are not covered by the predefined parameters.

## Changes
- **Added `ExtraBody` property** to `ChatCompletionOptions` class
  - Type: `IDictionary<string, BinaryData>` 
  - Supports any JSON-serializable type (string, number, boolean, object, array)
  - Maps to the existing `SerializedAdditionalRawData` infrastructure
  - Includes comprehensive XML documentation with usage examples

## Usage Example
```csharp
var options = new ChatCompletionOptions();

// Add custom string parameter
options.ExtraBody["custom_parameter"] = BinaryData.FromString("\"custom_value\"");

// Add experimental feature with complex object
options.ExtraBody["experimental_feature"] = BinaryData.FromObjectAsJson(new 
{ 
    enabled = true, 
    threshold = 0.8 
});

// Add numeric and boolean parameters
options.ExtraBody["numeric_param"] = BinaryData.FromObjectAsJson(42);
options.ExtraBody["boolean_param"] = BinaryData.FromObjectAsJson(true);
```

## Implementation Details
- The property getter automatically initializes `SerializedAdditionalRawData` if it's null, ensuring a seamless developer experience
- Leverages the existing serialization infrastructure, so no additional serialization logic is required
- Follows the established patterns used elsewhere in the codebase for handling additional raw data
- Property uses lazy initialization pattern for better performance when not used

## Breaking Changes
None. This is a purely additive change that maintains backward compatibility.

## Related Issues
- #132
- #496

## File Changes
- `src/Custom/Chat/ChatCompletionOptions.cs` - Added ExtraBody property with comprehensive documentation
