### PR TITLE
Add automatic copilot fix and retry workflow to generator upgrade PR

### DIFF
--- a/.github/skills/fixing-codegen-errors/SKILL.md
+++ b/.github/skills/fixing-codegen-errors/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: fixing-codegen-errors
+description: Guide for diagnosing and fixing errors from ./scripts/Invoke-CodeGen.ps1. Use this when code generation fails, produces prohibited-namespace errors, missing type errors, client TSP compile errors, or when a generator version update (Update TypeSpec Generator Version workflow) breaks the build.
+---
+
+# Fixing Code Generation Errors
+
+## Overview
+
+This skill describes how to diagnose and fix errors produced by `./scripts/Invoke-CodeGen.ps1`. These errors commonly arise during:
+- Spec ingestion (new base spec changes)
+- Generator version updates (the `Update TypeSpec Generator Version` workflow)
+- Client TSP modifications
+
+The script runs: `npm ci` → `npm run build` (codegen plugin) → `npx tsp compile .` (TypeSpec compilation + C# generation).
+
+## Error Categories
+
+### 1. `prohibited-namespace` Errors
+
+**Symptom:** Compiler error naming a type with `prohibited-namespace`.
+
+**Cause:** A TypeSpec type exists under `OpenAI` namespace but has no `[CodeGenType]` stub to place it in the correct area namespace (e.g., `OpenAI.Audio`).
+
+**Fix:**
+1. Identify the type name from the error message
+2. Determine if it's internal or public (internal types are prefixed with `Internal`)
+3. Add a stub in the correct file:
+   - Internal → `src/Custom/{Area}/Internal/GeneratorStubs.cs`
+   - Public → `src/Custom/{Area}/GeneratorStubs.cs`
+
+```csharp
+// Internal example
+[CodeGenType("SomeNewInternalType")] internal partial class InternalSomeNewInternalType { }
+
+// Public example
+[CodeGenType("SomeNewPublicType")] public partial class SomeNewPublicType { }
+```
+
+4. Re-run `./scripts/Invoke-CodeGen.ps1`
+
+### 2. Missing Type / Unresolved Reference Errors
+
+**Symptom:** `error type-not-found: Type "Foo" is not defined` or similar.
+
+**Cause:** The base spec references a type from `common/` that hasn't been copied locally yet.
+
+**Fix:**
+1. Search the upstream repo for the type definition:
+   ```powershell
+   Select-String -Path "specification/base/typespec/common/*.tsp" -Pattern "model Foo|union Foo|enum Foo|alias Foo|scalar Foo"
+   ```
+2. If not found locally, get it from upstream `microsoft/openai-openapi-pr` → `packages/openai-typespec/src/common/`
+3. Copy **only the specific type definition** into the local common file — do NOT copy entire files
+4. Re-run `./scripts/Invoke-CodeGen.ps1`
+
+### 3. Client TSP Decorator Errors
+
+**Symptom:** Errors referencing `@@clientLocation`, `@@clientName`, `@@visibility`, `@@alternateType`, or `@@usage` decorators.
+
+**Cause:** A type or operation was renamed/removed in the new base spec, but the client TSP still references the old name.
+
+**Fix:**
+1. Open the client TSP file: `specification/client/{area}.client.tsp`
+2. Find the stale reference named in the error
+3. Update it to match the new name from the base spec
+4. If an operation was removed, remove its `@@clientLocation` line
+5. Re-run `./scripts/Invoke-CodeGen.ps1`
+
+### 4. npm / Build Errors (Plugin Compilation)
+
+**Symptom:** Errors during `npm ci` or `npm run build` in the codegen plugin.
+
+**Cause:** Version incompatibilities after a generator update, or breaking API changes in the TypeSpec SDK.
+
+**Fix:**
+1. Check `codegen/package.json` for version mismatches
+2. Delete `node_modules` and `package-lock.json`, then re-run:
+   ```powershell
+   npm install
+   npm run build -w codegen
+   ```
+3. If the codegen plugin (`codegen/generator/src/`) has TypeScript compile errors, fix the TypeScript visitor code
+4. Re-run `./scripts/Invoke-CodeGen.ps1`
+
+### 5. Post-Generation Build Errors (`dotnet build`)
+
+**Symptom:** `./scripts/Invoke-CodeGen.ps1` succeeds but `dotnet build src/OpenAI.csproj` fails.
+
+**Cause:** Generated C# code references renamed/removed custom types, or numeric type conversions need updating.
+
+**Fix:**
+1. Check for renamed types → update `[CodeGenType]` attributes in `GeneratorStubs.cs`
+2. Check for numeric type issues → update exclusion lists in `codegen/generator/src/Visitors/NumericTypesVisitor.cs`
+3. Check custom code in `src/Custom/{Area}/` for broken references
+4. Rebuild: `dotnet build src/OpenAI.csproj`
+
+## Triage Steps
+
+When `./scripts/Invoke-CodeGen.ps1` fails:
+
+1. **Read the error message carefully** — it identifies the phase (npm, build, compile, or generation)
+2. **Identify the phase:**
+   - `npm ci` failure → dependency issue (Category 4)
+   - `npm run build` failure → plugin compilation (Category 4)
+   - `tsp compile` failure → TypeSpec errors (Categories 1-3)
+3. **For TypeSpec errors**, check whether the error references:
+   - A namespace → Category 1 (prohibited-namespace)
+   - A missing type → Category 2 (unresolved reference)
+   - A decorator → Category 3 (client TSP)
+4. **Fix the specific error**, then re-run `./scripts/Invoke-CodeGen.ps1`
+5. **After codegen succeeds**, run `dotnet build src/OpenAI.csproj` to verify
+6. **After build succeeds**, run `./scripts/Export-Api.ps1` to update API surface files
+
+## Agent Rules
+
+- **NEVER modify files in `specification/base/`** — the base spec must remain an exact upstream copy
+- **Only fix errors**, not warnings — warnings from `tsp compile` are expected and acceptable
+- **Re-run the full `./scripts/Invoke-CodeGen.ps1`** after each fix to verify
+- **Always run `dotnet build src/OpenAI.csproj`** after successful code generation
+- **Always run `./scripts/Export-Api.ps1`** after a successful build
+
+## Key File Locations
+
+| File | Purpose |
+|------|---------|
+| `scripts/Invoke-CodeGen.ps1` | Main code generation script |
+| `scripts/Submit-GeneratorUpdatePr.ps1` | Script used by the Update TypeSpec Generator Version workflow |
+| `codegen/package.json` | Generator dependencies and version |
+| `specification/client/{area}.client.tsp` | Client-side TypeSpec decorators per area |
+| `specification/client/models/{area}.models.tsp` | Client-side model overrides (not all areas) |
+| `specification/base/typespec/{area}/` | Base spec (DO NOT MODIFY) |
+| `src/Custom/{Area}/Internal/GeneratorStubs.cs` | Internal type stubs with `[CodeGenType]` |
+| `src/Custom/{Area}/GeneratorStubs.cs` | Public type stubs with `[CodeGenType]` |
+| `codegen/generator/src/Visitors/` | C# codegen visitors (e.g., NumericTypesVisitor) |
+| `.github/workflows/update-generator.yml` | The Update TypeSpec Generator Version workflow |

--- a/.github/workflows/upgrade-generator-retry.yml
+++ b/.github/workflows/upgrade-generator-retry.yml
@@ -35,7 +35,7 @@ jobs:
           BRANCH="${{ github.event.check_suite.head_branch }}"
 
           # Get the PR number for this branch
-          PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR found for branch $BRANCH. Skipping."
             echo "should-retry=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/upgrade-generator-retry.yml
+++ b/.github/workflows/upgrade-generator-retry.yml
@@ -1,0 +1,131 @@
+name: Copilot Auto-Fix for Generator Updates
+
+on:
+  # Trigger when a check suite completes on a generator-update PR branch
+  check_suite:
+    types: [completed]
+
+jobs:
+  retry-copilot-fix:
+    name: Re-trigger Copilot fix on failure
+    runs-on: ubuntu-latest
+    # Only run when:
+    # 1. The check suite failed
+    # 2. The branch is a generator-update branch
+    # 3. The head commit was authored by copilot or github-actions (not a human)
+    if: >
+      github.event.check_suite.conclusion == 'failure' &&
+      startsWith(github.event.check_suite.head_branch, 'typespec/update-http-client-csharp-')
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.check_suite.head_branch }}
+
+      - name: Check retry count and author
+        id: check-retry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.check_suite.head_branch }}"
+
+          # Get the PR number for this branch
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found for branch $BRANCH. Skipping."
+            echo "should-retry=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+          # Check if the label exists
+          HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep -c "typespec-generator-update" || echo "0")
+          if [ "$HAS_LABEL" = "0" ]; then
+            echo "PR does not have 'typespec-generator-update' label. Skipping."
+            echo "should-retry=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Count existing @copilot comments (including the initial one from Submit-GeneratorUpdatePr.ps1)
+          COPILOT_COMMENTS=$(gh pr view "$PR_NUMBER" --comments --json comments \
+            --jq '[.comments[] | select(.body | contains("@copilot"))] | length')
+          echo "Copilot comment count: $COPILOT_COMMENTS"
+
+          # Limit to 3 total @copilot attempts (1 initial + 2 retries)
+          MAX_ATTEMPTS=3
+          if [ "$COPILOT_COMMENTS" -ge "$MAX_ATTEMPTS" ]; then
+            echo "Max retry attempts ($MAX_ATTEMPTS) reached. Skipping."
+            echo "should-retry=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Only retry if the last commit was from copilot or github-actions (not a human fix)
+          LAST_AUTHOR=$(git log -1 --format='%an')
+          echo "Last commit author: $LAST_AUTHOR"
+          if [[ "$LAST_AUTHOR" != *"copilot"* && "$LAST_AUTHOR" != *"GitHub Action"* && "$LAST_AUTHOR" != *"github-actions"* ]]; then
+            echo "Last commit was by a human ($LAST_AUTHOR). Skipping auto-retry."
+            echo "should-retry=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "should-retry=true" >> $GITHUB_OUTPUT
+          echo "attempt=$((COPILOT_COMMENTS + 1))" >> $GITHUB_OUTPUT
+
+      - name: Get failure details
+        if: steps.check-retry.outputs.should-retry == 'true'
+        id: get-errors
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.check-retry.outputs.pr-number }}"
+
+          # Get failed check runs from this check suite
+          FAILED_CHECKS=$(gh api \
+            "/repos/${{ github.repository }}/check-suites/${{ github.event.check_suite.id }}/check-runs" \
+            --jq '.check_runs[] | select(.conclusion == "failure") | .name' 2>/dev/null || echo "unknown")
+
+          # Get the build log annotations (errors) from failed check runs
+          ERROR_DETAILS=$(gh api \
+            "/repos/${{ github.repository }}/check-suites/${{ github.event.check_suite.id }}/check-runs" \
+            --jq '.check_runs[] | select(.conclusion == "failure") | "### \(.name)\n\(.output.summary // "No summary available")"' 2>/dev/null || echo "")
+
+          if [ -z "$ERROR_DETAILS" ]; then
+            ERROR_DETAILS="CI checks failed but detailed error output was not available. Please check the failed runs: $FAILED_CHECKS"
+          fi
+
+          # Truncate if too long (GitHub comment limit)
+          if [ ${#ERROR_DETAILS} -gt 8000 ]; then
+            ERROR_DETAILS="${ERROR_DETAILS:0:8000}...(truncated)"
+          fi
+
+          # Write to file to preserve multiline content
+          echo "$ERROR_DETAILS" > /tmp/error_details.txt
+          echo "has-errors=true" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR to re-trigger Copilot
+        if: steps.check-retry.outputs.should-retry == 'true' && steps.get-errors.outputs.has-errors == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.check-retry.outputs.pr-number }}"
+          ATTEMPT="${{ steps.check-retry.outputs.attempt }}"
+          ERROR_DETAILS=$(cat /tmp/error_details.txt)
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          COMMENT_BODY="@copilot CI checks are still failing after your previous fix attempt (attempt $ATTEMPT/3).
+
+          Please use the \`fixing-codegen-errors\` skill to diagnose and fix the remaining errors.
+
+          $ERROR_DETAILS
+
+          [Failed CI Run]($RUN_URL)
+
+          Refer to \`.github/skills/fixing-codegen-errors/SKILL.md\` for the triage steps and fix instructions."
+
+          gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+          echo "Posted retry comment (attempt $ATTEMPT) on PR #$PR_NUMBER"

--- a/.github/workflows/upgrade-generator-retry.yml
+++ b/.github/workflows/upgrade-generator-retry.yml
@@ -44,8 +44,8 @@ jobs:
           echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
           # Check if the label exists
-          HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep -c "typespec-generator-update" || echo "0")
-          if [ "$HAS_LABEL" = "0" ]; then
+          HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels --jq 'any(.labels[].name; . == "typespec-generator-update")')
+          if [ "$HAS_LABEL" != "true" ]; then
             echo "PR does not have 'typespec-generator-update' label. Skipping."
             echo "should-retry=false" >> $GITHUB_OUTPUT
             exit 0

--- a/.github/workflows/upgrade-generator-retry.yml
+++ b/.github/workflows/upgrade-generator-retry.yml
@@ -114,18 +114,24 @@ jobs:
         run: |
           PR_NUMBER="${{ steps.check-retry.outputs.pr-number }}"
           ATTEMPT="${{ steps.check-retry.outputs.attempt }}"
-          ERROR_DETAILS=$(cat /tmp/error_details.txt)
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMENT_FILE=/tmp/retry_comment.md
 
-          COMMENT_BODY="@copilot CI checks are still failing after your previous fix attempt (attempt $ATTEMPT/3).
+          cat > "$COMMENT_FILE" <<EOF
+          @copilot CI checks are still failing after your previous fix attempt (attempt $ATTEMPT/3).
 
           Please use the \`fixing-codegen-errors\` skill to diagnose and fix the remaining errors.
 
-          $ERROR_DETAILS
+          EOF
+
+          cat /tmp/error_details.txt >> "$COMMENT_FILE"
+
+          cat >> "$COMMENT_FILE" <<EOF
 
           [Failed CI Run]($RUN_URL)
 
-          Refer to \`.github/skills/fixing-codegen-errors/SKILL.md\` for the triage steps and fix instructions."
+          Refer to \`.github/skills/fixing-codegen-errors/SKILL.md\` for the triage steps and fix instructions.
+          EOF
 
-          gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+          gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
           echo "Posted retry comment (attempt $ATTEMPT) on PR #$PR_NUMBER"

--- a/scripts/Submit-GeneratorUpdatePr.ps1
+++ b/scripts/Submit-GeneratorUpdatePr.ps1
@@ -217,20 +217,32 @@ try {
     
     # Regenerate OpenAI SDK code
     Write-Log "Regenerating OpenAI SDK code"
+    $script:CodeGenErrors = ""
     Push-Location "."
     try {
-        pwsh scripts/Invoke-CodeGen.ps1
+        $codegenOutput = pwsh scripts/Invoke-CodeGen.ps1 2>&1
+        $codegenOutput | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) {
+            $script:CodeGenErrors = ($codegenOutput | Where-Object { $_ -match 'error' }) -join "`n"
+            throw "Code generation failed with exit code $LASTEXITCODE"
+        }
     } catch {
         Write-WarningLog "OpenAI code generation failed: $_"
+        if (-not $script:CodeGenErrors) {
+            $script:CodeGenErrors = $_.Exception.Message
+        }
     }
     Pop-Location
 
     # Build the updated library
     Write-Log "Building the library"
+    $script:BuildErrors = ""
     Push-Location "."
     try {
-        & dotnet build src/OpenAI.csproj
+        $buildOutput = & dotnet build src/OpenAI.csproj 2>&1
+        $buildOutput | ForEach-Object { Write-Host $_ }
         if ($LASTEXITCODE -ne 0) {
+            $script:BuildErrors = ($buildOutput | Where-Object { $_ -match ': error ' }) -join "`n"
             throw "Build failed with exit code $LASTEXITCODE"
         }
     } catch {
@@ -313,13 +325,43 @@ $(if ($ActionRunUrl) { "`n- [Action Run]($ActionRunUrl)" })
 If there are any issues with the generated code, please review the [TypeSpec release notes](https://github.com/microsoft/typespec/releases) for breaking changes or new features that may require manual adjustments.
 "@
     
-    $prUrl = gh pr create --title $prTitle --body $prBody --base $BaseBranch --head $PRBranch 2>&1
+    # Ensure the label exists (create it if missing)
+    gh label create "typespec-generator-update" --description "PR created by the Update TypeSpec Generator Version workflow" --color "1d76db" 2>&1 | Out-Null
+
+    $prUrl = gh pr create --title $prTitle --body $prBody --base $BaseBranch --head $PRBranch --label "typespec-generator-update" 2>&1
     
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to create PR using gh CLI: $prUrl"
     }
     
     Write-Log "Successfully created PR: $prUrl"
+
+    # If codegen or build errors occurred, comment on the PR to request Copilot fix them
+    if ($WarningsEncountered -and ($script:CodeGenErrors -or $script:BuildErrors)) {
+        Write-Log "Requesting Copilot to fix errors on PR..."
+        $errorDetails = ""
+        if ($script:CodeGenErrors) {
+            $errorDetails += "### Code Generation Errors`n``````text`n$($script:CodeGenErrors)`n```````n`n"
+        }
+        if ($script:BuildErrors) {
+            $errorDetails += "### Build Errors`n``````text`n$($script:BuildErrors)`n```````n`n"
+        }
+        $copilotComment = @"
+@copilot The generator version update to ``$PackageVersion`` produced errors during code generation and/or build.
+
+Please use the ``fixing-codegen-errors`` skill to diagnose and fix these errors.
+
+$errorDetails
+Refer to ``.github/skills/fixing-codegen-errors/SKILL.md`` for the triage steps and fix instructions.
+"@
+        gh pr comment $prUrl --body $copilotComment 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-WarningLog "Failed to add Copilot comment to PR, but PR was created successfully."
+        } else {
+            Write-Log "Copilot fix request comment added to PR."
+        }
+    }
+
     # If warnings were encountered, make the script exit with non-zero code
     # This will mark the GitHub Action step as failed but still create the PR
     if ($WarningsEncountered) {

--- a/scripts/Submit-GeneratorUpdatePr.ps1
+++ b/scripts/Submit-GeneratorUpdatePr.ps1
@@ -325,13 +325,27 @@ $(if ($ActionRunUrl) { "`n- [Action Run]($ActionRunUrl)" })
 If there are any issues with the generated code, please review the [TypeSpec release notes](https://github.com/microsoft/typespec/releases) for breaking changes or new features that may require manual adjustments.
 "@
     
-    # Ensure the label exists (create it if missing)
-    gh label create "typespec-generator-update" --description "PR created by the Update TypeSpec Generator Version workflow" --color "1d76db" 2>&1 | Out-Null
+    # Ensure the label exists (create it if missing) — best-effort, do not fail the script if this errors
+    try {
+        gh label create "typespec-generator-update" --description "PR created by the Update TypeSpec Generator Version workflow" --color "1d76db" 2>&1 | Out-Null
+    } catch {
+        Write-WarningLog "Could not create 'typespec-generator-update' label (may already exist or insufficient permissions). Continuing."
+    }
 
-    $prUrl = gh pr create --title $prTitle --body $prBody --base $BaseBranch --head $PRBranch --label "typespec-generator-update" 2>&1
+    $prUrl = gh pr create --title $prTitle --body $prBody --base $BaseBranch --head $PRBranch 2>&1
     
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to create PR using gh CLI: $prUrl"
+    }
+
+    # Apply the label to the PR — best-effort, do not fail the script if this errors
+    try {
+        gh pr edit $prUrl --add-label "typespec-generator-update" 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-WarningLog "Could not apply 'typespec-generator-update' label to PR (insufficient permissions). Continuing."
+        }
+    } catch {
+        Write-WarningLog "Could not apply 'typespec-generator-update' label to PR. Continuing."
     }
     
     Write-Log "Successfully created PR: $prUrl"


### PR DESCRIPTION
After weekly run to update the generator version, we should also call copilot skills to attempt fixing Invoke_Codegen errors, rerun build/generation/tests, and reiterate. Copilot attempts are currently set to max 3.