### PR TITLE
docs: fix typo in telemetry finish reason comment

### DIFF
--- a/src/Utility/Telemetry/OpenTelemetryScope.cs
+++ b/src/Utility/Telemetry/OpenTelemetryScope.cs
@@ -168,7 +168,7 @@ internal class OpenTelemetryScope : IDisposable
             _ => finishReason.ToString(),
         };
 
-        // There could be multiple finish reasons, so semantic conventions use array type for the corrresponding attribute.
+        // There could be multiple finish reasons, so semantic conventions use array type for the corresponding attribute.
         // It's likely to change, but for now let's report it as array.
         _activity.SetTag(GenAiResponseFinishReasonKey, new[] { reasonStr });
     }


### PR DESCRIPTION
## Summary

Fix a typo in the telemetry finish-reason comment in `OpenTelemetryScope.cs`.

## Related issue

N/A. This is a trivial comment-only fix.

## Guideline alignment

- Followed the repository contributing guide: https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md
- The change is limited to a hand-written source comment and does not touch generated files or behavior.

## Validation/testing

Not run. This is a comment-only change.
