### PR TITLE
docs: fix typo in ChatCompletion finish-reason docs

### DIFF
--- a/src/Custom/Chat/ChatCompletion.cs
+++ b/src/Custom/Chat/ChatCompletion.cs
@@ -43,7 +43,7 @@ public partial class ChatCompletion
     ///             <see cref="ChatFinishReason.ToolCalls"/> if the model called a tool
     ///         </item>
     ///         <item>
-    ///             <see cref="ChatFinishReason.FunctionCall"/> (obsolte) if the model called a function
+    ///             <see cref="ChatFinishReason.FunctionCall"/> (obsolete) if the model called a function
     ///         </item>
     ///     </list>
     /// </summary>


### PR DESCRIPTION
## Summary
- fix `obsolte` in the `ChatCompletion` finish-reason XML docs

## Related issue
- N/A (trivial XML-doc fix)

## Guideline alignment
- Followed https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md
- Change is limited to `src/Custom/`, which the guide marks as hand-written code.

## Validation
- `git diff --check`