### PR TITLE
Fix NotImplementedException when serializing HyperparameterBetaFactor

### DIFF
--- a/OpenAI/src/Custom/FineTuning/HyperparameterBetaFactor.cs
+++ b/OpenAI/src/Custom/FineTuning/HyperparameterBetaFactor.cs
@@ -56,7 +56,7 @@ public partial class HyperparameterBetaFactor : IEquatable<int>, IEquatable<stri
 
     void IJsonModel<HyperparameterBetaFactor>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        throw new NotImplementedException();
+        SerializeHyperparameterBeta(this, writer, options);
     }
 
     HyperparameterBetaFactor IJsonModel<HyperparameterBetaFactor>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/tests/FineTuning/HyperparameterOptionsTests.cs
+++ b/tests/FineTuning/HyperparameterOptionsTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.ClientModel.Primitives;
+using NUnit.Framework;
 using OpenAI.FineTuning;
 
 namespace OpenAI.Tests.FineTuning;
@@ -43,5 +45,22 @@ class HyperparameterOptionsTests
     {
         FineTuningTrainingMethod supervisedMethod = FineTuningTrainingMethod.CreateSupervised();
         // TODO: Add more tests here
+    }
+
+    [Test]
+    [Parallelizable]
+    public void BetaFactorCanSerialize()
+    {
+        // Regression: HyperparameterBetaFactor's IJsonModel.Write threw NotImplementedException,
+        // so FineTuningTrainingMethod.CreateDirectPreferenceOptimization threw whenever a beta
+        // factor was supplied, even though the sibling hyperparameters serialized correctly.
+        BinaryData numeric = ModelReaderWriter.Write(new HyperparameterBetaFactor(2), ModelReaderWriterOptions.Json);
+        Assert.That(numeric.ToString(), Is.EqualTo("2"));
+
+        BinaryData auto = ModelReaderWriter.Write(HyperparameterBetaFactor.CreateAuto(), ModelReaderWriterOptions.Json);
+        Assert.That(auto.ToString(), Is.EqualTo("\"auto\""));
+
+        Assert.DoesNotThrow(() =>
+            FineTuningTrainingMethod.CreateDirectPreferenceOptimization(betaFactor: new HyperparameterBetaFactor(2)));
     }
 }


### PR DESCRIPTION
### Summary

`HyperparameterBetaFactor`'s `IJsonModel<HyperparameterBetaFactor>.Write` throws `NotImplementedException` instead of serializing:

```csharp
void IJsonModel<HyperparameterBetaFactor>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
{
    throw new NotImplementedException();
}
```

This is the only one of the four hyperparameter option types that doesn't serialize. The working helper `SerializeHyperparameterBeta` already exists in the same type (and `Create`/`Deserialize` are implemented), and the siblings all delegate to their helper from `Write` — e.g. `HyperparameterBatchSize` (`SerializeHyperparameterBatchSize(...)`), `HyperparameterLearningRate`, `HyperparameterEpochCount`.

Because `FineTuningTrainingMethod.CreateDirectPreferenceOptimization(...)` serializes the beta factor via `ModelReaderWriter.Write(betaFactor, ModelReaderWriterOptions.Json, OpenAIContext.Default)`, passing a non-null `betaFactor` throws `NotImplementedException` — so **DPO fine-tuning jobs that specify a beta hyperparameter cannot be created at all**, while the other three hyperparameters work.

### Fix

Have `Write` delegate to the existing `SerializeHyperparameterBeta`, matching the sibling types:

```csharp
void IJsonModel<HyperparameterBetaFactor>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
{
    SerializeHyperparameterBeta(this, writer, options);
}
```

One line; no public API surface change (`api/` listings unaffected).

### Test plan

- Added `BetaFactorCanSerialize` in `tests/FineTuning/HyperparameterOptionsTests.cs`: asserts `ModelReaderWriter.Write` produces `2` for `new HyperparameterBetaFactor(2)` and `"auto"` for `CreateAuto()`, and that `CreateDirectPreferenceOptimization(betaFactor: ...)` does not throw.
- Verified the test **fails on `main`** (`NotImplementedException`) and **passes with this change**.
- `FineTuning` + `Smoke` test categories pass (`639 passed, 5 skipped`); library builds clean on .NET 10.