### PR TITLE
Make GetVectorStoreAsync public for consistency with sync method

### DIFF
--- a/api/OpenAI.net8.0.cs
+++ b/api/OpenAI.net8.0.cs
@@ -5773,6 +5773,7 @@ namespace OpenAI.VectorStores {
         public virtual AsyncCollectionResult<VectorStoreFileAssociation> GetFileAssociationsAsync(string vectorStoreId, string batchJobId, ContinuationToken firstPageToken, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult GetFileAssociationsAsync(string vectorStoreId, string batchId, int? limit, string order, string after, string before, string filter, RequestOptions options);
         public virtual ClientResult<VectorStore> GetVectorStore(string vectorStoreId, CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult<VectorStore>> GetVectorStoreAsync(string vectorStoreId, CancellationToken cancellationToken = default);
         public virtual CollectionResult<VectorStore> GetVectorStores(VectorStoreCollectionOptions options = null, CancellationToken cancellationToken = default);
         public virtual CollectionResult<VectorStore> GetVectorStores(ContinuationToken firstPageToken, CancellationToken cancellationToken = default);
         public virtual CollectionResult GetVectorStores(int? limit, string order, string after, string before, RequestOptions options);

--- a/api/OpenAI.netstandard2.0.cs
+++ b/api/OpenAI.netstandard2.0.cs
@@ -5125,6 +5125,7 @@ namespace OpenAI.VectorStores {
         public virtual AsyncCollectionResult<VectorStoreFileAssociation> GetFileAssociationsAsync(string vectorStoreId, string batchJobId, ContinuationToken firstPageToken, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult GetFileAssociationsAsync(string vectorStoreId, string batchId, int? limit, string order, string after, string before, string filter, RequestOptions options);
         public virtual ClientResult<VectorStore> GetVectorStore(string vectorStoreId, CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult<VectorStore>> GetVectorStoreAsync(string vectorStoreId, CancellationToken cancellationToken = default);
         public virtual CollectionResult<VectorStore> GetVectorStores(VectorStoreCollectionOptions options = null, CancellationToken cancellationToken = default);
         public virtual CollectionResult<VectorStore> GetVectorStores(ContinuationToken firstPageToken, CancellationToken cancellationToken = default);
         public virtual CollectionResult GetVectorStores(int? limit, string order, string after, string before, RequestOptions options);

--- a/src/Custom/VectorStores/VectorStoreClient.cs
+++ b/src/Custom/VectorStores/VectorStoreClient.cs
@@ -164,7 +164,7 @@ public partial class VectorStoreClient
     /// <param name="vectorStoreId"> The ID of the vector store to retrieve. </param>
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <returns> A representation of an existing <see cref="VectorStore"/>. </returns>
-    internal virtual async Task<ClientResult<VectorStore>> GetVectorStoreAsync(string vectorStoreId, CancellationToken cancellationToken = default)
+    public virtual async Task<ClientResult<VectorStore>> GetVectorStoreAsync(string vectorStoreId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(vectorStoreId, nameof(vectorStoreId));
 


### PR DESCRIPTION
The `GetVectorStoreAsync` method is currently marked as `internal`, while the sync variant `GetVectorStore` is exposed as `public`. This creates an inconsistency and prevents developers from using the async API to retrieve an existing `VectorStore` by ID. This PR updates `GetVectorStoreAsync` to be `public` for parity with the synchronous `GetVectorStore` method.

Issue - https://github.com/openai/openai-dotnet/issues/240