### PR TITLE
docs: fix typo in streaming chat completion docs

### DIFF
--- a/src/Custom/Chat/Streaming/StreamingChatCompletionUpdate.cs
+++ b/src/Custom/Chat/Streaming/StreamingChatCompletionUpdate.cs
@@ -61,7 +61,7 @@ public partial class StreamingChatCompletionUpdate
     ///             <see cref="ChatFinishReason.ToolCalls"/> if the model called a tool
     ///         </item>
     ///         <item>
-    ///             <see cref="ChatFinishReason.FunctionCall"/> (obsolte) if the model called a function
+    ///             <see cref="ChatFinishReason.FunctionCall"/> (obsolete) if the model called a function
     ///         </item>
     ///     </list>
     /// </summary>


### PR DESCRIPTION
## Summary
- fix `obsolte` in the streaming chat completion XML docs

## Related issue
- N/A (trivial XML-doc fix)

## Guideline alignment
- Followed https://github.com/openai/openai-dotnet/blob/main/CONTRIBUTING.md
- Change is limited to `src/Custom/`, which the guide marks as hand-written code.

## Validation
- `git diff --check`