### PR TITLE
docs: fix typo in RunCreationOptions XML summary

### DIFF
--- a/src/Custom/Assistants/RunCreationOptions.cs
+++ b/src/Custom/Assistants/RunCreationOptions.cs
@@ -103,7 +103,7 @@ public partial class RunCreationOptions
     [CodeGenMember("Tools")]
     public IList<ToolDefinition> ToolsOverride { get; }
 
-    /// <summary> Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. </summary>
+    /// <summary> Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maximum of 512 characters long. </summary>
     public IDictionary<string, string> Metadata { get; }
 
     /// <summary> What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. </summary>


### PR DESCRIPTION
## Summary
- fix the `maxium` typo in the `RunCreationOptions` XML summary

## Related issue
- N/A

## Guideline alignment
- Reviewed [CONTRIBUTING.md](https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md)
- Kept this to a single doc-comment change in one hand-written `src/Custom/` file
- No generated files or behavior changes

## Validation/testing note
- Not run locally; XML-doc-only change
