### PR TITLE
Propagate central package version metadata

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,6 +2,33 @@
 
   <!--
     ==============================================================
+      Central Package Management Metadata Propagation
+
+      CPM does not propagate metadata such as PrivateAssets from 
+      PackageVersion to PackageReference. This bridges that gap 
+      so the intent can be declared centrally in Directory.Packages.props.
+
+      This must operate at evaluation time (not inside a Target) for
+      NuGet restore to observe the metadata. MSBuild evaluation does
+      not support dynamic metadata inspection, so each known NuGet
+      metadata type is handled explicitly.
+    ==============================================================
+  -->
+
+  <ItemGroup>
+    <_CpmPrivateAssets Include="@(PackageVersion->HasMetadata('PrivateAssets'))" />
+    <_CpmIncludeAssets Include="@(PackageVersion->HasMetadata('IncludeAssets'))" />
+    <_CpmExcludeAssets Include="@(PackageVersion->HasMetadata('ExcludeAssets'))" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="@(_CpmPrivateAssets)" PrivateAssets="%(_CpmPrivateAssets.PrivateAssets)" />
+    <PackageReference Update="@(_CpmIncludeAssets)" IncludeAssets="%(_CpmIncludeAssets.IncludeAssets)" />
+    <PackageReference Update="@(_CpmExcludeAssets)" ExcludeAssets="%(_CpmExcludeAssets.ExcludeAssets)" />
+  </ItemGroup>
+
+  <!--
+    ==============================================================
       GenAPI Target: Generate public API surface
     ==============================================================
   -->

--- a/src/OpenAI.csproj
+++ b/src/OpenAI.csproj
@@ -23,7 +23,7 @@
 
   <!-- Build-only dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
 
   <!-- LEGACY: Azure OpenAI bridge-->


### PR DESCRIPTION
# Summary

The focus of these changes is to propagate metadata about the package visiblity and scope to each package reference in the individual projects.  These changes supersede #994 and address the underlying issue in a more centralized manner.  The previous fix has been reverted.

## References and resources

- [[BUG] 2.9.0 added Microsoft.SourceLink.GitHub as a _runtime_ dependency (#991)](https://github.com/openai/openai-dotnet/issues/991)
- [Fix Microsoft.SourceLink.GitHub incorrectly surfacing as a runtime dependency (#994)](https://github.com/openai/openai-dotnet/pull/994)

