### PR TITLE
[Tests] Move to NUnit 4 patterns in preparation for upgrade to NUnit and unbranded test framework

### DIFF
--- a/tests/Assistants/Assistants.VectorStoresTests.cs
+++ b/tests/Assistants/Assistants.VectorStoresTests.cs
@@ -328,14 +328,14 @@ public class VectorStoresTests : SyncAsyncTestBase
             List<VectorStoreFileAssociation> itemsInPage = GetFileAssociationsFromPage(page).ToList();
             List<VectorStoreFileAssociation> itemsInRehydratedPage = GetFileAssociationsFromPage(rehydratedPage).ToList();
 
-            Assert.AreEqual(itemsInPage.Count, itemsInRehydratedPage.Count);
+            Assert.That(itemsInRehydratedPage.Count, Is.EqualTo(itemsInPage.Count));
 
             for (int i = 0; i < itemsInPage.Count; i++)
             {
-                Assert.AreEqual(itemsInPage[0].FileId, itemsInRehydratedPage[0].FileId);
-                Assert.AreEqual(itemsInPage[0].VectorStoreId, itemsInRehydratedPage[0].VectorStoreId);
-                Assert.AreEqual(itemsInPage[0].CreatedAt, itemsInRehydratedPage[0].CreatedAt);
-                Assert.AreEqual(itemsInPage[0].Size, itemsInRehydratedPage[0].Size);
+                Assert.That(itemsInRehydratedPage[0].FileId, Is.EqualTo(itemsInPage[0].FileId));
+                Assert.That(itemsInRehydratedPage[0].VectorStoreId, Is.EqualTo(itemsInPage[0].VectorStoreId));
+                Assert.That(itemsInRehydratedPage[0].CreatedAt, Is.EqualTo(itemsInPage[0].CreatedAt));
+                Assert.That(itemsInRehydratedPage[0].Size, Is.EqualTo(itemsInPage[0].Size));
             }
 
             pageCount++;
@@ -406,14 +406,14 @@ public class VectorStoresTests : SyncAsyncTestBase
             List<VectorStoreFileAssociation> itemsInPage = GetFileAssociationsFromPage(page).ToList();
             List<VectorStoreFileAssociation> itemsInRehydratedPage = GetFileAssociationsFromPage(rehydratedPage).ToList();
 
-            Assert.AreEqual(itemsInPage.Count, itemsInRehydratedPage.Count);
+            Assert.That(itemsInRehydratedPage.Count, Is.EqualTo(itemsInPage.Count));
 
             for (int i = 0; i < itemsInPage.Count; i++)
             {
-                Assert.AreEqual(itemsInPage[0].FileId, itemsInRehydratedPage[0].FileId);
-                Assert.AreEqual(itemsInPage[0].VectorStoreId, itemsInRehydratedPage[0].VectorStoreId);
-                Assert.AreEqual(itemsInPage[0].CreatedAt, itemsInRehydratedPage[0].CreatedAt);
-                Assert.AreEqual(itemsInPage[0].Size, itemsInRehydratedPage[0].Size);
+                Assert.That(itemsInRehydratedPage[0].FileId, Is.EqualTo(itemsInPage[0].FileId));
+                Assert.That(itemsInRehydratedPage[0].VectorStoreId, Is.EqualTo(itemsInPage[0].VectorStoreId));
+                Assert.That(itemsInRehydratedPage[0].CreatedAt, Is.EqualTo(itemsInPage[0].CreatedAt));
+                Assert.That(itemsInRehydratedPage[0].Size, Is.EqualTo(itemsInPage[0].Size));
             }
 
             pageCount++;
@@ -523,7 +523,7 @@ public class VectorStoresTests : SyncAsyncTestBase
 
         Assert.IsTrue(batchOperation.HasCompleted);
         Assert.IsTrue(rehydratedOperation.HasCompleted);
-        Assert.AreEqual(batchOperation.Status, rehydratedOperation.Status);
+        Assert.That(rehydratedOperation.Status, Is.EqualTo(batchOperation.Status));
     }
 
     public enum ChunkingStrategyKind { Auto, Static }

--- a/tests/Assistants/AssistantsSmokeTests.cs
+++ b/tests/Assistants/AssistantsSmokeTests.cs
@@ -79,7 +79,7 @@ public class AssistantsSmokeTests
         Assert.That((AssistantResponseFormat)null != AssistantResponseFormat.CreateTextFormat());
         Assert.That(AssistantResponseFormat.CreateTextFormat() != null);
         Assert.That(AssistantResponseFormat.CreateTextFormat(), Is.Not.EqualTo(null));
-        Assert.That(null, Is.Not.EqualTo(AssistantResponseFormat.CreateTextFormat()));
+        Assert.That(AssistantResponseFormat.CreateTextFormat(), Is.Not.Null);
 
         AssistantResponseFormat jsonSchemaFormat = AssistantResponseFormat.CreateJsonSchemaFormat(
             name: "test_schema",

--- a/tests/Assistants/AssistantsTests.cs
+++ b/tests/Assistants/AssistantsTests.cs
@@ -1760,7 +1760,7 @@ public class AssistantsTests : SyncAsyncTestBase
         // functions correctly as the convenience return type.
         await foreach (Assistant assistant in assistants)
         {
-            Assert.AreEqual(createdAssistants[count++].Id, assistant.Id);
+            Assert.That(assistant.Id, Is.EqualTo(createdAssistants[count++].Id));
 
             if (count >= createdAssistants.Count)
             {
@@ -1810,7 +1810,7 @@ public class AssistantsTests : SyncAsyncTestBase
         // functions correctly as the convenience return type.
         foreach (Assistant assistant in assistants)
         {
-            Assert.AreEqual(createdAssistants[count++].Id, assistant.Id);
+            Assert.That(assistant.Id, Is.EqualTo(createdAssistants[count++].Id));
 
             if (count >= createdAssistants.Count)
             {
@@ -1893,7 +1893,7 @@ public class AssistantsTests : SyncAsyncTestBase
                 .ToListAsync();
         }
 
-        CollectionAssert.AreEqual(runSteps, rehydratedRunSteps);
+        Assert.That(rehydratedRunSteps, Is.EqualTo(runSteps).AsCollection);
     }
 
     [Test]
@@ -1967,7 +1967,7 @@ public class AssistantsTests : SyncAsyncTestBase
                 .ToList();
         }
 
-        CollectionAssert.AreEqual(runSteps, rehydratedRunSteps);
+        Assert.That(rehydratedRunSteps, Is.EqualTo(runSteps).AsCollection);
     }
 
     [Test]

--- a/tests/Audio/TranscriptionTests.cs
+++ b/tests/Audio/TranscriptionTests.cs
@@ -180,7 +180,6 @@ public partial class TranscriptionTests : SyncAsyncTestBase
 
                 Assert.That(segment.Id, Is.EqualTo(i));
                 Assert.That(segment.EndTime, Is.GreaterThanOrEqualTo(segment.StartTime));
-                Assert.That(segment.TokenIds, Is.Not.Null);
                 Assert.That(segment.TokenIds.Length, Is.GreaterThan(0));
 
                 Assert.That(segment.AverageLogProbability, Is.LessThan(-0.001f).Or.GreaterThan(0.001f));

--- a/tests/Batch/BatchTests.cs
+++ b/tests/Batch/BatchTests.cs
@@ -233,13 +233,13 @@ public class BatchTests : SyncAsyncTestBase
         // We don't test wait for completion live because this is documented to
         // sometimes take 24 hours.
 
-        Assert.AreEqual(batchOperation.HasCompleted, rehydratedOperation.HasCompleted);
+        Assert.That(rehydratedOperation.HasCompleted, Is.EqualTo(batchOperation.HasCompleted));
 
         using JsonDocument originalOperationJson = JsonDocument.Parse(batchOperation.GetRawResponse().Content);
         using JsonDocument rehydratedOperationJson = JsonDocument.Parse(rehydratedOperation.GetRawResponse().Content);
 
-        Assert.AreEqual(originalOperationJson.RootElement.GetProperty("id").GetString(), rehydratedOperationJson.RootElement.GetProperty("id").GetString());
-        Assert.AreEqual(originalOperationJson.RootElement.GetProperty("created_at").GetInt64(), rehydratedOperationJson.RootElement.GetProperty("created_at").GetInt64());
-        Assert.AreEqual(originalOperationJson.RootElement.GetProperty("status").GetString(), rehydratedOperationJson.RootElement.GetProperty("status").GetString());
+        Assert.That(rehydratedOperationJson.RootElement.GetProperty("id").GetString(), Is.EqualTo(originalOperationJson.RootElement.GetProperty("id").GetString()));
+        Assert.That(rehydratedOperationJson.RootElement.GetProperty("created_at").GetInt64(), Is.EqualTo(originalOperationJson.RootElement.GetProperty("created_at").GetInt64()));
+        Assert.That(rehydratedOperationJson.RootElement.GetProperty("status").GetString(), Is.EqualTo(originalOperationJson.RootElement.GetProperty("status").GetString()));
     }
 }

--- a/tests/Chat/ChatStoreTests.cs
+++ b/tests/Chat/ChatStoreTests.cs
@@ -672,7 +672,7 @@ public class ChatStoreToolTests : SyncAsyncTestBase
             {
                 messageCount++;
                 Assert.That(message.Id, Is.Not.Null.And.Not.Empty);
-                Assert.AreEqual("Basic messages test: Say 'Hello, this is a test message.'", message.Content);
+                Assert.That(message.Content, Is.EqualTo("Basic messages test: Say 'Hello, this is a test message.'"));
 
                 if (messageCount >= 5) break; // Prevent infinite loop
             }

--- a/tests/Chat/ChatTests.cs
+++ b/tests/Chat/ChatTests.cs
@@ -903,15 +903,15 @@ public class ChatTests : SyncAsyncTestBase
             ? await client.CompleteChatAsync(messages)
             : client.CompleteChat(messages);
 
-        Assert.AreEqual(1, activityListener.Activities.Count);
+        Assert.That(activityListener.Activities.Count, Is.EqualTo(1));
         TestActivityListener.ValidateChatActivity(activityListener.Activities.Single(), result.Value);
 
         List<TestMeasurement> durations = meterListener.GetMeasurements("gen_ai.client.operation.duration");
-        Assert.AreEqual(1, durations.Count);
+        Assert.That(durations.Count, Is.EqualTo(1));
         ValidateChatMetricTags(durations.Single(), result.Value);
 
         List<TestMeasurement> usages = meterListener.GetMeasurements("gen_ai.client.token.usage");
-        Assert.AreEqual(2, usages.Count);
+        Assert.That(usages.Count, Is.EqualTo(2));
 
         Assert.True(usages[0].tags.TryGetValue("gen_ai.token.type", out var type));
         Assert.IsInstanceOf<string>(type);
@@ -919,8 +919,8 @@ public class ChatTests : SyncAsyncTestBase
         TestMeasurement input = (type is "input") ? usages[0] : usages[1];
         TestMeasurement output = (type is "input") ? usages[1] : usages[0];
 
-        Assert.AreEqual(result.Value.Usage.InputTokenCount, input.value);
-        Assert.AreEqual(result.Value.Usage.OutputTokenCount, output.value);
+        Assert.That(input.value, Is.EqualTo(result.Value.Usage.InputTokenCount));
+        Assert.That(output.value, Is.EqualTo(result.Value.Usage.OutputTokenCount));
     }
 
     [Test]

--- a/tests/FineTuning/FineTuningClientTests.cs
+++ b/tests/FineTuning/FineTuningClientTests.cs
@@ -78,7 +78,7 @@ public class FineTuningClientTests
             ? await ft.CancelAndUpdateAsync()
             : ft.CancelAndUpdate();
 
-        Assert.AreEqual(FineTuningStatus.Cancelled, ft.Status);
+        Assert.That(ft.Status, Is.EqualTo(FineTuningStatus.Cancelled));
         Assert.False(ft.Status.InProgress);
         Assert.True(ft.HasCompleted);
     }
@@ -110,25 +110,25 @@ public class FineTuningClientTests
         ft.CancelAndUpdate();
 
 #pragma warning disable CS0618
-        Assert.AreEqual(1, ft.Hyperparameters.EpochCount);
-        Assert.AreEqual(2, ft.Hyperparameters.BatchSize);
-        Assert.AreEqual(3, ft.Hyperparameters.LearningRateMultiplier);
+        Assert.That(ft.Hyperparameters.EpochCount, Is.EqualTo(1));
+        Assert.That(ft.Hyperparameters.BatchSize, Is.EqualTo(2));
+        Assert.That(ft.Hyperparameters.LearningRateMultiplier, Is.EqualTo(3));
 #pragma warning restore
 
         if (ft.MethodHyperparameters is HyperparametersForSupervised hp)
         {
-            Assert.AreEqual(1, hp.EpochCount);
-            Assert.AreEqual(2, hp.BatchSize);
-            Assert.AreEqual(3, hp.LearningRateMultiplier);
+            Assert.That(hp.EpochCount, Is.EqualTo(1));
+            Assert.That(hp.BatchSize, Is.EqualTo(2));
+            Assert.That(hp.LearningRateMultiplier, Is.EqualTo(3));
         }
         else
         {
             Assert.Fail($"Expected HyperparametersForSupervised, got {ft.MethodHyperparameters?.GetType().ToString() ?? "null"}");
         }
 
-        Assert.AreEqual(ft.UserProvidedSuffix, "TestFTJob");
-        Assert.AreEqual(1234567, ft.Seed);
-        Assert.AreEqual(validationFile.Id, ft.ValidationFileId);
+        Assert.That(ft.UserProvidedSuffix, Is.EqualTo("TestFTJob"));
+        Assert.That(ft.Seed, Is.EqualTo(1234567));
+        Assert.That(ft.ValidationFileId, Is.EqualTo(validationFile.Id));
     }
 
     [Test]
@@ -233,7 +233,7 @@ public class FineTuningClientTests
         }
         var secondJob = client.GetJobs(new() { AfterJobId = firstJob.JobId }).First();
 
-        Assert.AreNotEqual(firstJob.JobId, secondJob.JobId);
+        Assert.That(secondJob.JobId, Is.Not.EqualTo(firstJob.JobId));
         // Can't assert that one was created after the next because they might be created at the same second.
         // Assert.Greater(secondJob.CreatedAt, firstJob.CreatedAt, $"{firstJob}, {secondJob}");
     }

--- a/tests/FineTuning/HyperparameterOptionsTests.cs
+++ b/tests/FineTuning/HyperparameterOptionsTests.cs
@@ -13,20 +13,20 @@ class HyperparameterOptionsTests
     [Parallelizable]
     public void OptionsCanEasilyCompare()
     {
-        Assert.AreEqual(HyperparameterEpochCount.CreateAuto(), "auto");
-        Assert.AreEqual(HyperparameterBatchSize.CreateAuto(), "auto");
-        Assert.AreEqual(HyperparameterLearningRate.CreateAuto(), "auto");
-        Assert.AreEqual(HyperparameterBetaFactor.CreateAuto(), "auto");
+        Assert.That(HyperparameterEpochCount.CreateAuto(), Is.EqualTo("auto"));
+        Assert.That(HyperparameterBatchSize.CreateAuto(), Is.EqualTo("auto"));
+        Assert.That(HyperparameterLearningRate.CreateAuto(), Is.EqualTo("auto"));
+        Assert.That(HyperparameterBetaFactor.CreateAuto(), Is.EqualTo("auto"));
 
-        Assert.AreEqual(new HyperparameterEpochCount(1), 1);
-        Assert.AreEqual(new HyperparameterBatchSize(1), 1);
-        Assert.AreEqual(new HyperparameterLearningRate(1), 1);
-        Assert.AreEqual(new HyperparameterBetaFactor(1), 1);
+        Assert.That(new HyperparameterEpochCount(1), Is.EqualTo(1));
+        Assert.That(new HyperparameterBatchSize(1), Is.EqualTo(1));
+        Assert.That(new HyperparameterLearningRate(1), Is.EqualTo(1));
+        Assert.That(new HyperparameterBetaFactor(1), Is.EqualTo(1));
 
-        Assert.AreEqual(1, new HyperparameterEpochCount(1));
-        Assert.AreEqual(1, new HyperparameterBatchSize(1));
-        Assert.AreEqual(1.0, new HyperparameterLearningRate(1));
-        Assert.AreEqual(1, new HyperparameterBetaFactor(1));
+        Assert.That(new HyperparameterEpochCount(1), Is.EqualTo(1));
+        Assert.That(new HyperparameterBatchSize(1), Is.EqualTo(1));
+        Assert.That(new HyperparameterLearningRate(1), Is.EqualTo(1.0));
+        Assert.That(new HyperparameterBetaFactor(1), Is.EqualTo(1));
 
         Assert.That(1 == new HyperparameterEpochCount(1));
         Assert.That(1 == new HyperparameterBatchSize(1));

--- a/tests/Telemetry/TestActivityListener.cs
+++ b/tests/Telemetry/TestActivityListener.cs
@@ -38,28 +38,28 @@ internal class TestActivityListener : IDisposable
     public static void ValidateChatActivity(Activity activity, ChatCompletion response, string requestModel = "gpt-4o-mini", string host = "api.openai.com", int port = 443)
     {
         Assert.NotNull(activity);
-        Assert.AreEqual($"chat {requestModel}", activity.DisplayName);
-        Assert.AreEqual("chat", activity.GetTagItem("gen_ai.operation.name"));
-        Assert.AreEqual("openai", activity.GetTagItem("gen_ai.system"));
-        Assert.AreEqual(requestModel, activity.GetTagItem("gen_ai.request.model"));
+        Assert.That(activity.DisplayName, Is.EqualTo($"chat {requestModel}"));
+        Assert.That(activity.GetTagItem("gen_ai.operation.name"), Is.EqualTo("chat"));
+        Assert.That(activity.GetTagItem("gen_ai.system"), Is.EqualTo("openai"));
+        Assert.That(activity.GetTagItem("gen_ai.request.model"), Is.EqualTo(requestModel));
 
-        Assert.AreEqual(host, activity.GetTagItem("server.address"));
-        Assert.AreEqual(port, activity.GetTagItem("server.port"));
+        Assert.That(activity.GetTagItem("server.address"), Is.EqualTo(host));
+        Assert.That(activity.GetTagItem("server.port"), Is.EqualTo(port));
 
         if (response != null)
         {
-            Assert.AreEqual(response.Model, activity.GetTagItem("gen_ai.response.model"));
-            Assert.AreEqual(response.Id, activity.GetTagItem("gen_ai.response.id"));
-            Assert.AreEqual(new[] { response.FinishReason.ToString().ToLower() }, activity.GetTagItem("gen_ai.response.finish_reasons"));
-            Assert.AreEqual(response.Usage.OutputTokenCount, activity.GetTagItem("gen_ai.usage.output_tokens"));
-            Assert.AreEqual(response.Usage.InputTokenCount, activity.GetTagItem("gen_ai.usage.input_tokens"));
-            Assert.AreEqual(ActivityStatusCode.Unset, activity.Status);
+            Assert.That(activity.GetTagItem("gen_ai.response.model"), Is.EqualTo(response.Model));
+            Assert.That(activity.GetTagItem("gen_ai.response.id"), Is.EqualTo(response.Id));
+            Assert.That(activity.GetTagItem("gen_ai.response.finish_reasons"), Is.EqualTo(new[] { response.FinishReason.ToString().ToLower() }));
+            Assert.That(activity.GetTagItem("gen_ai.usage.output_tokens"), Is.EqualTo(response.Usage.OutputTokenCount));
+            Assert.That(activity.GetTagItem("gen_ai.usage.input_tokens"), Is.EqualTo(response.Usage.InputTokenCount));
+            Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Unset));
             Assert.Null(activity.StatusDescription);
             Assert.Null(activity.GetTagItem("error.type"));
         }
         else
         {
-            Assert.AreEqual(ActivityStatusCode.Error, activity.Status);
+            Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Error));
             Assert.NotNull(activity.GetTagItem("error.type"));
         }
     }
@@ -67,6 +67,6 @@ internal class TestActivityListener : IDisposable
     public static void ValidateChatActivity(Activity activity, Exception ex, string requestModel = "gpt-4o-mini", string host = "api.openai.com", int port = 443)
     {
         ValidateChatActivity(activity, (ChatCompletion)null, requestModel, host, port);
-        Assert.AreEqual(ex.GetType().FullName, activity.GetTagItem("error.type"));
+        Assert.That(activity.GetTagItem("error.type"), Is.EqualTo(ex.GetType().FullName));
     }
 }

--- a/tests/Telemetry/TestMeterListener.cs
+++ b/tests/Telemetry/TestMeterListener.cs
@@ -62,15 +62,15 @@ internal class TestMeterListener : IDisposable
 
     public static void ValidateChatMetricTags(TestMeasurement measurement, ChatCompletion response, string requestModel = "gpt-4o-mini", string host = "api.openai.com", int port = 443)
     {
-        Assert.AreEqual("openai", measurement.tags["gen_ai.system"]);
-        Assert.AreEqual("chat", measurement.tags["gen_ai.operation.name"]);
-        Assert.AreEqual(host, measurement.tags["server.address"]);
-        Assert.AreEqual(requestModel, measurement.tags["gen_ai.request.model"]);
-        Assert.AreEqual(port, measurement.tags["server.port"]);
+        Assert.That(measurement.tags["gen_ai.system"], Is.EqualTo("openai"));
+        Assert.That(measurement.tags["gen_ai.operation.name"], Is.EqualTo("chat"));
+        Assert.That(measurement.tags["server.address"], Is.EqualTo(host));
+        Assert.That(measurement.tags["gen_ai.request.model"], Is.EqualTo(requestModel));
+        Assert.That(measurement.tags["server.port"], Is.EqualTo(port));
 
         if (response != null)
         {
-            Assert.AreEqual(response.Model, measurement.tags["gen_ai.response.model"]);
+            Assert.That(measurement.tags["gen_ai.response.model"], Is.EqualTo(response.Model));
             Assert.False(measurement.tags.ContainsKey("error.type"));
         }
     }
@@ -79,6 +79,6 @@ internal class TestMeterListener : IDisposable
     {
         ValidateChatMetricTags(measurement, (ChatCompletion)null, requestModel, host, port);
         Assert.True(measurement.tags.ContainsKey("error.type"));
-        Assert.AreEqual(ex.GetType().FullName, measurement.tags["error.type"]);
+        Assert.That(measurement.tags["error.type"], Is.EqualTo(ex.GetType().FullName));
     }
 }


### PR DESCRIPTION
Upcoming SCM test framework will require NUnit 4+. This PR isn't actually upgrading the version yet but just moving to the constraint pattern from the old patterns so that the upgrade will be drop in.