### PR TITLE
docs: fix macOS naming in getting started guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ This readme shows you how to run each OpenAI based sample (.cs) file in this fol
     winget install Microsoft.DotNet.SDK.10
     ```
 
-- Mac OS
+- macOS
 
     ```bash
     # Install .NET 10 SDK Preview


### PR DESCRIPTION
## Summary
- fix the `macOS` naming in `docs/README.md`.

## Related issue
- N/A; trivial docs/comment fix.

## Guideline alignment
- Followed https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md and kept this to a single docs file with no code changes.

## Validation
- Not run; docs/comment-only change.
