### PR TITLE
docs: fix typo in RunTruncationStrategy summary

### DIFF
--- a/src/Custom/Assistants/RunTruncationStrategy.cs
+++ b/src/Custom/Assistants/RunTruncationStrategy.cs
@@ -2,7 +2,7 @@ using Microsoft.TypeSpec.Generator.Customizations;
 
 namespace OpenAI.Assistants
 {
-    /// <summary> Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run. </summary>
+    /// <summary> Controls for how a thread will be truncated prior to the run. Use this to control the initial context window of the run. </summary>
     [CodeGenType("TruncationObject")]
     [CodeGenSuppress(nameof(RunTruncationStrategy), typeof(InternalCreateThreadAndRunRequestTruncationStrategyType))]
     public partial class RunTruncationStrategy


### PR DESCRIPTION
## Summary
- fix `intial` in the `RunTruncationStrategy` XML summary

## Related issue
- N/A (trivial XML-doc fix)

## Guideline alignment
- Followed https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md
- Change is limited to `src/Custom/`, which the guide marks as hand-written code.

## Validation
- `git diff --check`