### PR TITLE
docs: fix realtime error comment wording

### DIFF
--- a/src/Custom/Realtime/GA/ServerUpdate/RealtimeServerUpdateError.cs
+++ b/src/Custom/Realtime/GA/ServerUpdate/RealtimeServerUpdateError.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Realtime;
 /// Corresponds to the <c>error</c> server event.
 /// Returned when an error occurs, which could be a client problem or a server
 /// problem. Most errors are recoverable and the session will stay open, we
-/// recommend to implementors to monitor and log error messages by default.
+/// recommend that implementers monitor and log error messages by default.
 /// </summary>
 // CUSTOM: Renamed.
 [CodeGenType("RealtimeServerEventErrorGA")]


### PR DESCRIPTION
## Summary
- Fixes a small XML-doc wording issue in the realtime error event comment.

## Related issue
- N/A

## Guideline alignment
- Single-file hand-written source comment fix
- No generated files touched
- No behavior changes

## Validation
- `git diff --check`
