### PR TITLE
docs: fix typo in GeneratedImageFormat comment

### DIFF
--- a/src/Custom/Images/GeneratedImageFormat.cs
+++ b/src/Custom/Images/GeneratedImageFormat.cs
@@ -14,7 +14,7 @@ public readonly partial struct GeneratedImageFormat
 
     // CUSTOM: Renamed.
     /// <summary>
-    ///     Returned as a URI pointing to a temporary internet location from where the image can be downlaoded. This
+    ///     Returned as a URI pointing to a temporary internet location from where the image can be downloaded. This
     ///     URI is only valid for 60 minutes after the image is generated.
     /// </summary>
     [CodeGenMember("Url")]


### PR DESCRIPTION
## Summary

Fix a typo in the `GeneratedImageFormat` XML summary comment.

## Related issue

N/A

## Guideline alignment

- CONTRIBUTING: https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md

## Validation

- Not run; comment-only change.
