### PR TITLE
Expose more properties from ChatCompletionOptions

### DIFF
--- a/src/Custom/Chat/ChatClient.cs
+++ b/src/Custom/Chat/ChatClient.cs
@@ -357,7 +357,7 @@ public partial class ChatClient
     private void CreateChatCompletionOptions(IEnumerable<ChatMessage> messages, ref ChatCompletionOptions options, bool stream = false)
     {
         options.Messages = messages.ToList();
-        options.Model = _model;
+        options.Model ??= _model;
         if (stream)
         {
             options.Stream = true;

--- a/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/src/Custom/Chat/ChatCompletionOptions.cs
@@ -28,16 +28,15 @@ public partial class ChatCompletionOptions
     /// The available derived classes include <see cref="AssistantChatMessage"/>, <see cref="FunctionChatMessage"/>, <see cref="SystemChatMessage"/>, <see cref="ToolChatMessage"/> and <see cref="UserChatMessage"/>.
     /// </summary>
     [CodeGenMember("Messages")]
-    internal IList<ChatMessage> Messages { get; set; }
+    public IList<ChatMessage> Messages { get; internal set; }
 
     // CUSTOM:
-    // - Made internal. This value comes from a parameter on the client method.
     // - Added setter.
     /// <summary>
     /// ID of the model to use. See the <see href="https://platform.openai.com/docs/models/model-endpoint-compatibility">model endpoint compatibility</see> table for details on which models work with the Chat API.
     /// </summary>
     [CodeGenMember("Model")]
-    internal string Model { get; set; }
+    public string Model { get; set; }
 
     // CUSTOM: Made internal. We only ever request a single choice.
     /// <summary> How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs. </summary>
@@ -47,7 +46,7 @@ public partial class ChatCompletionOptions
     // CUSTOM: Made internal. We set this manually based on the client method that is called.
     /// <summary> If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions). </summary>
     [CodeGenMember("Stream")]
-    internal bool? Stream { get; set; }
+    public bool? Stream { get; internal set; }
 
     /// <summary> Gets or sets the stream options. </summary>
     [CodeGenMember("StreamOptions")]

--- a/tests/Chat/ChatTests.cs
+++ b/tests/Chat/ChatTests.cs
@@ -57,6 +57,21 @@ public class ChatTests : SyncAsyncTestBase
     }
 
     [Test]
+    public async Task HelloWorldChatWithOverridenModel()
+    {
+        ChatClient client = GetTestClient();
+        IEnumerable<ChatMessage> messages = [new UserChatMessage("Hello, world!")];
+        ChatCompletionOptions options = new() { Model = "o3-mini" };
+        ClientResult<ChatCompletion> result = IsAsync
+            ? await client.CompleteChatAsync(messages, options)
+            : client.CompleteChat(messages, options);
+        Assert.That(result, Is.InstanceOf<ClientResult<ChatCompletion>>());
+        Assert.That(result.Value.Content[0].Kind, Is.EqualTo(ChatMessageContentPartKind.Text));
+        Assert.That(result.Value.Content[0].Text.Length, Is.GreaterThan(0));
+        Assert.That(result.Value.Model, Does.StartWith("o3-mini"));
+    }
+
+    [Test]
     public async Task MultiMessageChat()
     {
         ChatClient client = GetTestClient();


### PR DESCRIPTION
Fixes https://github.com/openai/openai-dotnet/issues/306, https://github.com/openai/openai-dotnet/issues/644

- Added a public getter to `Messages`, `Model`, `Stream`. That allows creating an OpenAI-compatible endpoint without having to use reflection.
- Added a public setter to `Model`. That allows choosing a different model per request with a fallback to the client's model.
- `StreamOptions`, `ChatResponseFormat` and `ToolChoice` are not addressed in this PR because they have a more complex type that you might want to rework before exposing.