### PR TITLE
Custom Serializer for Message Creation - Resolves Issue 552

### DIFF
--- a/tests/Assistants/AssistantsTests.cs
+++ b/tests/Assistants/AssistantsTests.cs
@@ -31,7 +31,6 @@ public class AssistantsTests : SyncAsyncTestBase
     private readonly List<string> _vectorStoreIdsToDelete = [];
 
     private static readonly DateTimeOffset s_2024 = new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-    private static readonly string s_testAssistantName = $".NET SDK Test Assistant - Please Delete Me";
     private static readonly string s_cleanupMetadataKey = $"test_metadata_cleanup_eligible";
 
     private static AssistantClient GetTestClient() => GetTestClient<AssistantClient>(TestScenario.Assistants);


### PR DESCRIPTION
# Fixes Issue 552 

I'm actually surprised this hasn't come up more often, the FileSearch/CodeGen combo allows for really simple data analysis.

Anyway; I discovered the root cause,  and here what I changed.

## Root cause 
The file_search tool definition in the spec ([models.tsp](https://github.com/openai/openai-dotnet/blob/08a1193f616124e9c93ff991ab8dcb376ef52d28/specification/base/typespec/assistants/models.tsp#L182)) is shared between Assistant creation and Message tool serialization. 

The generated serializer ([FileSearchToolDefinition.Serialization.cs](https://github.com/openai/openai-dotnet/blob/08a1193f616124e9c93ff991ab8dcb376ef52d28/src/Generated/Models/Assistants/FileSearchToolDefinition.Serialization.cs#L30)) force emits a "file_search" object when serializing the tool, which ends up injected into the message attachment payload (an unsupported property for that request).

## Solution
 I did not edit the generated FileSearchToolDefinition.Serialization.cs. Instead I intercepted message-level tool serialization in [MessageCreationAttachment.cs](https://github.com/openai/openai-dotnet/blob/08a1193f616124e9c93ff991ab8dcb376ef52d28/src/Custom/Assistants/MessageCreationAttachment.cs#L29).

I buffer the generated JSON for each tool, parse it, remove any "file_search" property, then write the cleaned JSON into the message attachment payload. This prevents the unwanted property from being sent.

**Why this approach**: generated code can’t be changed directly, so post-processing the generated output in the custom serializer is the safest fix that keeps generated behavior intact while preventing invalid request payloads.

## Testing

I was able to recreate the issue with the added test.
After implementing the fix, the test passes.

All tests with Category "Assistant" pass.

## Recommendation  
Split the spec definition so assistant-level tool properties (like file_search) are not shared with message-level tool representations. Ise separate types for tools used in assistant creation vs tools embedded in messages, or mark server-only/readOnly fields so the generator will not emit them into request models. If the Responses API already addresses this separation, consider aligning the assistants spec with that approach.