### PR TITLE
[Embeddings] Fix JSON escape sequence handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## Unreleased
+
+### Bugs Fixed
+
+- OpenAI.Embeddings:
+  - Fixed an issue where base64-encoded embedding values containing JSON escape sequences (e.g., `\/` or `\u002F` for `/`) failed to decode, causing a `FormatException`. Per RFC 8259 §7, these are valid JSON representations that the OpenAI API may produce.
+
 ## 2.9.1 (2026-03-02)
 
 ### Features Added

--- a/src/Custom/Embeddings/OpenAIEmbedding.cs
+++ b/src/Custom/Embeddings/OpenAIEmbedding.cs
@@ -5,6 +5,7 @@ using System.Buffers.Binary;
 using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 
 namespace OpenAI.Embeddings;
@@ -66,22 +67,47 @@ public partial class OpenAIEmbedding
         return ConvertFromJsonArray(binaryData);
     }
 
-    private static ReadOnlyMemory<float> ConvertFromBase64(ReadOnlySpan<byte> base64)
+    private static ReadOnlyMemory<float> ConvertFromBase64(ReadOnlySpan<byte> quotedBase64)
     {
-        base64 = base64.Slice(1, base64.Length - 2);
+        scoped ReadOnlySpan<byte> base64 = quotedBase64.Slice(1, quotedBase64.Length - 2);
 
-        // Decode base64 string to bytes.
+        // Per RFC 8259 §7, JSON strings may contain escape sequences (e.g., '\/' for '/').
+        // Since '/' is a valid base64 character, we must unescape before decoding.
+        byte[] unescaped = null;
         byte[] bytes = null;
+
         try
         {
+            if (base64.IndexOf((byte)'\\') >= 0)
+            {
+                Utf8JsonReader reader = new(quotedBase64);
+                reader.Read();
+
+#if NET8_0_OR_GREATER
+                unescaped = ArrayPool<byte>.Shared.Rent(base64.Length);
+                base64 = unescaped.AsSpan(0, reader.CopyString(unescaped));
+#else
+                base64 = Encoding.UTF8.GetBytes(reader.GetString()!);
+#endif
+            }
+
+            // Decode base64 string to bytes.
             bytes = ArrayPool<byte>.Shared.Rent(Base64.GetMaxDecodedFromUtf8Length(base64.Length));
-            OperationStatus status = Base64.DecodeFromUtf8(base64, bytes.AsSpan(), out int bytesConsumed, out int bytesWritten);
+            OperationStatus status = Base64.DecodeFromUtf8(base64, bytes.AsSpan(), out _, out int bytesWritten);
+
+            // Done with the unescape buffer — release before validation and float conversion.
+            if (unescaped is not null)
+            {
+                ArrayPool<byte>.Shared.Return(unescaped);
+                unescaped = null;
+            }
+
             if (status != OperationStatus.Done || bytesWritten % sizeof(float) != 0)
             {
                 ThrowInvalidData();
             }
 
-            // Interpret bytes as floats
+            // Interpret bytes as floats.
             float[] vector = new float[bytesWritten / sizeof(float)];
             bytes.AsSpan(0, bytesWritten).CopyTo(MemoryMarshal.AsBytes(vector.AsSpan()));
             if (!BitConverter.IsLittleEndian)
@@ -101,6 +127,10 @@ public partial class OpenAIEmbedding
         }
         finally
         {
+            if (unescaped is not null)
+            {
+                ArrayPool<byte>.Shared.Return(unescaped);
+            }
             if (bytes is not null)
             {
                 ArrayPool<byte>.Shared.Return(bytes);

--- a/tests/Embeddings/EmbeddingsMockTests.cs
+++ b/tests/Embeddings/EmbeddingsMockTests.cs
@@ -207,6 +207,54 @@ public class EmbeddingsMockTests : ClientTestBase
     }
 
     [Test]
+    public async Task GenerateEmbeddingDeserializesBase64WithEscapedSolidus()
+    {
+        // Float values [1.9921875, -1.99710083] encode to base64 "AAD/PwCh/78=" which contains '/'.
+        // Per RFC 8259 §7, JSON may escape '/' as '\/', producing "AAD\/PwCh\/78=".
+        // The SDK must handle this correctly.
+        OpenAIClientOptions clientOptions = GetClientOptionsWithMockResponse(200, """
+        {
+            "data": [
+                {
+                    "embedding": "AAD\/PwCh\/78="
+                }
+            ]
+        }
+        """);
+        EmbeddingClient client = CreateProxyFromClient(new EmbeddingClient("model", s_fakeCredential, clientOptions));
+
+        OpenAIEmbedding embedding = await client.GenerateEmbeddingAsync("prompt");
+
+        float[] vector = embedding.ToFloats().ToArray();
+        Assert.That(vector.Length, Is.EqualTo(2));
+        Assert.That(vector[0], Is.EqualTo(1.9921875f));
+        Assert.That(vector[1], Is.EqualTo(-1.99710083f));
+    }
+
+    [Test]
+    public async Task GenerateEmbeddingDeserializesBase64WithUnicodeEscapedSolidus()
+    {
+        // Same float values as above, but '/' is escaped as '\u002F' instead of '\/'.
+        OpenAIClientOptions clientOptions = GetClientOptionsWithMockResponse(200, """
+        {
+            "data": [
+                {
+                    "embedding": "AAD\u002FPwCh\u002F78="
+                }
+            ]
+        }
+        """);
+        EmbeddingClient client = CreateProxyFromClient(new EmbeddingClient("model", s_fakeCredential, clientOptions));
+
+        OpenAIEmbedding embedding = await client.GenerateEmbeddingAsync("prompt");
+
+        float[] vector = embedding.ToFloats().ToArray();
+        Assert.That(vector.Length, Is.EqualTo(2));
+        Assert.That(vector[0], Is.EqualTo(1.9921875f));
+        Assert.That(vector[1], Is.EqualTo(-1.99710083f));
+    }
+
+    [Test]
     public void JsonArraySupport()
     {
         string json = """


### PR DESCRIPTION
# Summary

The focus of these changes is to ensure that legal JSON escape sequences in the base64 string (e.g., '\/' for '/') are properly unescaped before decoding.

## References and related

- [[BUG] Improper embedding deserialization when escaped (#1041)](https://github.com/openai/openai-dotnet/issues/1041)
- [RFC 8259 §7](https://datatracker.ietf.org/doc/html/rfc8259#section-7)