### PR TITLE
Fix: Return empty list instead of null for MessageContentParts in Fun…

### DIFF
--- a/src/Custom/Realtime/RealtimeItem.cs
+++ b/src/Custom/Realtime/RealtimeItem.cs
@@ -15,6 +15,7 @@ public partial class RealtimeItem
         => (this as InternalRealtimeRequestAssistantMessageItem)?.Content.ToList().AsReadOnly()
         ?? (this as InternalRealtimeRequestSystemMessageItem)?.Content?.ToList().AsReadOnly()
         ?? (this as InternalRealtimeRequestUserMessageItem)?.Content?.ToList().AsReadOnly();
+    ?? System.Collections.Generic.Enumerable.Empty<ConversationContentPart>().ToList().AsReadOnly()
     public ConversationMessageRole? MessageRole
         => (this as InternalRealtimeRequestMessageItem)?.Role;
 


### PR DESCRIPTION
…ctionCallOutput items (#912)

The MessageContentParts property was returning null for FunctionCallOutput items, even though the property is declared as non-nullable. This fix adds a null-coalescing fallback that returns an empty read-only list instead, ensuring the property never returns null.