### PR TITLE
Add multimodal (text + image) moderation support

### DIFF
--- a/examples/ModerationClientExamples.cs
+++ b/examples/ModerationClientExamples.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using OpenAI.Moderations;
+using System;
+using System.Collections.Generic;
+
+namespace OpenAI.Examples;
+
+public partial class ModerationClientExamples
+{
+    [Test]
+    public void ClassifyMultimodalExample()
+    {
+        var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        ModerationClient client = new("omni-moderation-latest", apiKey);
+
+        var inputs = new List<ModerationInput>
+        {
+            ModerationInput.FromText("text to classify goes here"),
+            //ModerationInput.FromImageUrl("https://example.com/image.png"),
+            //ModerationInput.FromImageUrl($"data:image/jpeg;base64,iVBORw0KGgoA...")
+        };
+
+        var result = client.Classify(inputs);
+        Assert.NotNull(result.Value);
+    }
+}

--- a/src/Custom/Moderations/ModerationInput.cs
+++ b/src/Custom/Moderations/ModerationInput.cs
@@ -1,0 +1,35 @@
+namespace OpenAI.Moderations;
+
+/// <summary>
+/// Represents a moderation input item which can be either text or an image URL (including data URLs).
+/// </summary>
+public readonly struct ModerationInput
+{
+    public ModerationInputType Type { get; }
+    public string Text { get; }
+    public string ImageUrl { get; }
+
+    private ModerationInput(ModerationInputType type, string text, string imageUrl)
+    {
+        Type = type;
+        Text = text;
+        ImageUrl = imageUrl;
+    }
+
+    /// <summary>Create a text input: {"type":"text","text": "..."}.</summary>
+    public static ModerationInput FromText(string text)
+    {
+        Argument.AssertNotNullOrEmpty(text, nameof(text));
+        return new ModerationInput(ModerationInputType.Text, text, null);
+    }
+
+    /// <summary>
+    /// Create an image URL input: {"type":"image_url","image_url":{"url":"..."}}.
+    /// The URL can also be a data URL (e.g., "data:image/jpeg;base64,...").
+    /// </summary>
+    public static ModerationInput FromImageUrl(string url)
+    {
+        Argument.AssertNotNullOrEmpty(url, nameof(url));
+        return new ModerationInput(ModerationInputType.ImageUrl, null, url);
+    }
+}

--- a/src/Custom/Moderations/ModerationInputType.cs
+++ b/src/Custom/Moderations/ModerationInputType.cs
@@ -1,0 +1,7 @@
+namespace OpenAI.Moderations;
+
+public enum ModerationInputType
+{
+    Text = 0,
+    ImageUrl = 1
+}


### PR DESCRIPTION
- Added `ClassifyAsync` and `Classify` overloads accepting multimodal input.
- Implemented JSON serialization matching OpenAI moderation API v2 (`type: text | image_url`).
- Added `ModerationInput` struct and `ModerationInputType` enum.