### PR TITLE
Follow-up cleanup to PR #1133

### DIFF
--- a/examples/aspnet-core/Program.cs
+++ b/examples/aspnet-core/Program.cs
@@ -2,14 +2,9 @@ using OpenAI;
 using OpenAI.Responses;
 
 var builder = WebApplication.CreateBuilder(args);
-
-#region Snippet:Add_Responses_Client
 builder.AddResponsesClient("Clients:ResponsesClient");
-#endregion
 
 var app = builder.Build();
-
-#region Snippet:Responses_Create_Endpoint
 app.MapPost("/responses/create",
     async (ResponsesRequest request, ResponsesClient client, IConfiguration configuration) =>
 {
@@ -18,8 +13,6 @@ app.MapPost("/responses/create",
     ResponseResult response = await client.CreateResponseAsync(model, request.Message);
     return new ResponsesResponse(response.GetOutputText());
 });
-#endregion
-
 app.Run();
 
 public record ResponsesRequest(string Message);

--- a/examples/aspnet-core/Program.cs
+++ b/examples/aspnet-core/Program.cs
@@ -2,9 +2,14 @@ using OpenAI;
 using OpenAI.Responses;
 
 var builder = WebApplication.CreateBuilder(args);
+
+#region Snippet:Add_Responses_Client
 builder.AddResponsesClient("Clients:ResponsesClient");
+#endregion
 
 var app = builder.Build();
+
+#region Snippet:Responses_Create_Endpoint
 app.MapPost("/responses/create",
     async (ResponsesRequest request, ResponsesClient client, IConfiguration configuration) =>
 {
@@ -13,6 +18,8 @@ app.MapPost("/responses/create",
     ResponseResult response = await client.CreateResponseAsync(model, request.Message);
     return new ResponsesResponse(response.GetOutputText());
 });
+#endregion
+
 app.Run();
 
 public record ResponsesRequest(string Message);

--- a/examples/aspnet-core/README.md
+++ b/examples/aspnet-core/README.md
@@ -61,7 +61,7 @@ This sample demonstrates the configuration-driven approach available in the Open
 
 ### Configuration-driven registration
 
-```csharp
+```C# Snippet:Add_Responses_Client
 builder.AddResponsesClient("Clients:ResponsesClient");
 ```
 
@@ -71,7 +71,7 @@ builder.AddResponsesClient("Clients:ResponsesClient");
 
 ### Dependency injection usage
 
-```csharp
+```C# Snippet:Responses_Create_Endpoint
 app.MapPost("/responses/create",
     async (ResponsesRequest request, ResponsesClient client, IConfiguration configuration) =>
 {

--- a/tests/Snippets/ExampleSnippets.cs
+++ b/tests/Snippets/ExampleSnippets.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using NUnit.Framework;
+using OpenAI.Responses;
+
+#pragma warning disable OPENAI001
+#pragma warning disable SCME0002
+
+namespace OpenAI.Tests.Snippets;
+
+[Explicit("These tests are used for compile-time verification of code snippets used in READMEs accompanying sample apps in the examples directory. There is little value in executing them for test runs.")]
+[Category("Snippets")]
+[TestFixture]
+public class ExampleSnippets
+{
+    [Test]
+    public void AspNetCore_DependencyInjection_Register()
+    {
+        var builderMock = new Mock<IHostApplicationBuilder>();
+        var builder = builderMock.Object;
+
+        #region Snippet:Add_Responses_Client
+        builder.AddResponsesClient("Clients:ResponsesClient");
+        #endregion
+    }
+
+    [Test]
+    public void AspNetCore_DependencyInjection_Usage()
+    {
+        WebApplication app = WebApplication.CreateBuilder(Array.Empty<string>()).Build();
+
+        #region Snippet:Responses_Create_Endpoint
+        app.MapPost("/responses/create",
+            async (ResponsesRequest request, ResponsesClient client, IConfiguration configuration) =>
+        {
+            string model = configuration["Clients:ResponsesClient:Model"]
+                ?? throw new InvalidOperationException("Model not configured at Clients:ResponsesClient:Model.");
+            ResponseResult response = await client.CreateResponseAsync(model, request.Message);
+            return new ResponsesResponse(response.GetOutputText());
+        });
+        #endregion
+    }
+}
+
+public record ResponsesRequest(string Message);
+
+public record ResponsesResponse(string Response);

--- a/tests/Snippets/ReadMeSnippets.cs
+++ b/tests/Snippets/ReadMeSnippets.cs
@@ -1300,9 +1300,4 @@ public class ReadMeSnippets
         }
     }
     #endregion
-
-    public class ApplicationBuilder
-    {
-        public virtual IServiceCollection Services { get; }
-    }
 }


### PR DESCRIPTION
Follow-up to https://github.com/openai/openai-dotnet/pull/1133.

- Removes the unused `ApplicationBuilder` class from `tests/Snippets/ReadMeSnippets.cs`.
- Introduces code snippets to ensure the sample app's README stays up-to-date.