### PR TITLE
Remove unnecessary casts from samples

### DIFF
--- a/docs/guides/images-vision/responses/analyze_images_passing_base64_string.cs
+++ b/docs/guides/images-vision/responses/analyze_images_passing_base64_string.cs
@@ -17,7 +17,7 @@ using HttpClient http = new();
 // Download an image as stream
 using var stream = await http.GetStreamAsync(imageUrl);
 
-OpenAIResponse response1 = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response1 = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is in this image?"),
         ResponseContentPart.CreateInputImagePart(BinaryData.FromStream(stream), "image/png")
@@ -29,7 +29,7 @@ Console.WriteLine($"From image stream: {response1.GetOutputText()}");
 // Download an image as byte array
 byte[] bytes = await http.GetByteArrayAsync(imageUrl);
 
-OpenAIResponse response2 = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response2 = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is in this image?"),
         ResponseContentPart.CreateInputImagePart(BinaryData.FromBytes(bytes), "image/png")

--- a/docs/guides/images-vision/responses/analyze_images_passing_file.cs
+++ b/docs/guides/images-vision/responses/analyze_images_passing_file.cs
@@ -22,7 +22,7 @@ using var stream = await http.GetStreamAsync(imageUrl);
 OpenAIFileClient files = new(key);
 OpenAIFile file = await files.UploadFileAsync(BinaryData.FromStream(stream), filename, FileUploadPurpose.Vision);
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("what's in this image?"),
         ResponseContentPart.CreateInputImagePart(file.Id)

--- a/docs/guides/images-vision/responses/analyze_images_passing_url.cs
+++ b/docs/guides/images-vision/responses/analyze_images_passing_url.cs
@@ -13,7 +13,7 @@ OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
 
 Uri imageUrl = new("https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg");
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is in this image?"),
         ResponseContentPart.CreateInputImagePart(imageUrl)

--- a/docs/guides/text/responses/responses_fileinput.cs
+++ b/docs/guides/text/responses/responses_fileinput.cs
@@ -16,7 +16,7 @@ OpenAIResponseClient client = new("gpt-4.1", key);
 OpenAIFileClient files = new(key);
 OpenAIFile file = files.UploadFile("draconomicon.pdf", FileUploadPurpose.UserData);
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse(
+OpenAIResponse response = client.CreateResponse(
     BinaryContent.Create(BinaryData.FromObjectAsJson(
     new {
         model = "gpt-4.1",

--- a/docs/guides/text/responses/responses_prompttemplate.cs
+++ b/docs/guides/text/responses/responses_prompttemplate.cs
@@ -10,7 +10,7 @@ using System.ClientModel;
 
 string key = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!;
 OpenAIResponseClient client = new("gpt-4.1", key);
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse(
+OpenAIResponse response = client.CreateResponse(
     BinaryContent.Create(BinaryData.FromObjectAsJson(
     new {
         model = "gpt-4.1",

--- a/docs/guides/tools-connectors-mcp/responses/approvals-always-require-approval.cs
+++ b/docs/guides/tools-connectors-mcp/responses/approvals-always-require-approval.cs
@@ -19,7 +19,7 @@ options.Tools.Add(ResponseTool.CreateMcpTool(
 ));
 
 // STEP 1: Create response that requests tool call approval
-OpenAIResponse response1 = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response1 = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("Roll 2d4+1")
     ])
@@ -29,7 +29,7 @@ McpToolCallApprovalRequestItem? approvalRequestItem = response1.OutputItems.Last
 
 // STEP 2: Approve the tool call request and get final response
 options.PreviousResponseId = response1.Id;
-OpenAIResponse response2 = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response2 = client.CreateResponse([
     ResponseItem.CreateMcpApprovalResponseItem(approvalRequestItem!.Id, approved: true),
 ], options);
 

--- a/docs/guides/tools-connectors-mcp/responses/approvals-never-require-approval.cs
+++ b/docs/guides/tools-connectors-mcp/responses/approvals-never-require-approval.cs
@@ -19,7 +19,7 @@ options.Tools.Add(ResponseTool.CreateMcpTool(
     toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
 ));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What transport protocols does the 2025-03-26 version of the MCP spec (modelcontextprotocol/modelcontextprotocol) support?")
     ])

--- a/docs/guides/tools-connectors-mcp/responses/authentication.cs
+++ b/docs/guides/tools-connectors-mcp/responses/authentication.cs
@@ -19,7 +19,7 @@ options.Tools.Add(ResponseTool.CreateMcpTool(
     authorizationToken: authToken
 ));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("Create a payment link for $20")
     ])

--- a/docs/guides/tools-connectors-mcp/responses/filtering-tools.cs
+++ b/docs/guides/tools-connectors-mcp/responses/filtering-tools.cs
@@ -19,7 +19,7 @@ options.Tools.Add(ResponseTool.CreateMcpTool(
     toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
 ));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("Roll 2d4+1")
     ])

--- a/docs/guides/tools-connectors-mcp/responses/quickstart-remote-mcp.cs
+++ b/docs/guides/tools-connectors-mcp/responses/quickstart-remote-mcp.cs
@@ -18,7 +18,7 @@ options.Tools.Add(ResponseTool.CreateMcpTool(
     toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
 ));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("Roll 2d4+1")
     ])

--- a/docs/guides/tools-web-search/responses/quickstart.cs
+++ b/docs/guides/tools-web-search/responses/quickstart.cs
@@ -14,7 +14,7 @@ OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
 ResponseCreationOptions options = new();
 options.Tools.Add(ResponseTool.CreateWebSearchTool());
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart(
             "What was a positive news story from today?"

--- a/docs/guides/tools-web-search/responses/user-location.cs
+++ b/docs/guides/tools-web-search/responses/user-location.cs
@@ -20,7 +20,7 @@ options.Tools.Add(ResponseTool.CreateWebSearchTool(
     )
 ));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart(
             "What are the best restaurants near me?"

--- a/docs/guides/tools/responses/file_search.cs
+++ b/docs/guides/tools/responses/file_search.cs
@@ -14,7 +14,7 @@ OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
 ResponseCreationOptions options = new();
 options.Tools.Add(ResponseTool.CreateFileSearchTool([ "<vector_store_id>" ]));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is deep research by OpenAI?")
     ])

--- a/docs/guides/tools/responses/function_calling.cs
+++ b/docs/guides/tools/responses/function_calling.cs
@@ -34,7 +34,7 @@ options.Tools.Add(ResponseTool.CreateFunctionTool(
     )
 );
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is the weather like in Paris today?")
     ])

--- a/docs/guides/tools/responses/remote_mcp.cs
+++ b/docs/guides/tools/responses/remote_mcp.cs
@@ -18,7 +18,7 @@ options.Tools.Add(ResponseTool.CreateMcpTool(
     toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
 ));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("Roll 2d4+1")
     ])

--- a/docs/guides/tools/responses/web_search.cs
+++ b/docs/guides/tools/responses/web_search.cs
@@ -14,7 +14,7 @@ OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
 ResponseCreationOptions options = new();
 options.Tools.Add(ResponseTool.CreateWebSearchTool());
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart(
             "What was a positive news story from today?"

--- a/docs/quickstart/responses/analyze_images_files_file_url.cs
+++ b/docs/quickstart/responses/analyze_images_files_file_url.cs
@@ -17,7 +17,7 @@ using Stream stream = await http.GetStreamAsync("https://www.berkshirehathaway.c
 OpenAIFileClient files = new(key);
 OpenAIFile file = files.UploadFile(stream, "2024ltr.pdf", FileUploadPurpose.UserData);
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("Analyze the letter and provide a summary of the key points."),
         ResponseContentPart.CreateInputFilePart(file.Id)

--- a/docs/quickstart/responses/analyze_images_files_image_url.cs
+++ b/docs/quickstart/responses/analyze_images_files_image_url.cs
@@ -10,7 +10,7 @@ using OpenAI.Responses;
 
 string key = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!;
 OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is in this image?"),
         ResponseContentPart.CreateInputImagePart(new Uri("https://openai-documentation.vercel.app/images/cat_and_otter.png"))

--- a/docs/quickstart/responses/analyze_images_files_upload_file.cs
+++ b/docs/quickstart/responses/analyze_images_files_upload_file.cs
@@ -15,7 +15,7 @@ OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
 OpenAIFileClient files = new(key);
 OpenAIFile file = files.UploadFile("draconomicon.pdf", FileUploadPurpose.UserData);
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputFilePart(file.Id),
         ResponseContentPart.CreateInputTextPart("What is the first dragon in the book?")

--- a/docs/quickstart/responses/extend_model_with_tools_file_search.cs
+++ b/docs/quickstart/responses/extend_model_with_tools_file_search.cs
@@ -14,7 +14,7 @@ OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
 ResponseCreationOptions options = new();
 options.Tools.Add(ResponseTool.CreateFileSearchTool([ "<vector_store_id>" ]));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is deep research by OpenAI?")
     ])

--- a/docs/quickstart/responses/extend_model_with_tools_function_calling.cs
+++ b/docs/quickstart/responses/extend_model_with_tools_function_calling.cs
@@ -34,7 +34,7 @@ options.Tools.Add(ResponseTool.CreateFunctionTool(
     )
 );
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What is the weather like in Paris today?")
     ])

--- a/docs/quickstart/responses/extend_model_with_tools_remote_mcp.cs
+++ b/docs/quickstart/responses/extend_model_with_tools_remote_mcp.cs
@@ -18,7 +18,7 @@ options.Tools.Add(ResponseTool.CreateMcpTool(
     toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval)
 ));
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("Roll 2d4+1")
     ])

--- a/docs/quickstart/responses/extend_model_with_tools_web_search.cs
+++ b/docs/quickstart/responses/extend_model_with_tools_web_search.cs
@@ -14,7 +14,7 @@ OpenAIResponseClient client = new(model: "gpt-5", apiKey: key);
 ResponseCreationOptions options = new();
 options.Tools.Add(ResponseTool.CreateWebSearchTool());
 
-OpenAIResponse response = (OpenAIResponse)client.CreateResponse([
+OpenAIResponse response = client.CreateResponse([
     ResponseItem.CreateUserMessageItem([
         ResponseContentPart.CreateInputTextPart("What was a positive news story from today?")
     ])


### PR DESCRIPTION
Simplify the code samples further by removing unnecessary casts to type `OpenAIResponse`. The explicit typing for `OpenAIResponse response` will trigger implicit conversion.