### PR TITLE
Add code samples for MCP tooling

### DIFF
--- a/docs/guides/tools-connectors-mcp/responses/approvals-always-require-approval.cs
+++ b/docs/guides/tools-connectors-mcp/responses/approvals-always-require-approval.cs
@@ -1,0 +1,44 @@
+// SAMPLE: Generate response from remote MCP through Responses API
+// PAGE: https://platform.openai.com/docs/guides/tools-connectors-mcp#approvals
+// GUIDANCE: Instructions to run this code: https://aka.ms/oai/net/start
+#pragma warning disable OPENAI001
+
+#:package OpenAI@2.*
+#:property PublishAot=false
+
+using OpenAI.Responses;
+
+string key = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!;
+OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
+
+ResponseCreationOptions options1 = new();
+options1.Tools.Add(ResponseTool.CreateMcpTool(
+    serverLabel: "dmcp",
+    serverUri: new Uri("https://dmcp-server.deno.dev/sse")
+));
+
+McpToolCallApprovalRequestItem request1 = ResponseItem.CreateMcpApprovalRequestItem(
+    serverLabel: "dmcp",
+    name: "roll",
+    arguments: BinaryData.FromObjectAsJson(new { diceRollExpression = "2d4+1" })
+);
+
+OpenAIResponse response1 = (OpenAIResponse)client.CreateResponse([
+    request1
+], options1);
+
+ResponseCreationOptions options2 = new();
+options2.Tools.Add(ResponseTool.CreateMcpTool(
+    serverLabel: "dmcp",
+    serverUri: new Uri("https://dmcp-server.deno.dev/sse"),
+    toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval)
+));
+
+options2.PreviousResponseId = response1.Id;
+
+OpenAIResponse response2 = (OpenAIResponse)client.CreateResponse([
+    request1,
+    ResponseItem.CreateMcpApprovalResponseItem(request1.Id, approved: true),
+], options2);
+
+Console.WriteLine(response2.GetOutputText());

--- a/docs/guides/tools-connectors-mcp/responses/approvals-never-require-approval.cs
+++ b/docs/guides/tools-connectors-mcp/responses/approvals-never-require-approval.cs
@@ -1,0 +1,28 @@
+// SAMPLE: Generate response from remote MCP through Responses API
+// PAGE: https://platform.openai.com/docs/guides/tools-connectors-mcp#approvals
+// GUIDANCE: Instructions to run this code: https://aka.ms/oai/net/start
+#pragma warning disable OPENAI001
+
+#:package OpenAI@2.*
+#:property PublishAot=false
+
+using OpenAI.Responses;
+
+string key = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!;
+OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
+
+ResponseCreationOptions options = new();
+options.Tools.Add(ResponseTool.CreateMcpTool(
+    serverLabel: "deepwiki",
+    serverUri: new Uri("https://mcp.deepwiki.com/mcp"),
+    allowedTools: new McpToolFilter() { ToolNames = { "ask_question", "read_wiki_structure" } },
+    toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
+));
+
+OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+    ResponseItem.CreateUserMessageItem([
+        ResponseContentPart.CreateInputTextPart("What transport protocols does the 2025-03-26 version of the MCP spec (modelcontextprotocol/modelcontextprotocol) support?")
+    ])
+], options);
+
+Console.WriteLine(response.GetOutputText());

--- a/docs/guides/tools-connectors-mcp/responses/filtering-tools.cs
+++ b/docs/guides/tools-connectors-mcp/responses/filtering-tools.cs
@@ -1,0 +1,28 @@
+// SAMPLE: Generate response from remote MCP through Responses API
+// PAGE: https://platform.openai.com/docs/guides/tools-connectors-mcp#filtering-tools
+// GUIDANCE: Instructions to run this code: https://aka.ms/oai/net/start
+#pragma warning disable OPENAI001
+
+#:package OpenAI@2.*
+#:property PublishAot=false
+
+using OpenAI.Responses;
+
+string key = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!;
+OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
+
+ResponseCreationOptions options = new();
+options.Tools.Add(ResponseTool.CreateMcpTool(
+    serverLabel: "dmcp",
+    serverUri: new Uri("https://dmcp-server.deno.dev/sse"),
+    allowedTools: new McpToolFilter() { ToolNames = { "roll" } },
+    toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
+));
+
+OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+    ResponseItem.CreateUserMessageItem([
+        ResponseContentPart.CreateInputTextPart("Roll 2d4+1")
+    ])
+], options);
+
+Console.WriteLine(response.GetOutputText());

--- a/docs/guides/tools-connectors-mcp/responses/quickstart-remote-mcp.cs
+++ b/docs/guides/tools-connectors-mcp/responses/quickstart-remote-mcp.cs
@@ -1,0 +1,27 @@
+// SAMPLE: Generate response from remote MCP through Responses API
+// PAGE: https://platform.openai.com/docs/guides/tools-connectors-mcp?quickstart-panels=remote-mcp#quickstart
+// GUIDANCE: Instructions to run this code: https://aka.ms/oai/net/start
+#pragma warning disable OPENAI001
+
+#:package OpenAI@2.*
+#:property PublishAot=false
+
+using OpenAI.Responses;
+
+string key = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!;
+OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
+
+ResponseCreationOptions options = new();
+options.Tools.Add(ResponseTool.CreateMcpTool(
+    serverLabel: "dmcp",
+    serverUri: new Uri("https://dmcp-server.deno.dev/sse"),
+    toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
+));
+
+OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+    ResponseItem.CreateUserMessageItem([
+        ResponseContentPart.CreateInputTextPart("Roll 2d4+1")
+    ])
+], options);
+
+Console.WriteLine(response.GetOutputText());


### PR DESCRIPTION
This PR is intended to add code samples for the [Connectors and MCP servers page](https://platform.openai.com/docs/guides/tools-connectors-mcp) including:

- Quickstart using remote MCP servers
- Filterling tools
- Always require approvals
- Never require approvals

This PR doesn't include the sample codes for:

- Quickstart using connetors
- Authentication
- Connectors
