### PR TITLE
Fix .NET SDK version mismatch in update-generator workflow

### DIFF
--- a/.github/workflows/update-generator.yml
+++ b/.github/workflows/update-generator.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          # Automatically read .NET SDK version from global.json to stay in sync
+          global-json-file: global.json
           
       - name: Check for generator updates
         id: check-updates


### PR DESCRIPTION
### Problem
The `update-generator.yml` workflow was failing with .NET SDK version mismatch errors that corrupted the TypeSpec plugin's JSON-RPC communication, causing `SyntaxError: Unexpected non-whitespace character after JSON` errors.

### Root Cause
The workflow was installing .NET SDK 8.x but the repository's `global.json` requires 9.0.205

### Solution
Updated the workflow to use `global-json-file: global.json` instead of hardcoding `dotnet-version: 8.x`. This ensures the workflow automatically installs the exact .NET SDK version specified in the repository's `global.json` file.

### Changes
`.github/workflows/update-generator.yml`: Changed from hardcoded `dotnet-version: 8.x` to `global-json-file: global.json`