### PR TITLE
[Responses] File URL support for response content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.10.0-beta.1 (Unreleased)
 
+### Features Added
+
+- OpenAI.Responses:
+  - Added `InputFileUri` property and `CreateInputFilePart(Uri)` factory method to `ResponseContentPart` to support file URL inputs.
+
 ### Bugs Fixed
 
 - OpenAI.Chat:

--- a/api/OpenAI.net10.0.cs
+++ b/api/OpenAI.net10.0.cs
@@ -7187,6 +7187,7 @@ namespace OpenAI.Responses {
         public string InputFileBytesMediaType { get; }
         public string InputFileId { get; }
         public string InputFilename { get; }
+        public Uri InputFileUri { get; }
         public ResponseImageDetailLevel? InputImageDetailLevel { get; }
         public string InputImageFileId { get; }
         public Uri InputImageUri { get; }
@@ -7200,6 +7201,7 @@ namespace OpenAI.Responses {
         public string Text { get; }
         public static ResponseContentPart CreateInputFilePart(BinaryData fileBytes, string fileBytesMediaType, string filename);
         public static ResponseContentPart CreateInputFilePart(string fileId);
+        public static ResponseContentPart CreateInputFilePart(Uri fileUri);
         public static ResponseContentPart CreateInputImagePart(string imageFileId, ResponseImageDetailLevel? imageDetailLevel = null);
         public static ResponseContentPart CreateInputImagePart(Uri imageUri, ResponseImageDetailLevel? imageDetailLevel = null);
         public static ResponseContentPart CreateInputTextPart(string text);

--- a/api/OpenAI.net8.0.cs
+++ b/api/OpenAI.net8.0.cs
@@ -7187,6 +7187,7 @@ namespace OpenAI.Responses {
         public string InputFileBytesMediaType { get; }
         public string InputFileId { get; }
         public string InputFilename { get; }
+        public Uri InputFileUri { get; }
         public ResponseImageDetailLevel? InputImageDetailLevel { get; }
         public string InputImageFileId { get; }
         public Uri InputImageUri { get; }
@@ -7200,6 +7201,7 @@ namespace OpenAI.Responses {
         public string Text { get; }
         public static ResponseContentPart CreateInputFilePart(BinaryData fileBytes, string fileBytesMediaType, string filename);
         public static ResponseContentPart CreateInputFilePart(string fileId);
+        public static ResponseContentPart CreateInputFilePart(Uri fileUri);
         public static ResponseContentPart CreateInputImagePart(string imageFileId, ResponseImageDetailLevel? imageDetailLevel = null);
         public static ResponseContentPart CreateInputImagePart(Uri imageUri, ResponseImageDetailLevel? imageDetailLevel = null);
         public static ResponseContentPart CreateInputTextPart(string text);

--- a/api/OpenAI.netstandard2.0.cs
+++ b/api/OpenAI.netstandard2.0.cs
@@ -6293,6 +6293,7 @@ namespace OpenAI.Responses {
         public string InputFileBytesMediaType { get; }
         public string InputFileId { get; }
         public string InputFilename { get; }
+        public Uri InputFileUri { get; }
         public ResponseImageDetailLevel? InputImageDetailLevel { get; }
         public string InputImageFileId { get; }
         public Uri InputImageUri { get; }
@@ -6305,6 +6306,7 @@ namespace OpenAI.Responses {
         public string Text { get; }
         public static ResponseContentPart CreateInputFilePart(BinaryData fileBytes, string fileBytesMediaType, string filename);
         public static ResponseContentPart CreateInputFilePart(string fileId);
+        public static ResponseContentPart CreateInputFilePart(Uri fileUri);
         public static ResponseContentPart CreateInputImagePart(string imageFileId, ResponseImageDetailLevel? imageDetailLevel = null);
         public static ResponseContentPart CreateInputImagePart(Uri imageUri, ResponseImageDetailLevel? imageDetailLevel = null);
         public static ResponseContentPart CreateInputTextPart(string text);

--- a/specification/base/typespec/responses/models.tsp
+++ b/specification/base/typespec/responses/models.tsp
@@ -1236,6 +1236,9 @@ model ItemContentInputFile extends ItemContent {
   /** The ID of the file to be sent to the model. */
   file_id?: string | null;
 
+  /** The URL of the file to be sent to the model. */
+  file_url?: url | null;
+
   /** The name of the file to be sent to the model. */
   filename?: string;
 

--- a/src/Custom/Responses/Internal/InternalItemContentInputFile.cs
+++ b/src/Custom/Responses/Internal/InternalItemContentInputFile.cs
@@ -25,7 +25,7 @@ internal partial class InternalItemContentInputFile
     private string _internalFileData;
 
     public InternalItemContentInputFile(string filename, BinaryData fileBytes, string fileBytesMediaType)
-        : this(InternalItemContentType.InputFile, default, null, filename, null)
+        : this(InternalItemContentType.InputFile, default, null, null, filename, null)
     {
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
         Argument.AssertNotNull(fileBytes, nameof(fileBytes));

--- a/src/Custom/Responses/ResponseContentPart.cs
+++ b/src/Custom/Responses/ResponseContentPart.cs
@@ -33,6 +33,7 @@ public partial class ResponseContentPart
     // CUSTOM: Exposed input file properties.
     public string InputFileId => (this as InternalItemContentInputFile)?.FileId;
     public string InputFilename => (this as InternalItemContentInputFile)?.Filename;
+    public Uri InputFileUri => (this as InternalItemContentInputFile)?.FileUrl;
     public BinaryData InputFileBytes => (this as InternalItemContentInputFile)?.InternalFileBytes;
     public string InputFileBytesMediaType => (this as InternalItemContentInputFile)?.InternalFileBytesMediaType;
 
@@ -80,6 +81,16 @@ public partial class ResponseContentPart
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
 
         return new InternalItemContentInputFile(filename, fileBytes, fileBytesMediaType);
+    }
+
+    public static ResponseContentPart CreateInputFilePart(Uri fileUri)
+    {
+        Argument.AssertNotNull(fileUri, nameof(fileUri));
+
+        return new InternalItemContentInputFile()
+        {
+            FileUrl = fileUri,
+        };
     }
 
     public static ResponseContentPart CreateOutputTextPart(string text, IEnumerable<ResponseMessageAnnotation> annotations)

--- a/src/Generated/Models/Responses/InternalItemContentInputFile.Serialization.cs
+++ b/src/Generated/Models/Responses/InternalItemContentInputFile.Serialization.cs
@@ -41,6 +41,11 @@ namespace OpenAI.Responses
                 writer.WritePropertyName("file_id"u8);
                 writer.WriteStringValue(FileId);
             }
+            if (Optional.IsDefined(FileUrl) && !Patch.Contains("$.file_url"u8))
+            {
+                writer.WritePropertyName("file_url"u8);
+                writer.WriteStringValue(FileUrl.AbsoluteUri);
+            }
             if (Optional.IsDefined(Filename) && !Patch.Contains("$.filename"u8))
             {
                 writer.WritePropertyName("filename"u8);
@@ -80,6 +85,7 @@ namespace OpenAI.Responses
             JsonPatch patch = new JsonPatch(data is null ? ReadOnlyMemory<byte>.Empty : data.ToMemory());
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
             string fileId = default;
+            Uri fileUrl = default;
             string filename = default;
             string internalFileData = default;
             foreach (var prop in element.EnumerateObject())
@@ -99,6 +105,16 @@ namespace OpenAI.Responses
                     fileId = prop.Value.GetString();
                     continue;
                 }
+                if (prop.NameEquals("file_url"u8))
+                {
+                    if (prop.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        fileUrl = null;
+                        continue;
+                    }
+                    fileUrl = string.IsNullOrEmpty(prop.Value.GetString()) ? null : new Uri(prop.Value.GetString());
+                    continue;
+                }
                 if (prop.NameEquals("filename"u8))
                 {
                     filename = prop.Value.GetString();
@@ -111,7 +127,13 @@ namespace OpenAI.Responses
                 }
                 patch.Set([.. "$."u8, .. Encoding.UTF8.GetBytes(prop.Name)], prop.Value.GetUtf8Bytes());
             }
-            return new InternalItemContentInputFile(internalType, patch, fileId, filename, internalFileData);
+            return new InternalItemContentInputFile(
+                internalType,
+                patch,
+                fileId,
+                fileUrl,
+                filename,
+                internalFileData);
         }
 
         BinaryData IPersistableModel<InternalItemContentInputFile>.Write(ModelReaderWriterOptions options) => PersistableModelWriteCore(options);

--- a/src/Generated/Models/Responses/InternalItemContentInputFile.cs
+++ b/src/Generated/Models/Responses/InternalItemContentInputFile.cs
@@ -2,26 +2,30 @@
 
 #nullable disable
 
+using System;
 using System.ClientModel.Primitives;
 
 namespace OpenAI.Responses
 {
     internal partial class InternalItemContentInputFile : ResponseContentPart
     {
-        public InternalItemContentInputFile() : this(InternalItemContentType.InputFile, default, null, null, null)
+        public InternalItemContentInputFile() : this(InternalItemContentType.InputFile, default, null, null, null, null)
         {
         }
 
 #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-        internal InternalItemContentInputFile(InternalItemContentType internalType, in JsonPatch patch, string fileId, string filename, string internalFileData) : base(internalType, patch)
+        internal InternalItemContentInputFile(InternalItemContentType internalType, in JsonPatch patch, string fileId, Uri fileUrl, string filename, string internalFileData) : base(internalType, patch)
         {
             FileId = fileId;
+            FileUrl = fileUrl;
             Filename = filename;
             InternalFileData = internalFileData;
         }
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
         public string FileId { get; set; }
+
+        public Uri FileUrl { get; set; }
 
         public string Filename { get; set; }
     }

--- a/tests/Responses/ResponsesSmokeTests.cs
+++ b/tests/Responses/ResponsesSmokeTests.cs
@@ -194,6 +194,32 @@ public partial class ResponsesSmokeTests
     }
 
     [Test]
+    public void StableInputFileUrlContentPartSerialization()
+    {
+        static void AssertExpectedFilePart(ResponseContentPart filePart)
+        {
+            Assert.That(filePart.Kind, Is.EqualTo(ResponseContentPartKind.InputFile));
+            Assert.That(filePart.InputFileUri, Is.EqualTo("https://example.com/document.pdf"));
+            Assert.That(filePart.InputFileId, Is.Null);
+            Assert.That(filePart.InputFileBytes, Is.Null);
+            Assert.That(filePart.InputFileBytesMediaType, Is.Null);
+            Assert.That(filePart.InputFilename, Is.Null);
+        }
+
+        ResponseContentPart filePart = ResponseContentPart.CreateInputFilePart(
+            new Uri("https://example.com/document.pdf"));
+
+        AssertExpectedFilePart(filePart);
+
+        BinaryData serializedFilePart = ModelReaderWriter.Write(filePart);
+        Assert.That(serializedFilePart, Is.Not.Null);
+
+        ResponseContentPart deserializedFilePart = ModelReaderWriter.Read<ResponseContentPart>(serializedFilePart);
+
+        AssertExpectedFilePart(deserializedFilePart);
+    }
+
+    [Test]
     public void StableInputImageDataContentPartSerialization()
     {
         static void AssertExpectedImagePart(ResponseContentPart filePart)


### PR DESCRIPTION
# Summary

The focus of these changes is to add support for `file_url` support to `ResponseContentPart`.     

fixes #902.


## References and resources

- [[FEATURE REQ] ResponseContentPart.CreateInputFilePart with file_url (#902)](https://github.com/openai/openai-dotnet/issues/902)