### PR TITLE
fix: avoid underscores in multipart boundaries

### DIFF
--- a/OpenAI/src/Generated/Internal/MultiPartFormDataBinaryContent.cs
+++ b/OpenAI/src/Generated/Internal/MultiPartFormDataBinaryContent.cs
@@ -17,7 +17,7 @@ namespace OpenAI
     {
         private readonly MultipartFormDataContent _multipartContent;
         private static readonly Random _random = new Random();
-        private static readonly char[] _boundaryValues = "0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz".ToCharArray();
+        private static readonly char[] _boundaryValues = "0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ?abcdefghijklmnopqrstuvwxyz".ToCharArray();
 
         public MultiPartFormDataBinaryContent()
         {

--- a/tests/Files/MultipartContentTests.cs
+++ b/tests/Files/MultipartContentTests.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+using OpenAI;
+using System.Net.Http;
+
+namespace OpenAI.Tests.Files;
+
+[Category("Smoke")]
+public class MultipartContentTests
+{
+    [Test]
+    public void MultipartBoundaryAvoidsUnderscore()
+    {
+        for (int i = 0; i < 256; i++)
+        {
+            string boundary = MultiPartFormDataBinaryContent.CreateBoundary();
+
+            Assert.That(boundary, Does.Not.Contain("_"));
+            Assert.DoesNotThrow(() => new MultipartFormDataContent(boundary).Dispose());
+        }
+    }
+}

--- a/tests/Utility/MultipartFormDataBinaryContent.cs
+++ b/tests/Utility/MultipartFormDataBinaryContent.cs
@@ -17,7 +17,7 @@ namespace OpenAI
     {
         private readonly MultipartFormDataContent _multipartContent;
         private static readonly Random _random = new Random();
-        private static readonly char[] _boundaryValues = "0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz".ToCharArray();
+        private static readonly char[] _boundaryValues = "0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ?abcdefghijklmnopqrstuvwxyz".ToCharArray();
 
         public MultiPartFormDataBinaryContent()
         {


### PR DESCRIPTION
## Summary
- avoid `_` in generated multipart boundaries for older `System.Net.Http` implementations
- keep the boundary alphabet at 64 characters for the existing mask-based selection
- add a regression that generated boundaries contain no underscores and are accepted by `MultipartFormDataContent`

Fixes #322.

## Testing
- `dotnet test tests/OpenAI.Tests.csproj -f net8.0 --filter FullyQualifiedName~MultipartContentTests`
- `dotnet test tests/OpenAI.Tests.csproj -f net10.0 --filter FullyQualifiedName~MultipartContentTests`
- `git diff --check`