### PR TITLE
improve performance of BinaryData construction

### DIFF
--- a/examples/Chat/Example08_ChatSerialization.cs
+++ b/examples/Chat/Example08_ChatSerialization.cs
@@ -39,7 +39,7 @@ public partial class ChatExamples
         writer.WriteEndArray();
         writer.Flush();
 
-        return BinaryData.FromBytes(stream.ToArray());
+        return BinaryData.FromBytes(stream.GetBuffer().AsMemory(0, (int)stream.Length));
     }
     #endregion
 

--- a/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/src/Custom/Embeddings/EmbeddingClient.cs
@@ -217,7 +217,7 @@ public partial class EmbeddingClient
         writer.WriteStringValue(input);
         writer.Flush();
 
-        options.Input = BinaryData.FromBytes(stream.ToArray());
+        options.Input = BinaryData.FromBytes(stream.GetBuffer().AsMemory(0, (int)stream.Length));
         options.Model = _model;
         options.EncodingFormat = InternalCreateEmbeddingRequestEncodingFormat.Base64;
     }
@@ -237,7 +237,7 @@ public partial class EmbeddingClient
         writer.WriteEndArray();
         writer.Flush();
 
-        options.Input = BinaryData.FromBytes(stream.ToArray());
+        options.Input = BinaryData.FromBytes(stream.GetBuffer().AsMemory(0, (int)stream.Length));
         options.Model = _model;
         options.EncodingFormat = InternalCreateEmbeddingRequestEncodingFormat.Base64;
     }
@@ -264,7 +264,7 @@ public partial class EmbeddingClient
         writer.WriteEndArray();
         writer.Flush();
 
-        options.Input = BinaryData.FromBytes(stream.ToArray());
+        options.Input = BinaryData.FromBytes(stream.GetBuffer().AsMemory(0, (int)stream.Length));
         options.Model = _model;
         options.EncodingFormat = InternalCreateEmbeddingRequestEncodingFormat.Base64;
     }

--- a/src/Custom/Moderations/ModerationClient.cs
+++ b/src/Custom/Moderations/ModerationClient.cs
@@ -170,7 +170,7 @@ public partial class ModerationClient
         writer.WriteStringValue(input);
         writer.Flush();
 
-        options.Input = BinaryData.FromBytes(stream.ToArray());
+        options.Input = BinaryData.FromBytes(stream.GetBuffer().AsMemory(0, (int)stream.Length));
         options.Model = _model;
     }
 
@@ -189,7 +189,7 @@ public partial class ModerationClient
         writer.WriteEndArray();
         writer.Flush();
 
-        options.Input = BinaryData.FromBytes(stream.ToArray());
+        options.Input = BinaryData.FromBytes(stream.GetBuffer().AsMemory(0, (int)stream.Length));
         options.Model = _model;
     }
 }


### PR DESCRIPTION
Avoids using `stream.ToArray()` in favor of ReadOnlyMemory.

| Method  | Mean     | Error     | StdDev    | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|-------- |---------:|----------:|----------:|------:|-------:|-------:|----------:|------------:|
| ToArray | 4.029 us | 0.0377 us | 0.0334 us |  1.00 | 2.9984 | 0.1831 |  24.53 KB |        1.00 |
| ROM     | 3.818 us | 0.0177 us | 0.0148 us |  0.95 | 2.4033 | 0.0839 |  19.66 KB |        0.80 |