### PR TITLE
Make `Id` required for `McpToolCallApprovalRequestItem`

### DIFF
--- a/api/OpenAI.net8.0.cs
+++ b/api/OpenAI.net8.0.cs
@@ -4910,7 +4910,7 @@ namespace OpenAI.Responses {
     }
     [Experimental("OPENAI001")]
     public class McpToolCallApprovalRequestItem : ResponseItem, IJsonModel<McpToolCallApprovalRequestItem>, IPersistableModel<McpToolCallApprovalRequestItem> {
-        public McpToolCallApprovalRequestItem(string serverLabel, string toolName, BinaryData toolArguments);
+        public McpToolCallApprovalRequestItem(string id, string serverLabel, string toolName, BinaryData toolArguments);
         public string ServerLabel { get; set; }
         public BinaryData ToolArguments { get; set; }
         public string ToolName { get; set; }
@@ -5298,7 +5298,7 @@ namespace OpenAI.Responses {
         public static FileSearchCallResponseItem CreateFileSearchCallItem(IEnumerable<string> queries);
         public static FunctionCallResponseItem CreateFunctionCallItem(string callId, string functionName, BinaryData functionArguments);
         public static FunctionCallOutputResponseItem CreateFunctionCallOutputItem(string callId, string functionOutput);
-        public static McpToolCallApprovalRequestItem CreateMcpApprovalRequestItem(string serverLabel, string name, BinaryData arguments);
+        public static McpToolCallApprovalRequestItem CreateMcpApprovalRequestItem(string id, string serverLabel, string name, BinaryData arguments);
         public static McpToolCallApprovalResponseItem CreateMcpApprovalResponseItem(string approvalRequestId, bool approved);
         public static McpToolCallItem CreateMcpToolCallItem(string serverLabel, string name, BinaryData arguments);
         public static McpToolDefinitionListItem CreateMcpToolDefinitionListItem(string serverLabel, IEnumerable<McpToolDefinition> toolDefinitions);

--- a/api/OpenAI.netstandard2.0.cs
+++ b/api/OpenAI.netstandard2.0.cs
@@ -4314,7 +4314,7 @@ namespace OpenAI.Responses {
         protected virtual BinaryData PersistableModelWriteCore(ModelReaderWriterOptions options);
     }
     public class McpToolCallApprovalRequestItem : ResponseItem, IJsonModel<McpToolCallApprovalRequestItem>, IPersistableModel<McpToolCallApprovalRequestItem> {
-        public McpToolCallApprovalRequestItem(string serverLabel, string toolName, BinaryData toolArguments);
+        public McpToolCallApprovalRequestItem(string id, string serverLabel, string toolName, BinaryData toolArguments);
         public string ServerLabel { get; set; }
         public BinaryData ToolArguments { get; set; }
         public string ToolName { get; set; }
@@ -4672,7 +4672,7 @@ namespace OpenAI.Responses {
         public static FileSearchCallResponseItem CreateFileSearchCallItem(IEnumerable<string> queries);
         public static FunctionCallResponseItem CreateFunctionCallItem(string callId, string functionName, BinaryData functionArguments);
         public static FunctionCallOutputResponseItem CreateFunctionCallOutputItem(string callId, string functionOutput);
-        public static McpToolCallApprovalRequestItem CreateMcpApprovalRequestItem(string serverLabel, string name, BinaryData arguments);
+        public static McpToolCallApprovalRequestItem CreateMcpApprovalRequestItem(string id, string serverLabel, string name, BinaryData arguments);
         public static McpToolCallApprovalResponseItem CreateMcpApprovalResponseItem(string approvalRequestId, bool approved);
         public static McpToolCallItem CreateMcpToolCallItem(string serverLabel, string name, BinaryData arguments);
         public static McpToolDefinitionListItem CreateMcpToolDefinitionListItem(string serverLabel, IEnumerable<McpToolDefinition> toolDefinitions);

--- a/specification/client/responses.client.tsp
+++ b/specification/client/responses.client.tsp
@@ -7,8 +7,9 @@ using Azure.ClientGenerator.Core;
 @@alternateType(CreateResponse.service_tier, DotNetResponseServiceTier);
 @@alternateType(Response.service_tier, DotNetResponseServiceTier);
 
-@@visibility(ItemResource.id, Lifecycle.Read);
+// ------------ ItemResources ------------
 @@usage(ItemResource, Usage.input | Usage.output);
+@@visibility(ItemResource.id, Lifecycle.Read);
 
 @@visibility(ComputerToolCallItemResource.status, Lifecycle.Read);
 
@@ -31,13 +32,6 @@ using Azure.ClientGenerator.Core;
 
 @@visibility(ResponsesMessageItemResource.status, Lifecycle.Read);
 
-@@clientName(FileSearchTool.max_num_results, "MaxResultCount");
-
-@@clientName(FunctionTool.name, "FunctionName");
-@@clientName(FunctionTool.description, "FunctionDescription");
-@@clientName(FunctionTool.parameters, "FunctionParameters");
-@@clientName(FunctionTool.strict, "StrictModeEnabled");
-
 @@alternateType(MCPApprovalRequestItemResource.arguments, unknown);
 @@clientName(MCPApprovalRequestItemResource.name, "ToolName");
 @@clientName(MCPApprovalRequestItemResource.arguments, "ToolArguments");
@@ -53,8 +47,19 @@ using Azure.ClientGenerator.Core;
 @@alternateType(MCPListToolsItemResource.error, unknown);
 @@clientName(MCPListToolsItemResource.tools, "ToolDefinitions");
 
+// ------------ Tools ------------
+
+@@clientName(FileSearchTool.max_num_results, "MaxResultCount");
+
+@@clientName(FunctionTool.name, "FunctionName");
+@@clientName(FunctionTool.description, "FunctionDescription");
+@@clientName(FunctionTool.parameters, "FunctionParameters");
+@@clientName(FunctionTool.strict, "StrictModeEnabled");
+
 @@alternateType(MCPTool.server_url, url);
 @@clientName(MCPTool.server_url, "ServerUri");
+
+// ------------ Streaming ------------
 
 @@alternateType(ResponseFunctionCallArgumentsDoneEvent.arguments, unknown);
 // @@clientName(ResponseFunctionCallArgumentsDoneEvent.arguments, "FunctionArguments");

--- a/src/Custom/Responses/Items/McpTool/McpToolCallApprovalRequestItem.cs
+++ b/src/Custom/Responses/Items/McpTool/McpToolCallApprovalRequestItem.cs
@@ -1,7 +1,29 @@
-﻿namespace OpenAI.Responses;
+﻿using System;
 
-// CUSTOM: Renamed.
+namespace OpenAI.Responses;
+
+// CUSTOM:
+// - Renamed.
+// - Made internal the constructor that does not take the item ID as a parameter. This is because MCP
+//   approval requests are correlated to MCP approval responses using this ID. Therefore, it
+//   implies that the ID of MCP approval requests is required. Note that this is contrary to other
+//   similar cases, such as function call items, which are instead correlated to function call
+//   outputs using a dedicated "call ID".
 [CodeGenType("MCPApprovalRequestItemResource")]
+[CodeGenVisibility(nameof(McpToolCallApprovalRequestItem), CodeGenVisibility.Internal, typeof(string), typeof(string), typeof(BinaryData))]
 public partial class McpToolCallApprovalRequestItem
 {
+    // CUSTOM: Added a constructor that takes the item ID.
+    public McpToolCallApprovalRequestItem(string id, string serverLabel, string toolName, BinaryData toolArguments) : base(InternalItemType.McpApprovalRequest)
+    {
+        Argument.AssertNotNull(id, nameof(id));
+        Argument.AssertNotNull(serverLabel, nameof(serverLabel));
+        Argument.AssertNotNull(toolName, nameof(toolName));
+        Argument.AssertNotNull(toolArguments, nameof(toolArguments));
+
+        Id = id;
+        ServerLabel = serverLabel;
+        ToolName = toolName;
+        ToolArguments = toolArguments;
+    }
 }

--- a/src/Custom/Responses/Items/Reference/ReferenceResponseItem.cs
+++ b/src/Custom/Responses/Items/Reference/ReferenceResponseItem.cs
@@ -2,13 +2,13 @@ namespace OpenAI.Responses;
 
 // CUSTOM:
 // - Renamed.
-// - Made internal the constructor that does not take an ID, because contrary to other item types,
-//   the ID of reference items is not read-only and is required.
+// - Made internal the constructor that does not take the item ID, because contrary to other item
+//   types, the ID of reference items is not read-only and is required.
 [CodeGenType("DotNetItemReferenceItemResource")]
 [CodeGenVisibility(nameof(ReferenceResponseItem), CodeGenVisibility.Internal)]
 public partial class ReferenceResponseItem
 {
-    // CUSTOM: Added a constructor that takes an ID.
+    // CUSTOM: Added a constructor that takes the item ID.
     public ReferenceResponseItem(string id) : base(InternalItemType.ItemReference)
     {
         Argument.AssertNotNull(id, nameof(id));

--- a/src/Custom/Responses/Items/ResponseItem.cs
+++ b/src/Custom/Responses/Items/ResponseItem.cs
@@ -116,9 +116,9 @@ public partial class ResponseItem
         return new ReferenceResponseItem(id);
     }
 
-    public static McpToolCallApprovalRequestItem CreateMcpApprovalRequestItem(string serverLabel, string name, BinaryData arguments)
+    public static McpToolCallApprovalRequestItem CreateMcpApprovalRequestItem(string id, string serverLabel, string name, BinaryData arguments)
     {
-        return new McpToolCallApprovalRequestItem(serverLabel, name, arguments);
+        return new McpToolCallApprovalRequestItem(id, serverLabel, name, arguments);
     }
 
     public static McpToolCallApprovalResponseItem CreateMcpApprovalResponseItem(string approvalRequestId, bool approved)

--- a/src/Generated/Models/Responses/McpToolCallApprovalRequestItem.cs
+++ b/src/Generated/Models/Responses/McpToolCallApprovalRequestItem.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Responses
     [Experimental("OPENAI001")]
     public partial class McpToolCallApprovalRequestItem : ResponseItem
     {
-        public McpToolCallApprovalRequestItem(string serverLabel, string toolName, BinaryData toolArguments) : base(InternalItemType.McpApprovalRequest)
+        internal McpToolCallApprovalRequestItem(string serverLabel, string toolName, BinaryData toolArguments) : base(InternalItemType.McpApprovalRequest)
         {
             Argument.AssertNotNull(serverLabel, nameof(serverLabel));
             Argument.AssertNotNull(toolName, nameof(toolName));


### PR DESCRIPTION
Replaced the constructor that does not take the item ID as a parameter in favor of one that does. This is because MCP approval requests are correlated to MCP approval responses using this ID. Therefore, it implies that the ID of MCP approval requests is required. Note that this is contrary to other similar cases, such as function call items, which are instead correlated to function call outputs using a dedicated "call ID".