### PR TITLE
ci: declare contents:read on three test/build workflows

### DIFF
--- a/.github/workflows/integrity-checks.yml
+++ b/.github/workflows/integrity-checks.yml
@@ -23,6 +23,9 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-codegen:
     name: Validate code generation

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -7,6 +7,9 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Live Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   build: # Test, pack and publish the Open AI nuget package as a build artifact
     name: Build


### PR DESCRIPTION
Three workflows currently leave the workflow `GITHUB_TOKEN` scope implicit. None of them write back to the repo via that token:

- `.github/workflows/integrity-checks.yml` -- runs `Invoke-CodeGen.ps1` and `Export-Api.ps1` then fails the build if the working tree diverges. No GitHub API write.
- `.github/workflows/live-test.yml` -- runs the live tests when a PR gets the `live test` label or via `workflow_dispatch`. Authenticates to Azure via `actions/setup-dotnet` OIDC + the `Live Testing` environment; the workflow `GITHUB_TOKEN` isn't used for the test path.
- `.github/workflows/main.yml` -- builds, runs unit tests, packs the NuGet, and uploads it as an Actions artifact. Artifact upload in v4 doesn't need explicit permissions.

This patch pins each to `permissions: contents: read` at workflow scope, matching the workflow-level blocks already declared by `release.yml` (`contents: write` + `packages: write`), `record-test.yml` (`contents: write` + `pull-requests: write`), `needs-triage.yml`, and `update-generator.yml`.

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for these three files
- third-party action exposure (`actions/setup-dotnet`, `actions/checkout`) stays bounded to read

No behavioural change.