### PR TITLE
build: build the library after regenerating

### DIFF
--- a/scripts/Submit-GeneratorUpdatePr.ps1
+++ b/scripts/Submit-GeneratorUpdatePr.ps1
@@ -215,13 +215,16 @@ try {
     }
     Pop-Location
 
-     # Export the API
-    Write-Log "Updating API"
+    # Build the updated library
+    Write-Log "Building the library"
     Push-Location "."
     try {
-        pwsh scripts/Export-Api.ps1
+        & dotnet build src/OpenAI.csproj
+        if ($LASTEXITCODE -ne 0) {
+            throw "Build failed with exit code $LASTEXITCODE"
+        }
     } catch {
-        Write-Warning-Log "Exporting API failed: $_"
+        Write-Warning-Log "Building the library failed: $_"
     }
     Pop-Location
     


### PR DESCRIPTION
This PR removes the call to Export-API as part of the generator upgrade automation, since that functionality depends on an internal tool `genapi`. For now, the call is replaced with simplify attempting to build the regenerated library.