### PR TITLE
Fix typo in MCP guide sample comment

### DIFF
--- a/docs/guides/mcp/chat_with_mcp.cs
+++ b/docs/guides/mcp/chat_with_mcp.cs
@@ -22,7 +22,7 @@ IMcpClient mcpClient = await McpClientFactory.CreateAsync(new StdioClientTranspo
     Arguments = [],
 }));
 
-// get avaliable tools and add them to completion options
+// get available tools and add them to completion options
 ChatCompletionOptions options = new();
 await foreach (McpClientTool tool in mcpClient.EnumerateToolsAsync())
 {


### PR DESCRIPTION
## Summary
- Fix the `avaliable` typo in the MCP guide sample comment.

## Related issue
- N/A

## Guideline alignment
- Docs-only change in `docs/`.
- No generated files or behavior changes.

## Validation
- Not run locally; this is a comment-only docs change.
