### PR TITLE
fix: properly reset serialization provider in visitor

### DIFF
--- a/codegen/generator/src/OpenAILibraryGenerator.cs
+++ b/codegen/generator/src/OpenAILibraryGenerator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel.Composition;
 using Microsoft.TypeSpec.Generator;
 using Microsoft.TypeSpec.Generator.ClientModel;
@@ -16,11 +15,12 @@ namespace OpenAILibraryPlugin
         protected override void Configure()
         {
             base.Configure();
+            // This should be first, as it recomputes the type
+            AddVisitor(new NonAbstractPublicTypesVisitor());
             AddVisitor(new ConstructorFixupVisitor());
             AddVisitor(new KindRenameVisitor());
             AddVisitor(new VisibilityVisitor());
             AddVisitor(new ContentInnerCollectionDefinedVisitor());
-            AddVisitor(new NonAbstractPublicTypesVisitor());
             AddVisitor(new PageOrderRemovalVisitor(this));
             AddVisitor(new OmittedTypesVisitor());
             AddVisitor(new InvariantFormatAdditionalPropertiesVisitor());


### PR DESCRIPTION
Fixes an issue where we were modifying the accessibility modifier for types that were originally abstract, but not recomputing their serialization providers.

fixes: https://github.com/microsoft/typespec/issues/8616