### PR TITLE
Parallellize ExportApi build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -59,10 +59,15 @@
     <ItemGroup>
       <_ExportApiTargetFramework Include="$(TargetFrameworks)" />
     </ItemGroup>
-    
-    <MSBuild Projects="$(MSBuildProjectFile)"
+
+    <ItemGroup>
+      <_ExportApiProject Include="$(MSBuildProjectFile)"
+                         AdditionalProperties="TargetFramework=%(_ExportApiTargetFramework.Identity);ExportingApi=true" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ExportApiProject)"
              Targets="ExportApiInner"
-             Properties="TargetFramework=%(_ExportApiTargetFramework.Identity);ExportingApi=true" />
+             BuildInParallel="true" />
   </Target>
 
   <!-- Inner build target: Runs for each specific target framework -->

--- a/scripts/Export-Api.ps1
+++ b/scripts/Export-Api.ps1
@@ -70,6 +70,7 @@ $buildArgs = @(
     "-t:ExportApi"
     "-c:$configuration"
     "-p:ExportingApi=true"
+    "-m"
 )
 
 Write-Host "Output Directory: $outputDirectory"


### PR DESCRIPTION
In the `ExportApi` build target, when `%(_ExportApiTargetFramework.Identity)` appears in the `Properties` attribute of the `<MSBuild>` task, MSBuild batches the task. Batching the task executes one separate call per TFM, sequentially, even with `BuildInParallel="true"`. 

This fix moves the per-TFM property into `AdditionalProperties` metadata on intermediate `_ExportApiProject` items. This way all project items are passed to the `<MSBuild>` task in a single invocation via `@(_ExportApiProject)`, and `BuildInParallel="true"` can actually dispatch them across multiple MSBuild nodes concurrently enabled by adding the `-m` flag to the Export-Api.ps1 script.