### PR TITLE
Add OpenAIResponseClient.GetResponse{Streaming}Async overloads that take RequestOptions

### DIFF
--- a/src/Custom/Responses/OpenAIResponseClient.cs
+++ b/src/Custom/Responses/OpenAIResponseClient.cs
@@ -261,7 +261,7 @@ public partial class OpenAIResponseClient
         return GetResponseStreamingAsync(responseId, cancellationToken.ToRequestOptions(streaming: true), startingAfter);
     }
 
-    internal virtual AsyncCollectionResult<StreamingResponseUpdate> GetResponseStreamingAsync(string responseId, RequestOptions requestOptions, int? startingAfter = null)
+    internal AsyncCollectionResult<StreamingResponseUpdate> GetResponseStreamingAsync(string responseId, RequestOptions requestOptions, int? startingAfter = null)
     {
         Argument.AssertNotNull(responseId, nameof(responseId));
         Argument.AssertNotNull(requestOptions, nameof(requestOptions));


### PR DESCRIPTION
Adding internal overloads for GetResponse{Streaming}Async methods, similar to what was done for CreateResponse{Streaming}Async in this PR: https://github.com/openai/openai-dotnet/pull/687, to be able to set the user-agent header on an HTTP request sent by these methods.