### PR TITLE
Rename `GeneratedImageQuality` values

### DIFF
--- a/api/OpenAI.net10.0.cs
+++ b/api/OpenAI.net10.0.cs
@@ -3693,13 +3693,13 @@ namespace OpenAI.Images {
         public GeneratedImageQuality(string value);
         [Experimental("OPENAI001")]
         public static GeneratedImageQuality Auto { get; }
-        [Experimental("OPENAI001")]
-        public static GeneratedImageQuality HD { get; }
         public static GeneratedImageQuality High { get; }
         [Experimental("OPENAI001")]
-        public static GeneratedImageQuality Low { get; }
+        public static GeneratedImageQuality HighQuality { get; }
         [Experimental("OPENAI001")]
-        public static GeneratedImageQuality Medium { get; }
+        public static GeneratedImageQuality LowQuality { get; }
+        [Experimental("OPENAI001")]
+        public static GeneratedImageQuality MediumQuality { get; }
         public static GeneratedImageQuality Standard { get; }
         public readonly bool Equals(GeneratedImageQuality other);
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/api/OpenAI.net8.0.cs
+++ b/api/OpenAI.net8.0.cs
@@ -3693,13 +3693,13 @@ namespace OpenAI.Images {
         public GeneratedImageQuality(string value);
         [Experimental("OPENAI001")]
         public static GeneratedImageQuality Auto { get; }
-        [Experimental("OPENAI001")]
-        public static GeneratedImageQuality HD { get; }
         public static GeneratedImageQuality High { get; }
         [Experimental("OPENAI001")]
-        public static GeneratedImageQuality Low { get; }
+        public static GeneratedImageQuality HighQuality { get; }
         [Experimental("OPENAI001")]
-        public static GeneratedImageQuality Medium { get; }
+        public static GeneratedImageQuality LowQuality { get; }
+        [Experimental("OPENAI001")]
+        public static GeneratedImageQuality MediumQuality { get; }
         public static GeneratedImageQuality Standard { get; }
         public readonly bool Equals(GeneratedImageQuality other);
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/api/OpenAI.netstandard2.0.cs
+++ b/api/OpenAI.netstandard2.0.cs
@@ -3201,10 +3201,10 @@ namespace OpenAI.Images {
     public readonly partial struct GeneratedImageQuality : IEquatable<GeneratedImageQuality> {
         public GeneratedImageQuality(string value);
         public static GeneratedImageQuality Auto { get; }
-        public static GeneratedImageQuality HD { get; }
         public static GeneratedImageQuality High { get; }
-        public static GeneratedImageQuality Low { get; }
-        public static GeneratedImageQuality Medium { get; }
+        public static GeneratedImageQuality HighQuality { get; }
+        public static GeneratedImageQuality LowQuality { get; }
+        public static GeneratedImageQuality MediumQuality { get; }
         public static GeneratedImageQuality Standard { get; }
         public readonly bool Equals(GeneratedImageQuality other);
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Custom/Images/GeneratedImageQuality.cs
+++ b/src/Custom/Images/GeneratedImageQuality.cs
@@ -12,7 +12,21 @@ namespace OpenAI.Images;
 public readonly partial struct GeneratedImageQuality
 {
     // CUSTOM: Renamed.
-    [Experimental("OPENAI001")]
     [CodeGenMember("Hd")]
-    public static GeneratedImageQuality HD { get; } = new GeneratedImageQuality(HdValue);
+    public static GeneratedImageQuality High { get; } = new GeneratedImageQuality(HdValue);
+
+    // CUSTOM: Renamed.
+    [Experimental("OPENAI001")]
+    [CodeGenMember("Low")]
+    public static GeneratedImageQuality LowQuality { get; } = new GeneratedImageQuality(LowValue);
+
+    // CUSTOM: Renamed.
+    [Experimental("OPENAI001")]
+    [CodeGenMember("Medium")]
+    public static GeneratedImageQuality MediumQuality { get; } = new GeneratedImageQuality(MediumValue);
+
+    // CUSTOM: Renamed.
+    [Experimental("OPENAI001")]
+    [CodeGenMember("High")]
+    public static GeneratedImageQuality HighQuality { get; } = new GeneratedImageQuality(HighValue);
 }

--- a/src/Generated/Models/Images/GeneratedImageQuality.cs
+++ b/src/Generated/Models/Images/GeneratedImageQuality.cs
@@ -29,14 +29,6 @@ namespace OpenAI.Images
         public static GeneratedImageQuality Standard { get; } = new GeneratedImageQuality(StandardValue);
 
         [Experimental("OPENAI001")]
-        public static GeneratedImageQuality Low { get; } = new GeneratedImageQuality(LowValue);
-
-        [Experimental("OPENAI001")]
-        public static GeneratedImageQuality Medium { get; } = new GeneratedImageQuality(MediumValue);
-
-        public static GeneratedImageQuality High { get; } = new GeneratedImageQuality(HighValue);
-
-        [Experimental("OPENAI001")]
         public static GeneratedImageQuality Auto { get; } = new GeneratedImageQuality(AutoValue);
 
         public static bool operator ==(GeneratedImageQuality left, GeneratedImageQuality right) => left.Equals(right);

--- a/tests/Images/ImageEditsTests.cs
+++ b/tests/Images/ImageEditsTests.cs
@@ -67,7 +67,7 @@ public partial class ImageEditsTests : ImageTestFixtureBase
         ImageEditOptions options = new()
         {
             Background = GeneratedImageBackground.Opaque,
-            Quality = GeneratedImageQuality.Low,
+            Quality = GeneratedImageQuality.LowQuality,
             Size = GeneratedImageSize.W1024xH1024
         };
 


### PR DESCRIPTION
Avoid a behavioral breaking change by making `High` continue to mean "hd" and then add `HighQuality` to mean "high".

`High` -> "hd"
`HighQuality` -> "high"
`MediumQuality` -> "medium"
`LowQuality` -> "low"