### PR TITLE
fix: serialize realtime truncate audio end as integer

### DIFF
--- a/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandConversationItemTruncate.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandConversationItemTruncate.Serialization.cs
@@ -91,7 +91,7 @@ namespace OpenAI.Realtime
             if (!Patch.Contains("$.audio_end_ms"u8))
             {
                 writer.WritePropertyName("audio_end_ms"u8);
-                writer.WriteNumberValue(AudioEndTime.TotalMilliseconds);
+                writer.WriteNumberValue(AudioEndTime.Ticks / TimeSpan.TicksPerMillisecond);
             }
 
             Patch.WriteTo(writer);

--- a/tests/Realtime/RealtimeSerializationSmokeTests.cs
+++ b/tests/Realtime/RealtimeSerializationSmokeTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using OpenAI.Realtime;
+using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace OpenAI.Tests.Realtime;
+
+#pragma warning disable OPENAI002
+
+[Category("Smoke")]
+public class RealtimeSerializationSmokeTests
+{
+    [Test]
+    public void ConversationItemTruncateSerializesAudioEndMillisecondsAsInteger()
+    {
+        RealtimeClientCommandConversationItemTruncate command = new(
+            "item_test",
+            contentIndex: 0,
+            audioEndTime: TimeSpan.FromTicks(12_345_678));
+
+        BinaryData serializedCommand = ModelReaderWriter.Write(command);
+
+        using JsonDocument document = JsonDocument.Parse(serializedCommand);
+        JsonElement audioEndMilliseconds = document.RootElement.GetProperty("audio_end_ms");
+
+        Assert.That(audioEndMilliseconds.TryGetInt64(out long value), Is.True);
+        Assert.That(value, Is.EqualTo(1234));
+        Assert.That(audioEndMilliseconds.GetRawText(), Does.Not.Contain("."));
+    }
+}


### PR DESCRIPTION
## Summary
- serialize realtime `conversation.item.truncate` `audio_end_ms` from `TimeSpan` ticks as an integer millisecond value
- add a serialization regression that rejects fractional JSON output for truncate commands

Fixes #1173.

## Testing
- `dotnet test tests/OpenAI.Tests.csproj -f net8.0 --filter FullyQualifiedName~RealtimeSerializationSmokeTests`
- `dotnet test tests/OpenAI.Tests.csproj -f net10.0 --filter FullyQualifiedName~RealtimeSerializationSmokeTests`
- `git diff --check`