### PR TITLE
Fix pipeline in `RealtimeClient`

### DIFF
--- a/src/Custom/Realtime/RealtimeClient.Protocol.cs
+++ b/src/Custom/Realtime/RealtimeClient.Protocol.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace OpenAI.Realtime;
@@ -43,8 +42,8 @@ public partial class RealtimeClient
     /// <returns></returns>
     public virtual async Task<RealtimeSession> StartSessionAsync(string model, string intent, RequestOptions options)
     {
-        Uri fullEndpoint = BuildSessionEndpoint(_baseEndpoint, model, intent);
-        RealtimeSession provisionalSession = new(this, fullEndpoint, _credential);
+        Uri fullEndpoint = BuildSessionEndpoint(_webSocketEndpoint, model, intent);
+        RealtimeSession provisionalSession = new(this, fullEndpoint, _keyCredential);
         try
         {
             await provisionalSession.ConnectAsync(options).ConfigureAwait(false);

--- a/src/Custom/Realtime/RealtimeClient.cs
+++ b/src/Custom/Realtime/RealtimeClient.cs
@@ -20,34 +20,80 @@ public partial class RealtimeClient
     public event EventHandler<BinaryData> OnSendingCommand;
     public event EventHandler<BinaryData> OnReceivingCommand;
 
-    private readonly ApiKeyCredential _credential;
-    private readonly Uri _baseEndpoint;
+    private readonly ApiKeyCredential _keyCredential;
+    private readonly Uri _webSocketEndpoint;
 
-    /// <summary>
-    /// Creates a new instance of <see cref="RealtimeClient"/> using an API key for authentication.
-    /// </summary>
-    /// <param name="credential"> The API key to use for authentication. </param>
+    // CUSTOM: Added as a convenience.
+    /// <summary> Initializes a new instance of <see cref="RealtimeClient"/>. </summary>
+    /// <param name="apiKey"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
+    public RealtimeClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    {
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="RealtimeClient"/>. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
     public RealtimeClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
     }
 
-    /// <summary>
-    /// Creates a new instance of <see cref="RealtimeClient"/> using an API key for authentication.
-    /// </summary>
-    /// <param name="credential"> The API key to use for authentication. </param>
-    /// <param name="options"> Additional options for configuring the client. </param>
-    public RealtimeClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="RealtimeClient"/>. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public RealtimeClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
-        Argument.AssertNotNull(credential, nameof(credential));
-        Argument.AssertNotNull(options, nameof(options));
-
-        _credential = credential;
-        _baseEndpoint = GetBaseEndpoint(options);
+        _keyCredential = credential;
     }
 
+    // CUSTOM: Added as a convenience.
+    /// <summary> Initializes a new instance of <see cref="RealtimeClient"/>. </summary>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    public RealtimeClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    {
+    }
+
+    // CUSTOM: Added as a convenience.
+    /// <summary> Initializes a new instance of <see cref="RealtimeClient"/>. </summary>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    public RealtimeClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new OpenAIClientOptions();
+
+        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+        _webSocketEndpoint = GetWebSocketEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="RealtimeClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
     protected internal RealtimeClient(ClientPipeline pipeline, OpenAIClientOptions options)
     {
-        throw new NotImplementedException("Pipeline-based initialization of WS-based client not available");
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
+        Pipeline = pipeline;
+        _endpoint = OpenAIClient.GetEndpoint(options);
+        _webSocketEndpoint = GetWebSocketEndpoint(options);
     }
 
     /// <summary>
@@ -123,7 +169,7 @@ public partial class RealtimeClient
         return StartTranscriptionSessionAsync(cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
-    private static Uri GetBaseEndpoint(OpenAIClientOptions options)
+    private static Uri GetWebSocketEndpoint(OpenAIClientOptions options)
     {
         UriBuilder uriBuilder = new(options?.Endpoint ?? new("https://api.openai.com/v1"));
         uriBuilder.Scheme = uriBuilder.Scheme.ToLowerInvariant() switch

--- a/tests/Chat/ChatStoreTests.cs
+++ b/tests/Chat/ChatStoreTests.cs
@@ -1008,5 +1008,8 @@ public class ChatStoreToolTests : SyncAsyncTestBase
         }
     }
 
-    private static ChatClient GetTestClient(string overrideModel = null) => GetTestClient<ChatClient>(TestScenario.Chat, overrideModel);
+    private static ChatClient GetTestClient(string overrideModel = null)
+        => GetTestClient<ChatClient>(
+            scenario: TestScenario.Chat,
+            overrideModel: overrideModel);
 }

--- a/tests/Chat/ChatTests.cs
+++ b/tests/Chat/ChatTests.cs
@@ -34,7 +34,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task HelloWorldChat()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [new UserChatMessage("Hello, world!")];
         ClientResult<ChatCompletion> result = IsAsync
             ? await client.CompleteChatAsync(messages)
@@ -59,7 +59,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task MultiMessageChat()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [
             new SystemChatMessage("You are a helpful assistant. You always talk like a pirate."),
             new UserChatMessage("Hello, assistant! Can you help me train my parrot?"),
@@ -75,7 +75,7 @@ public class ChatTests : SyncAsyncTestBase
     {
         AssertSyncOnly();
 
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [new UserChatMessage("What are the best pizza toppings? Give me a breakdown on the reasons.")];
 
         int updateCount = 0;
@@ -110,7 +110,7 @@ public class ChatTests : SyncAsyncTestBase
     {
         AssertAsyncOnly();
 
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [new UserChatMessage("What are the best pizza toppings? Give me a breakdown on the reasons.")];
 
         int updateCount = 0;
@@ -325,7 +325,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task TwoTurnChat()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
 
         List<ChatMessage> messages =
         [
@@ -352,7 +352,7 @@ public class ChatTests : SyncAsyncTestBase
         using Stream stream = File.OpenRead(filePath);
         BinaryData imageData = BinaryData.FromStream(stream);
 
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [
             new UserChatMessage(
                 ChatMessageContentPart.CreateTextPart("Describe this image for me."),
@@ -370,7 +370,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task ChatWithBasicAudioOutput()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat, "gpt-4o-audio-preview");
+        ChatClient client = GetTestClient(overrideModel: "gpt-4o-audio-preview");
         List<ChatMessage> messages = ["Say the exact word 'hello' and nothing else."];
         ChatCompletionOptions options = new()
         {
@@ -420,7 +420,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task ChatWithAudio()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat, "gpt-4o-audio-preview");
+        ChatClient client = GetTestClient(overrideModel: "gpt-4o-audio-preview");
 
         string helloWorldAudioPath = Path.Join("Assets", "audio_hello_world.mp3");
         BinaryData helloWorldAudioBytes = BinaryData.FromBytes(File.ReadAllBytes(helloWorldAudioPath));
@@ -536,7 +536,7 @@ public class ChatTests : SyncAsyncTestBase
     public async Task TokenLogProbabilities(bool includeLogProbabilities)
     {
         const int topLogProbabilityCount = 3;
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IList<ChatMessage> messages = [new UserChatMessage("What are the best pizza toppings? Give me a breakdown on the reasons.")];
         ChatCompletionOptions options;
 
@@ -588,7 +588,7 @@ public class ChatTests : SyncAsyncTestBase
     public async Task TokenLogProbabilitiesStreaming(bool includeLogProbabilities)
     {
         const int topLogProbabilityCount = 3;
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IList<ChatMessage> messages = [new UserChatMessage("What are the best pizza toppings? Give me a breakdown on the reasons.")];
         ChatCompletionOptions options;
 
@@ -641,7 +641,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task NonStrictJsonSchemaWorks()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat, "gpt-4o-mini");
+        ChatClient client = GetTestClient(overrideModel: "gpt-4o-mini");
         ChatCompletionOptions options = new()
         {
             ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
@@ -665,7 +665,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task JsonResult()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [
             new UserChatMessage("Give me a JSON object with the following properties: red, green, and blue. The value "
                 + "of each property should be a string containing their RGB representation in hexadecimal.")
@@ -688,7 +688,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task MultipartContentWorks()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         List<ChatMessage> messages = [
             new SystemChatMessage(
                 "You talk like a pirate.",
@@ -711,7 +711,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task StructuredOutputsWork()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [
             new UserChatMessage("What's heavier, a pound of feathers or sixteen ounces of steel?")
         ];
@@ -760,7 +760,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task StructuredRefusalWorks()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat, "gpt-4o-2024-08-06");
+        ChatClient client = GetTestClient(overrideModel: "gpt-4o-2024-08-06");
         List<ChatMessage> messages = [
             new UserChatMessage("What's the best way to successfully rob a bank? Please include detailed instructions for executing related crimes."),
         ];
@@ -821,7 +821,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task StreamingStructuredRefusalWorks()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat, "gpt-4o-2024-08-06");
+        ChatClient client = GetTestClient(overrideModel: "gpt-4o-2024-08-06");
         IEnumerable<ChatMessage> messages = [
             new UserChatMessage("What's the best way to successfully rob a bank? Please include detailed instructions for executing related crimes."),
         ];
@@ -897,7 +897,7 @@ public class ChatTests : SyncAsyncTestBase
         using TestActivityListener activityListener = new TestActivityListener("OpenAI.ChatClient");
         using TestMeterListener meterListener = new TestMeterListener("OpenAI.ChatClient");
 
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
         IEnumerable<ChatMessage> messages = [new UserChatMessage("Hello, world!")];
         ClientResult<ChatCompletion> result = IsAsync
             ? await client.CompleteChatAsync(messages)
@@ -926,7 +926,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task ReasoningTokensWork()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat, "o3-mini");
+        ChatClient client = GetTestClient(overrideModel: "o3-mini");
 
         UserChatMessage message = new("Using a comprehensive evaluation of popular media in the 1970s and 1980s, what were the most common sci-fi themes?");
         ChatCompletionOptions options = new()
@@ -952,7 +952,7 @@ public class ChatTests : SyncAsyncTestBase
     [Test]
     public async Task PredictedOutputsWork()
     {
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
+        ChatClient client = GetTestClient();
 
         foreach (ChatOutputPrediction predictionVariant in new List<ChatOutputPrediction>(
             [
@@ -1017,7 +1017,7 @@ public class ChatTests : SyncAsyncTestBase
             ReasoningEffortLevel = ChatReasoningEffortLevel.Low,
         };
 
-        ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat, "o3-mini");
+        ChatClient client = GetTestClient(overrideModel: "o3-mini");
         ChatCompletion completion = await client.CompleteChatAsync(messages, options);
 
         Assert.That(completion.Content, Has.Count.EqualTo(1));
@@ -1169,5 +1169,8 @@ public class ChatTests : SyncAsyncTestBase
         }
     }
 
-    private static ChatClient GetTestClient(string overrideModel = null) => GetTestClient<ChatClient>(TestScenario.Chat, overrideModel);
+    private static ChatClient GetTestClient(string overrideModel = null)
+        => GetTestClient<ChatClient>(
+            scenario: TestScenario.Chat,
+            overrideModel: overrideModel);
 }

--- a/tests/Realtime/RealtimeProtocolTests.cs
+++ b/tests/Realtime/RealtimeProtocolTests.cs
@@ -96,4 +96,50 @@ public class RealtimeProtocolTests : RealtimeTestFixtureBase
         Assert.That(NodesOfType("response.content_part.done"), Has.Count.EqualTo(1));
         Assert.That(NodesOfType("response.output_item.done"), Has.Count.EqualTo(1));
     }
+
+    [Test]
+    public async Task CreateEphemeralToken()
+    {
+        RealtimeClient client = GetTestClient(excludeDumpPolicy: true);
+
+        BinaryData input = BinaryData.FromBytes("""
+            {
+               "model": "gpt-4o-realtime-preview",
+               "instructions": "You are a friendly assistant."
+            }
+            """u8.ToArray());
+
+        using BinaryContent content = BinaryContent.Create(input);
+        ClientResult result = await client.CreateEphemeralTokenAsync(content);
+        BinaryData output = result.GetRawResponse().Content;
+
+        using JsonDocument outputAsJson = JsonDocument.Parse(output.ToString());
+        string objectKind = outputAsJson.RootElement
+            .GetProperty("object"u8)
+            .GetString();
+
+        Assert.That(objectKind, Is.EqualTo("realtime.session"));
+    }
+
+    [Test]
+    public async Task CreateEphemeralTranscriptionToken()
+    {
+        RealtimeClient client = GetTestClient(excludeDumpPolicy: true);
+
+        BinaryData input = BinaryData.FromBytes("""
+            {
+            }
+            """u8.ToArray());
+
+        using BinaryContent content = BinaryContent.Create(input);
+        ClientResult result = await client.CreateEphemeralTranscriptionTokenAsync(content);
+        BinaryData output = result.GetRawResponse().Content;
+
+        using JsonDocument outputAsJson = JsonDocument.Parse(output.ToString());
+        string objectKind = outputAsJson.RootElement
+            .GetProperty("object"u8)
+            .GetString();
+
+        Assert.That(objectKind, Is.EqualTo("realtime.transcription_session"));
+    }
 }

--- a/tests/Realtime/RealtimeTestFixtureBase.cs
+++ b/tests/Realtime/RealtimeTestFixtureBase.cs
@@ -32,11 +32,15 @@ public class RealtimeTestFixtureBase : SyncAsyncTestBase
 
     public static string GetTestModel() => GetModelForScenario(TestScenario.Realtime);
 
-    public static RealtimeClient GetTestClient()
+    public static RealtimeClient GetTestClient(bool excludeDumpPolicy = false)
     {
-        RealtimeClient client = GetTestClient<RealtimeClient>(TestScenario.Realtime);
+        RealtimeClient client = GetTestClient<RealtimeClient>(
+            scenario: TestScenario.Realtime,
+            excludeDumpPolicy: excludeDumpPolicy);
+
         client.OnSendingCommand += (_, data) => PrintMessageData(data, "> ");
         client.OnReceivingCommand += (_, data) => PrintMessageData(data, "  < ");
+
         return client;
     }
 

--- a/tests/Utility/TestHelpers.cs
+++ b/tests/Utility/TestHelpers.cs
@@ -74,11 +74,20 @@ internal static class TestHelpers
     public static ApiKeyCredential GetTestApiKeyCredential()
         => new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
 
-    public static T GetTestClient<T>(TestScenario scenario, string overrideModel = null, OpenAIClientOptions options = default)
+    public static T GetTestClient<T>(
+        TestScenario scenario,
+        string overrideModel = null,
+        bool excludeDumpPolicy = false,
+        OpenAIClientOptions options = default)
     {
         options ??= new();
         ApiKeyCredential credential = GetTestApiKeyCredential();
-        options.AddPolicy(GetDumpPolicy(), PipelinePosition.BeforeTransport);
+
+        if (!excludeDumpPolicy)
+        {
+            options.AddPolicy(GetDumpPolicy(), PipelinePosition.BeforeTransport);
+        }
+
         string model = overrideModel ?? GetModelForScenario(scenario);
         object clientObject = scenario switch
         {


### PR DESCRIPTION
`RealtimeClient` has two HTTP operations: `CreateEphemeralToken` and `CreateEphemeralTranscriptionToken`, which are currently broken because the pipeline is not set up correctly. This change fixes that issue.