### PR TITLE
docs: use realtime function-call arguments in sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Thank you to our developer community members who helped to make the OpenAI clien
 
 - Aditya Singh _([GitHub](https://github.com/adityasingh2400))_
 - JS van Dijk _([GitHub](https://github.com/hogeheer499-commits))_
+- Rohan Santhosh Kumar _([GitHub](https://github.com/Rohan5commit))_
 
 ### Features Added
 
@@ -17,6 +18,11 @@ Thank you to our developer community members who helped to make the OpenAI clien
 ### Bugs Fixed
 
 - Fixed streaming responses ending early when the service emits an event that the library does not model. The server-sent event enumerator stopped at the first event that produced no updates, so an unrecognized event in the middle of a stream silently terminated the whole stream and looked like a clean, early completion. Unrecognized events are now skipped and every later update still surfaces. This affects all streaming APIs, including `OpenAI.Assistants`, `OpenAI.Chat`, `OpenAI.Responses`, and `OpenAI.Audio`, on both the synchronous and asynchronous paths. _(A community contribution, courtesy of [adityasingh2400](https://github.com/adityasingh2400))_
+
+### Other Changes
+
+- OpenAI.Realtime:
+  - Updated the function-calling example to parse and validate model-provided arguments before invoking the local function. _(A community contribution, courtesy of [Rohan5commit](https://github.com/Rohan5commit))_
 
 ## 2.13.0 (2026-08-10)
 

--- a/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
+++ b/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace OpenAI.Examples;
@@ -209,9 +210,16 @@ public partial class RealtimeExamples
                         {
                             hasToolCalls = true;
 
-                            Console.WriteLine($">> Calling {functionCallItem.FunctionName} function...");
+                            Console.WriteLine($">> Calling {functionCallItem.FunctionName} function with arguments...");
 
-                            string output = GetCurrentWeather(location: "San Francisco, CA");
+                            using JsonDocument argumentsJson = JsonDocument.Parse(functionCallItem.FunctionArguments);
+                            string location = argumentsJson.RootElement.GetProperty("location").GetString()
+                                ?? throw new InvalidOperationException("Tool call is missing a location.");
+                            string unit = argumentsJson.RootElement.TryGetProperty("unit", out JsonElement unitElement)
+                                ? unitElement.GetString() ?? "celsius"
+                                : "celsius";
+
+                            string output = GetCurrentWeather(location: location, unit: unit);
 
                             RealtimeItem functionCallOutputItem = RealtimeItem.CreateFunctionCallOutputItem(
                                 callId: functionCallItem.CallId,

--- a/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
+++ b/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
@@ -226,9 +226,19 @@ public partial class RealtimeExamples
 
                             string location = locationElement.GetString()
                                 ?? throw new InvalidOperationException("Tool call is missing a location.");
-                            string unit = argumentsJson.RootElement.TryGetProperty("unit", out JsonElement unitElement)
-                                ? unitElement.GetString() ?? "celsius"
-                                : "celsius";
+
+                            string unit = "celsius";
+                            if (argumentsJson.RootElement.TryGetProperty("unit", out JsonElement unitElement))
+                            {
+                                if (unitElement.ValueKind != JsonValueKind.String
+                                    || unitElement.GetString() is not string requestedUnit
+                                    || (requestedUnit != "celsius" && requestedUnit != "fahrenheit"))
+                                {
+                                    throw new InvalidOperationException("Tool call has an invalid unit.");
+                                }
+
+                                unit = requestedUnit;
+                            }
 
                             string output = GetCurrentWeather(location: location, unit: unit);
 

--- a/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
+++ b/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
@@ -212,8 +212,19 @@ public partial class RealtimeExamples
 
                             Console.WriteLine($">> Calling {functionCallItem.FunctionName} function with arguments...");
 
+                            if (!string.Equals(functionCallItem.FunctionName, nameof(GetCurrentWeather), StringComparison.Ordinal))
+                            {
+                                throw new InvalidOperationException($"Unsupported tool call: {functionCallItem.FunctionName}.");
+                            }
+
                             using JsonDocument argumentsJson = JsonDocument.Parse(functionCallItem.FunctionArguments);
-                            string location = argumentsJson.RootElement.GetProperty("location").GetString()
+                            if (!argumentsJson.RootElement.TryGetProperty("location", out JsonElement locationElement)
+                                || locationElement.ValueKind != JsonValueKind.String)
+                            {
+                                throw new InvalidOperationException("Tool call is missing a location.");
+                            }
+
+                            string location = locationElement.GetString()
                                 ?? throw new InvalidOperationException("Tool call is missing a location.");
                             string unit = argumentsJson.RootElement.TryGetProperty("unit", out JsonElement unitElement)
                                 ? unitElement.GetString() ?? "celsius"


### PR DESCRIPTION
## Summary
- Updates the realtime tool-calling sample to use the function arguments returned by the model instead of a hard-coded location.
- Keeps the sample aligned with how a real tool invocation would be wired up.

## Related issue
- Fixes #535

## Guideline alignment
- Single-file example improvement
- No generated files touched

## Validation
- `git diff --check`
- Local `dotnet build` could not be run in this environment because the `dotnet` CLI is unavailable.
