### PR TITLE
Fix DI example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ Register the `ChatClient` as a singleton in your `Program.cs`:
 builder.Services.AddSingleton<ChatClient>(serviceProvider =>
 {
     var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+    var model = "gpt-4o";
 
-    return new ChatClient(apiKey);
+    return new ChatClient(model, apiKey);
 });
 ```
 


### PR DESCRIPTION
There is a small error in README.md: `ChatClient` doesn't have a constructor with only one parameter, and you must always provide a model as the first param. 