### PR TITLE
Fix codegen/package.json path in update-generator workflow

### DIFF
--- a/.github/workflows/update-generator.yml
+++ b/.github/workflows/update-generator.yml
@@ -37,7 +37,7 @@ jobs:
         id: check-updates
         run: |
           # Get current version from the OpenAI package.json file
-          CURRENT_VERSION=$(node -p "require('.codegen/package.json').dependencies['@typespec/http-client-csharp']" 2>/dev/null || echo "unknown")
+          CURRENT_VERSION=$(node -p "require('./codegen/package.json').dependencies['@typespec/http-client-csharp']" 2>/dev/null || echo "unknown")
           
           echo "Current OpenAI version: $CURRENT_VERSION"
           


### PR DESCRIPTION
The incorrect path prevented the workflow from reading the current `@typespec/http-client-csharp version` and caused failures - https://github.com/openai/openai-dotnet/actions/runs/16949793494/job/48039708258