### PR TITLE
Add FileUploadOptions with ExpiresAfterDays for file upload expiratio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## Unreleased
+
+### Features Added
+
+- OpenAI.Files:
+  - Added the `FileUploadOptions` class with the `ExpiresAfterDays` property, which enables users to specify the number of days after which an uploaded file will automatically expire and be deleted.
+  - Added new overloads of `UploadFile` and `UploadFileAsync` methods on `OpenAIFileClient` that accept `FileUploadOptions` to allow specifying file expiration settings.
+
 ## 2.8.0 (2025-12-11)
 
 ### Features Added

--- a/README.md
+++ b/README.md
@@ -766,6 +766,21 @@ OpenAIFile salesFile = fileClient.UploadFile(
     FileUploadPurpose.Assistants);
 ```
 
+> **Note:** You can optionally specify when the file should automatically expire and be deleted by using the `FileUploadOptions` class:
+>
+> ```csharp
+> FileUploadOptions uploadOptions = new()
+> {
+>     ExpiresAfterDays = 7  // File will be deleted 7 days after creation
+> };
+>
+> OpenAIFile tempFile = fileClient.UploadFile(
+>     document,
+>     "temp_file.json",
+>     FileUploadPurpose.Assistants,
+>     uploadOptions);
+> ```
+
 Create a new assistant using an instance of the `AssistantCreationOptions` class to customize it. Here, we use:
 
 - A friendly `Name` for the assistant, as will display in the Playground

--- a/src/Custom/Files/FileUploadOptions.cs
+++ b/src/Custom/Files/FileUploadOptions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Files;
+
+/// <summary>
+/// Represents additional options available when uploading a file.
+/// </summary>
+public class FileUploadOptions
+{
+    private int? _expiresAfterDays;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FileUploadOptions"/>.
+    /// </summary>
+    public FileUploadOptions()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the number of days after which the file will expire and be deleted.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set, the file will automatically expire and be deleted after the specified number of days
+    /// following its creation. The expiration is calculated from the file's <c>created_at</c> timestamp.
+    /// </para>
+    /// <para>
+    /// This property is optional. When not set (null), the file will not expire automatically.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value must be greater than zero.</exception>
+    [Experimental("OPENAI001")]
+    public int? ExpiresAfterDays
+    {
+        get => _expiresAfterDays;
+        set
+        {
+            if (value.HasValue && value.Value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "ExpiresAfterDays must be greater than zero.");
+            }
+            _expiresAfterDays = value;
+        }
+    }
+}

--- a/src/Custom/Files/Internal/InternalFileUploadOptions.cs
+++ b/src/Custom/Files/Internal/InternalFileUploadOptions.cs
@@ -1,4 +1,5 @@
 using Microsoft.TypeSpec.Generator.Customizations;
+using System.ClientModel.Primitives;
 using System.IO;
 
 namespace OpenAI.Files;
@@ -37,6 +38,12 @@ internal partial class InternalFileUploadOptions
         content.Add(file, "file", filename);
 
         content.Add(Purpose.ToString(), "purpose");
+
+        if (ExpiresAfter.HasValue)
+        {
+            string expiresAfterJson = ModelReaderWriter.Write(ExpiresAfter.Value, ModelReaderWriterOptions.Json, OpenAIContext.Default).ToString();
+            content.Add(expiresAfterJson, "expires_after");
+        }
 
         return content;
     }

--- a/src/Custom/Files/OpenAIFileClient.cs
+++ b/src/Custom/Files/OpenAIFileClient.cs
@@ -118,12 +118,38 @@ public partial class OpenAIFileClient
         Argument.AssertNotNull(file, nameof(file));
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
 
-        InternalFileUploadOptions options = new()
+        InternalFileUploadOptions internalOptions = new()
         {
             Purpose = purpose
         };
 
-        using MultiPartFormDataBinaryContent content = options.ToMultipartContent(file, filename);
+        using MultiPartFormDataBinaryContent content = internalOptions.ToMultipartContent(file, filename);
+        ClientResult result = await UploadFileAsync(content, content.ContentType, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        return ClientResult.FromValue((OpenAIFile)result, result.GetRawResponse());
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file stream to upload. </param>
+    /// <param name="filename">
+    ///     The filename associated with the file stream. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="options"> Additional options for the file upload. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, FileUploadOptions options, CancellationToken cancellationToken = default)
+    {
+        Argument.AssertNotNull(file, nameof(file));
+        Argument.AssertNotNullOrEmpty(filename, nameof(filename));
+
+        InternalFileUploadOptions internalOptions = CreateInternalUploadOptions(purpose, options);
+
+        using MultiPartFormDataBinaryContent content = internalOptions.ToMultipartContent(file, filename);
         ClientResult result = await UploadFileAsync(content, content.ContentType, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         return ClientResult.FromValue((OpenAIFile)result, result.GetRawResponse());
     }
@@ -145,12 +171,38 @@ public partial class OpenAIFileClient
         Argument.AssertNotNull(file, nameof(file));
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
 
-        InternalFileUploadOptions options = new()
+        InternalFileUploadOptions internalOptions = new()
         {
             Purpose = purpose
         };
 
-        using MultiPartFormDataBinaryContent content = options.ToMultipartContent(file, filename);
+        using MultiPartFormDataBinaryContent content = internalOptions.ToMultipartContent(file, filename);
+        ClientResult result = UploadFile(content, content.ContentType, cancellationToken.ToRequestOptions());
+        return ClientResult.FromValue((OpenAIFile)result, result.GetRawResponse());
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file stream to upload. </param>
+    /// <param name="filename">
+    ///     The filename associated with the file stream. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="options"> Additional options for the file upload. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, FileUploadOptions options, CancellationToken cancellationToken = default)
+    {
+        Argument.AssertNotNull(file, nameof(file));
+        Argument.AssertNotNullOrEmpty(filename, nameof(filename));
+
+        InternalFileUploadOptions internalOptions = CreateInternalUploadOptions(purpose, options);
+
+        using MultiPartFormDataBinaryContent content = internalOptions.ToMultipartContent(file, filename);
         ClientResult result = UploadFile(content, content.ContentType, cancellationToken.ToRequestOptions());
         return ClientResult.FromValue((OpenAIFile)result, result.GetRawResponse());
     }
@@ -183,6 +235,27 @@ public partial class OpenAIFileClient
     ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="options"> Additional options for the file upload. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose, FileUploadOptions options)
+    {
+        Argument.AssertNotNull(file, nameof(file));
+        Argument.AssertNotNullOrEmpty(filename, nameof(filename));
+
+        return UploadFileAsync(file?.ToStream(), filename, purpose, options);
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file bytes to upload. </param>
+    /// <param name="filename">
+    ///     The filename associated with the file bytes. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
     public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose)
@@ -191,6 +264,27 @@ public partial class OpenAIFileClient
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
 
         return UploadFile(file?.ToStream(), filename, purpose);
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file bytes to upload. </param>
+    /// <param name="filename">
+    ///     The filename associated with the file bytes. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="options"> Additional options for the file upload. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose, FileUploadOptions options)
+    {
+        Argument.AssertNotNull(file, nameof(file));
+        Argument.AssertNotNullOrEmpty(filename, nameof(filename));
+
+        return UploadFile(file?.ToStream(), filename, purpose, options);
     }
 
     /// <summary> Uploads a file that can be used across various operations. </summary>
@@ -219,6 +313,26 @@ public partial class OpenAIFileClient
     ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="options"> Additional options for the file upload. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filePath"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose, FileUploadOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(filePath, nameof(filePath));
+
+        using FileStream stream = File.OpenRead(filePath);
+        return await UploadFileAsync(stream, filePath, purpose, options).ConfigureAwait(false);
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="filePath">
+    ///     The path of the file to upload. The provided file path's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the file path's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filePath"/> is an empty string, and was expected to be non-empty. </exception>
     public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose)
@@ -227,6 +341,26 @@ public partial class OpenAIFileClient
 
         using FileStream stream = File.OpenRead(filePath);
         return UploadFile(stream, filePath, purpose);
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="filePath">
+    ///     The path of the file to upload. The provided file path's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the file path's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="options"> Additional options for the file upload. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filePath"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose, FileUploadOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(filePath, nameof(filePath));
+
+        using FileStream stream = File.OpenRead(filePath);
+        return UploadFile(stream, filePath, purpose, options);
     }
 
     /// <summary> Gets basic information about each of the files belonging to the user's organization. </summary>
@@ -339,5 +473,28 @@ public partial class OpenAIFileClient
 
         ClientResult result = DownloadFile(fileId, cancellationToken.ToRequestOptions());
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
+    }
+
+    // CUSTOM: Helper constant for converting days to seconds
+    private const int SecondsPerDay = 24 * 60 * 60;
+
+    // CUSTOM: Helper constant for the expiration anchor (always "created_at" per OpenAI spec)
+    private const string ExpirationAnchor = "created_at";
+
+    // CUSTOM: Helper method to create internal upload options from public options
+    private static InternalFileUploadOptions CreateInternalUploadOptions(FileUploadPurpose purpose, FileUploadOptions options)
+    {
+        InternalFileUploadOptions internalOptions = new()
+        {
+            Purpose = purpose
+        };
+
+        if (options?.ExpiresAfterDays != null)
+        {
+            int expirationSeconds = options.ExpiresAfterDays.Value * SecondsPerDay;
+            internalOptions.ExpiresAfter = new InternalFileExpirationAfter(ExpirationAnchor, expirationSeconds);
+        }
+
+        return internalOptions;
     }
 }


### PR DESCRIPTION
Exposes the new optional `expires_after` property from the OpenAI Files API spec via a public `FileUploadOptions` class, following the SDK pattern where optional properties live in an options class.

### Changes

- **`FileUploadOptions`**: New public class with `ExpiresAfterDays` property (validated > 0)
- **`OpenAIFileClient`**: Added overloads for all `UploadFile`/`UploadFileAsync` variants accepting `FileUploadOptions`
- **`InternalFileUploadOptions`**: Updated `ToMultipartContent` to serialize `expires_after` when set
- **Tests**: Coverage for request serialization, all source types (Stream/BinaryData/path), and validation
- **Docs**: Updated README and CHANGELOG

### Usage

```csharp
FileUploadOptions options = new()
{
    ExpiresAfterDays = 7
};

OpenAIFile file = fileClient.UploadFile(
    stream,
    "temp.json",
    FileUploadPurpose.Assistants,
    options);
```

The new overloads and `FileUploadOptions.ExpiresAfterDays` are marked `[Experimental("OPENAI001")]` consistent with other preview features.

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> Implement this feature https://github.com/openai/openai-dotnet/issues/896 with 100% coverage and updated documentaation


</details>

