### PR TITLE
docs: fix typo in OpenAIFileCollection comment

### DIFF
--- a/src/Custom/Files/OpenAIFileCollection.cs
+++ b/src/Custom/Files/OpenAIFileCollection.cs
@@ -16,7 +16,7 @@ public partial class OpenAIFileCollection : ReadOnlyCollection<OpenAIFile>
     [CodeGenMember("Object")]
     private string Object { get; } = "list";
 
-    // CUSTOM: Internalizing pending stanardized pagination representation for the list operation.
+    // CUSTOM: Internalizing pending standardized pagination representation for the list operation.
     [CodeGenMember("FirstId")]
     internal string FirstId { get; }
 


### PR DESCRIPTION
## Summary
- fix `stanardized` in the hand-written `OpenAIFileCollection` comment

## Related issue
- N/A (trivial comment-only fix)

## Guideline alignment
- Followed https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md
- Change is limited to `src/Custom/`, which the guide marks as hand-written code.

## Validation
- `git diff --check`