### PR TITLE
examples: use tool call arguments in the realtime sample

### DIFF
--- a/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
+++ b/examples/Realtime/Example01_AudioFromFileWithToolsAsync.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace OpenAI.Examples;
@@ -209,9 +210,17 @@ public partial class RealtimeExamples
                         {
                             hasToolCalls = true;
 
-                            Console.WriteLine($">> Calling {functionCallItem.FunctionName} function...");
+                            using JsonDocument argumentsJson = JsonDocument.Parse(functionCallItem.FunctionArguments.ToString());
+                            string location = argumentsJson.RootElement.TryGetProperty("location", out JsonElement locationElement)
+                                ? locationElement.GetString() ?? "San Francisco, CA"
+                                : "San Francisco, CA";
+                            string unit = argumentsJson.RootElement.TryGetProperty("unit", out JsonElement unitElement)
+                                ? unitElement.GetString() ?? "celsius"
+                                : "celsius";
 
-                            string output = GetCurrentWeather(location: "San Francisco, CA");
+                            Console.WriteLine($">> Calling {functionCallItem.FunctionName} function for {location}...");
+
+                            string output = GetCurrentWeather(location: location, unit: unit);
 
                             RealtimeItem functionCallOutputItem = RealtimeItem.CreateFunctionCallOutputItem(
                                 callId: functionCallItem.CallId,


### PR DESCRIPTION
## Summary
- parse the model-provided function arguments in the realtime tools example before constructing the tool output item
- use the requested `location` and `unit` values instead of always sending a hard-coded weather lookup

## Related issue
- Closes #535

## Guideline alignment
- keeps the change to a single manually maintained example file with no generated code changes
- makes the sample closer to a real tool-calling flow without changing library behavior

## Validation
- ran `git diff --check`
- did not run a local `dotnet` build because the `dotnet` CLI is unavailable in this environment
