### PR TITLE
[DOCS] Fix README sample for response streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,14 +519,19 @@ await foreach (StreamingResponseUpdate update
             },
         }))
 {
-    if (update is StreamingResponseItemUpdate itemUpdate
+    if (update is StreamingResponseOutputItemAddedUpdate itemUpdate
         && itemUpdate.Item is ReasoningResponseItem reasoningItem)
     {
         Console.WriteLine($"[Reasoning] ({reasoningItem.Status})");
     }
-    else if (update is StreamingResponseContentPartDeltaUpdate deltaUpdate)
+    else if (update is StreamingResponseOutputItemAddedUpdate itemDone
+        && itemDone.Item is ReasoningResponseItem reasoningDone)
     {
-        Console.Write(deltaUpdate.Text);
+        Console.WriteLine($"[Reasoning DONE] ({reasoningDone.Status})");
+    }
+    else if (update is StreamingResponseOutputTextDeltaUpdate delta)
+    {
+        Console.Write(delta.Delta);
     }
 }
 ```


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the Response streaming sample in the README, which drifted from the current API.

# References and resources

- [[QUESTION] Response API, using reasoning and streaming: StreamingResponseItemUpdate type missing (#598)](https://github.com/openai/openai-dotnet/issues/598)