### PR TITLE
build: add more pinned dep. to upgrade script

### DIFF
--- a/scripts/Submit-GeneratorUpdatePr.ps1
+++ b/scripts/Submit-GeneratorUpdatePr.ps1
@@ -214,6 +214,16 @@ try {
         Write-Warning-Log "OpenAI code generation failed: $_"
     }
     Pop-Location
+
+     # Export the API
+    Write-Log "Updating API"
+    Push-Location "."
+    try {
+        pwsh scripts/Export-Api.ps1
+    } catch {
+        Write-Warning-Log "Exporting API failed: $_"
+    }
+    Pop-Location
     
     # Check if there are changes to commit
     $gitStatus = git status --porcelain
@@ -230,6 +240,7 @@ try {
     Write-Log "Adding and committing changes"
     git add codegen/package.json
     git add codegen/generator/src/OpenAI.Library.Plugin.csproj
+    git add api
     git add package-lock.json
     git add ./ # Add any generated code changes
     

--- a/scripts/Submit-GeneratorUpdatePr.ps1
+++ b/scripts/Submit-GeneratorUpdatePr.ps1
@@ -92,7 +92,10 @@ function Get-PackageDependencies {
 }
 
 $InjectedDependencies = @(
-    '@azure-tools/typespec-client-generator-core'
+    '@azure-tools/typespec-client-generator-core',
+    '@azure-tools/typespec-azure-core',
+    '@typespec/http',
+    '@typespec/openapi'
 )
 
 Write-Log "Starting TypeSpec generator update process"


### PR DESCRIPTION
This PR adds some enhancements to the generator upgrade automation script to always attempt to match all of the pinned dependencies. This will reduce the amount of manual intervention needed in the case the generator updates its' dependencies to newer versions.

It also runs the Export-Api script as part of the generation upgrade workflow.