### PR TITLE
Add support for JSON array format for embedings

### DIFF
--- a/codegen/nuget.config
+++ b/codegen/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="generator" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Embedding vectors can be returned as either Base64 string or JSON array. 
Right now, we only support Base64. 
This PR adds support for JSON array. 