### PR TITLE
Add OpenAIResponseClient.CreateResponse{Streaming}Async overloads that take RequestOptions

### DIFF
--- a/src/Custom/Chat/ChatClient.cs
+++ b/src/Custom/Chat/ChatClient.cs
@@ -138,7 +138,7 @@ public partial class ChatClient
     /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual Task<ClientResult<ChatCompletion>> CompleteChatAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
-        return CompleteChatAsync(messages, options, cancellationToken.ToRequestOptions());
+        return CompleteChatAsync(messages, options, cancellationToken.ToRequestOptions() ?? new RequestOptions());
     }
 
     internal async Task<ClientResult<ChatCompletion>> CompleteChatAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options, RequestOptions requestOptions)

--- a/src/Custom/Responses/OpenAIResponseClient.cs
+++ b/src/Custom/Responses/OpenAIResponseClient.cs
@@ -121,7 +121,7 @@ public partial class OpenAIResponseClient
 
     public virtual Task<ClientResult<OpenAIResponse>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options = null, CancellationToken cancellationToken = default)
     {
-        return CreateResponseAsync(inputItems, options, cancellationToken.ToRequestOptions());
+        return CreateResponseAsync(inputItems, options, cancellationToken.ToRequestOptions() ?? new RequestOptions());
     }
 
     internal async Task<ClientResult<OpenAIResponse>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options, RequestOptions requestOptions)

--- a/src/Custom/Responses/OpenAIResponseClient.cs
+++ b/src/Custom/Responses/OpenAIResponseClient.cs
@@ -124,11 +124,10 @@ public partial class OpenAIResponseClient
         return CreateResponseAsync(inputItems, options, cancellationToken.ToRequestOptions());
     }
 
-    public virtual async Task<ClientResult<OpenAIResponse>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options, RequestOptions requestOptions)
+    internal async Task<ClientResult<OpenAIResponse>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options, RequestOptions requestOptions)
     {
         Argument.AssertNotNullOrEmpty(inputItems, nameof(inputItems));
         Argument.AssertNotNull(requestOptions, nameof(requestOptions));
-
         if (requestOptions.BufferResponse is false)
         {
             throw new InvalidOperationException("'requestOptions.BufferResponse' must be 'true' when calling 'CreateResponseAsync'.");
@@ -176,11 +175,10 @@ public partial class OpenAIResponseClient
         return CreateResponseStreamingAsync(inputItems, options, cancellationToken.ToRequestOptions(streaming: true));
     }
 
-    public virtual AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options, RequestOptions requestOptions)
+    internal AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options, RequestOptions requestOptions)
     {
         Argument.AssertNotNullOrEmpty(inputItems, nameof(inputItems));
         Argument.AssertNotNull(requestOptions, nameof(requestOptions));
-
         if (requestOptions.BufferResponse is true)
         {
             throw new InvalidOperationException("'requestOptions.BufferResponse' must be 'false' when calling 'CreateResponseStreamingAsync'.");

--- a/src/Custom/Responses/OpenAIResponseClient.cs
+++ b/src/Custom/Responses/OpenAIResponseClient.cs
@@ -119,12 +119,23 @@ public partial class OpenAIResponseClient
     [Experimental("OPENAI001")]
     public Uri Endpoint => _endpoint;
 
-    public virtual async Task<ClientResult<OpenAIResponse>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options = null, CancellationToken cancellationToken = default)
+    public virtual Task<ClientResult<OpenAIResponse>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options = null, CancellationToken cancellationToken = default)
+    {
+        return CreateResponseAsync(inputItems, options, cancellationToken.ToRequestOptions());
+    }
+
+    public virtual async Task<ClientResult<OpenAIResponse>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options, RequestOptions requestOptions)
     {
         Argument.AssertNotNullOrEmpty(inputItems, nameof(inputItems));
+        Argument.AssertNotNull(requestOptions, nameof(requestOptions));
+
+        if (requestOptions.BufferResponse is false)
+        {
+            throw new InvalidOperationException("'requestOptions.BufferResponse' must be 'true' when calling 'CreateResponseAsync'.");
+        }
 
         using BinaryContent content = CreatePerCallOptions(options, inputItems, stream: false).ToBinaryContent();
-        ClientResult protocolResult = await CreateResponseAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        ClientResult protocolResult = await CreateResponseAsync(content, requestOptions).ConfigureAwait(false);
         OpenAIResponse convenienceValue = (OpenAIResponse)protocolResult;
         return ClientResult.FromValue(convenienceValue, protocolResult.GetRawResponse());
     }
@@ -162,13 +173,24 @@ public partial class OpenAIResponseClient
 
     public virtual AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options = null, CancellationToken cancellationToken = default)
     {
+        return CreateResponseStreamingAsync(inputItems, options, cancellationToken.ToRequestOptions(streaming: true));
+    }
+
+    public virtual AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options, RequestOptions requestOptions)
+    {
         Argument.AssertNotNullOrEmpty(inputItems, nameof(inputItems));
+        Argument.AssertNotNull(requestOptions, nameof(requestOptions));
+
+        if (requestOptions.BufferResponse is true)
+        {
+            throw new InvalidOperationException("'requestOptions.BufferResponse' must be 'false' when calling 'CreateResponseStreamingAsync'.");
+        }
 
         using BinaryContent content = CreatePerCallOptions(options, inputItems, stream: true).ToBinaryContent();
         return new AsyncSseUpdateCollection<StreamingResponseUpdate>(
-            async () => await CreateResponseAsync(content, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false),
+            async () => await CreateResponseAsync(content, requestOptions).ConfigureAwait(false),
             StreamingResponseUpdate.DeserializeStreamingResponseUpdate,
-            cancellationToken);
+            requestOptions.CancellationToken);
     }
 
     public virtual CollectionResult<StreamingResponseUpdate> CreateResponseStreaming(IEnumerable<ResponseItem> inputItems, ResponseCreationOptions options = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Today, if you're using the convenience types and you just want to set a user-agent header on a request (you're handed the instance and thus can't configure it at creation), the only supported option I see is to abandon the convenience methods and adopt the protocol methods, which means formatting all the input JSON and parsing all the response SSE / JSON. That's a big pill to swallow. Based on need, could we add a few convenience overloads that just take a RequestOptions instead of a CancellationToken? It results in minimal additional surface area / almost no additional duplicated code, as it's just taking a RequestOptions instead of taking a CancellationToken and calling ToRequestOptions on it. I've demonstrated in this PR with CreateResponseAsync and CreateResponseStreamingAsync, which are the two methods I currently care about.