### PR TITLE
build: include spec folder in codgen validation

### DIFF
--- a/.github/workflows/codegen-validation.yml
+++ b/.github/workflows/codegen-validation.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - 'codegen/**'
+      - 'specification/**'
       - '.github/workflows/codegen-validation.yml'
       - 'scripts/Invoke-CodeGen.ps1'
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
This PR enabled the codegen validation CI to run when changes are made to the `specification` folder.