### PR TITLE
[IMPROVEMENT PERFORMANCE] System.IO.MemoryStream replaced with Microsoft.IO.RecyclableMemoryStream

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,20 +6,18 @@
     -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <!-- General Dependencies -->
   <ItemGroup>
+    <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="System.ClientModel" Version="1.10.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.2" />
   </ItemGroup>
-
   <!-- Build-only Dependencies -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.DotNet.GenAPI.Task" Version="10.0.300-preview.0.26072.115" PrivateAssets="All" />
   </ItemGroup>
-
   <!-- Test-Only Dependencies -->
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
@@ -28,19 +26,15 @@
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.2" />
-
     <!--IMPORTANT: The Moq version should not be updated without legal team approval -->
     <PackageVersion Include="Moq" Version="[4.18.2]" />
-
     <!-- Development Feed Packages -->
     <PackageVersion Include="Microsoft.ClientModel.TestFramework" Version="1.0.0-alpha.20260408.1" />
   </ItemGroup>
-
   <!-- Generator-Only Dependencies -->
   <ItemGroup Condition="'$(IsGeneratorProject)' == 'true' or $(MSBuildProjectName.EndsWith('Plugin'))">
     <PackageVersion Include="Microsoft.TypeSpec.Generator.ClientModel" Version="1.0.0-alpha.20260501.5" />
   </ItemGroup>
-
   <!-- Transitive Dependency Overrides: https://github.com/advisories/GHSA-g4vj-cjjj-v7hg -->
   <ItemGroup>
     <PackageVersion Include="NuGet.Packaging" Version="6.14.3" />

--- a/OpenAI/src/Custom/Assistants/MessageCreationAttachment.cs
+++ b/OpenAI/src/Custom/Assistants/MessageCreationAttachment.cs
@@ -2,6 +2,7 @@ using Microsoft.TypeSpec.Generator.Customizations;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
+using Microsoft.IO;
 
 namespace OpenAI.Assistants;
 
@@ -9,6 +10,7 @@ namespace OpenAI.Assistants;
 [CodeGenSerialization(nameof(Tools), "tools", SerializationValueHook = nameof(SerializeTools), DeserializationValueHook = nameof(DeserializeTools))]
 public partial class MessageCreationAttachment
 {
+
     /// <summary>
     /// The tools to which the attachment applies to.
     /// </summary>
@@ -35,8 +37,8 @@ public partial class MessageCreationAttachment
         writer.WriteStartArray();
         foreach (ToolDefinition tool in Tools)
         {
-            using var ms = new System.IO.MemoryStream();
-            using (var tempWriter = new Utf8JsonWriter(ms))
+            using Microsoft.IO.RecyclableMemoryStream ms = OpenAI.MemoryStreamManager.Manager.GetStream();
+            using (var tempWriter = new Utf8JsonWriter(ms as System.IO.Stream))
             {
                 tempWriter.WriteObjectValue(tool, options);
                 tempWriter.Flush();

--- a/OpenAI/src/Custom/Batch/Internal/CreateBatchOperationToken.cs
+++ b/OpenAI/src/Custom/Batch/Internal/CreateBatchOperationToken.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Buffers;
 using System.ClientModel;
 using System.Diagnostics;
-using System.IO;
 using System.Text.Json;
 
 #nullable enable
@@ -19,8 +19,8 @@ internal class CreateBatchOperationToken : ContinuationToken
 
     public override BinaryData ToBytes()
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
         writer.WriteStartObject();
 
         writer.WriteString("batchId", BatchId);

--- a/OpenAI/src/Custom/Batch/Internal/CreateBatchOperationToken.cs
+++ b/OpenAI/src/Custom/Batch/Internal/CreateBatchOperationToken.cs
@@ -20,7 +20,7 @@ internal class CreateBatchOperationToken : ContinuationToken
     public override BinaryData ToBytes()
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
         writer.WriteStartObject();
 
         writer.WriteString("batchId", BatchId);

--- a/OpenAI/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/OpenAI/src/Custom/Embeddings/EmbeddingClient.cs
@@ -1,5 +1,6 @@
 using Microsoft.TypeSpec.Generator.Customizations;
 using System;
+using System.Buffers;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
@@ -254,8 +255,8 @@ public partial class EmbeddingClient
 
     private void CreateEmbeddingGenerationOptions(string input, ref EmbeddingGenerationOptions options)
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStringValue(input);
         writer.Flush();
@@ -267,8 +268,8 @@ public partial class EmbeddingClient
 
     private void CreateEmbeddingGenerationOptions(IEnumerable<string> inputs, ref EmbeddingGenerationOptions options)
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartArray();
 
@@ -287,8 +288,8 @@ public partial class EmbeddingClient
 
     private void CreateEmbeddingGenerationOptions(IEnumerable<ReadOnlyMemory<int>> inputs, ref EmbeddingGenerationOptions options)
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartArray();
 

--- a/OpenAI/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/OpenAI/src/Custom/Embeddings/EmbeddingClient.cs
@@ -256,7 +256,7 @@ public partial class EmbeddingClient
     private void CreateEmbeddingGenerationOptions(string input, ref EmbeddingGenerationOptions options)
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStringValue(input);
         writer.Flush();
@@ -269,7 +269,7 @@ public partial class EmbeddingClient
     private void CreateEmbeddingGenerationOptions(IEnumerable<string> inputs, ref EmbeddingGenerationOptions options)
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartArray();
 
@@ -289,7 +289,7 @@ public partial class EmbeddingClient
     private void CreateEmbeddingGenerationOptions(IEnumerable<ReadOnlyMemory<int>> inputs, ref EmbeddingGenerationOptions options)
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartArray();
 

--- a/OpenAI/src/Custom/FineTuning/Internal/FineTuningJobToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/FineTuningJobToken.cs
@@ -23,7 +23,7 @@ internal class FineTuningJobToken : ContinuationToken
     public override BinaryData ToBytes()
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartObject();
 

--- a/OpenAI/src/Custom/FineTuning/Internal/FineTuningJobToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/FineTuningJobToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.ClientModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -21,8 +22,8 @@ internal class FineTuningJobToken : ContinuationToken
 
     public override BinaryData ToBytes()
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartObject();
 

--- a/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningCheckpointCollectionPageToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningCheckpointCollectionPageToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics;
@@ -28,8 +29,8 @@ internal class FineTuningCheckpointCollectionPageToken: ContinuationToken
 
     public override BinaryData ToBytes()
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartObject();
         writer.WriteString("jobId", JobId);

--- a/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningCheckpointCollectionPageToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningCheckpointCollectionPageToken.cs
@@ -30,7 +30,7 @@ internal class FineTuningCheckpointCollectionPageToken: ContinuationToken
     public override BinaryData ToBytes()
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartObject();
         writer.WriteString("jobId", JobId);

--- a/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventCollectionPageToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventCollectionPageToken.cs
@@ -30,7 +30,7 @@ internal class FineTuningEventCollectionPageToken : ContinuationToken
     public override BinaryData ToBytes()
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartObject();
         writer.WriteString("jobId", JobId);

--- a/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventCollectionPageToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventCollectionPageToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics;
@@ -28,8 +29,8 @@ internal class FineTuningEventCollectionPageToken : ContinuationToken
 
     public override BinaryData ToBytes()
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartObject();
         writer.WriteString("jobId", JobId);

--- a/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventsPageToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventsPageToken.cs
@@ -27,7 +27,7 @@ internal class FineTuningEventsPageToken : ContinuationToken
     public override BinaryData ToBytes()
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartObject();
 

--- a/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventsPageToken.cs
+++ b/OpenAI/src/Custom/FineTuning/Internal/Pagination/FineTuningEventsPageToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.ClientModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -25,8 +26,8 @@ internal class FineTuningEventsPageToken : ContinuationToken
 
     public override BinaryData ToBytes()
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartObject();
 

--- a/OpenAI/src/Custom/Moderations/ModerationClient.cs
+++ b/OpenAI/src/Custom/Moderations/ModerationClient.cs
@@ -1,5 +1,6 @@
 using Microsoft.TypeSpec.Generator.Customizations;
 using System;
+using System.Buffers;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
@@ -238,8 +239,8 @@ public partial class ModerationClient
 
     private void CreateModerationOptions(string input, ref ModerationOptions options)
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStringValue(input);
         writer.Flush();
@@ -250,8 +251,8 @@ public partial class ModerationClient
 
     private void CreateModerationOptions(IEnumerable<string> inputs, ref ModerationOptions options)
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartArray();
 
@@ -269,8 +270,8 @@ public partial class ModerationClient
 
     private void CreateModerationOptions(IEnumerable<ModerationInputPart> inputParts, ref ModerationOptions options)
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartArray();
         foreach (ModerationInputPart part in inputParts)

--- a/OpenAI/src/Custom/Moderations/ModerationClient.cs
+++ b/OpenAI/src/Custom/Moderations/ModerationClient.cs
@@ -240,7 +240,7 @@ public partial class ModerationClient
     private void CreateModerationOptions(string input, ref ModerationOptions options)
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStringValue(input);
         writer.Flush();
@@ -252,7 +252,7 @@ public partial class ModerationClient
     private void CreateModerationOptions(IEnumerable<string> inputs, ref ModerationOptions options)
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartArray();
 
@@ -271,7 +271,7 @@ public partial class ModerationClient
     private void CreateModerationOptions(IEnumerable<ModerationInputPart> inputParts, ref ModerationOptions options)
     {
         using Microsoft.IO.RecyclableMemoryStream stream = OpenAI.MemoryStreamManager.Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartArray();
         foreach (ModerationInputPart part in inputParts)

--- a/OpenAI/src/Custom/Realtime/Internal/WebsocketPipelineResponse.cs
+++ b/OpenAI/src/Custom/Realtime/Internal/WebsocketPipelineResponse.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
 
 namespace OpenAI.Realtime;
 
@@ -25,10 +26,10 @@ internal class WebsocketPipelineResponse : PipelineResponse
 
     public override Stream ContentStream
     {
-        get => _contentStream ??= new MemoryStream();
+        get => _contentStream ??= MemoryStreamManager.Manager.GetStream();
         set => throw new NotImplementedException();
     }
-    private MemoryStream _contentStream;
+    private Microsoft.IO.RecyclableMemoryStream _contentStream;
 
     public override BinaryData Content => _content ??= new(_contentStream.ToArray());
     private BinaryData _content;

--- a/OpenAI/src/Generated/Internal/Utf8JsonBinaryContent.cs
+++ b/OpenAI/src/Generated/Internal/Utf8JsonBinaryContent.cs
@@ -2,6 +2,7 @@
 
 #nullable disable
 
+using System.Buffers;
 using System.ClientModel;
 using System.IO;
 using System.Text.Json;
@@ -12,14 +13,14 @@ namespace OpenAI
 {
     internal partial class Utf8JsonBinaryContent : BinaryContent
     {
-        private readonly MemoryStream _stream;
+        private readonly Microsoft.IO.RecyclableMemoryStream _stream;
         private readonly BinaryContent _content;
 
         public Utf8JsonBinaryContent()
         {
-            _stream = new MemoryStream();
+            _stream = MemoryStreamManager.Manager.GetStream();
             _content = Create(_stream);
-            JsonWriter = new Utf8JsonWriter(_stream);
+            JsonWriter = new Utf8JsonWriter(_stream as IBufferWriter<byte>);
         }
 
         public Utf8JsonWriter JsonWriter { get; }

--- a/OpenAI/src/Generated/Internal/Utf8JsonBinaryContent.cs
+++ b/OpenAI/src/Generated/Internal/Utf8JsonBinaryContent.cs
@@ -20,7 +20,7 @@ namespace OpenAI
         {
             _stream = MemoryStreamManager.Manager.GetStream();
             _content = Create(_stream);
-            JsonWriter = new Utf8JsonWriter(_stream as IBufferWriter<byte>);
+            JsonWriter = new Utf8JsonWriter(_stream as System.IO.Stream);
         }
 
         public Utf8JsonWriter JsonWriter { get; }

--- a/OpenAI/src/OpenAI.csproj
+++ b/OpenAI/src/OpenAI.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="System.ClientModel" />
     <PackageReference Include="System.Net.ServerSentEvents" />
   </ItemGroup>

--- a/OpenAI/src/Utility/RecyclableMemoryStreamManager.cs
+++ b/OpenAI/src/Utility/RecyclableMemoryStreamManager.cs
@@ -1,0 +1,8 @@
+using Microsoft.IO;
+
+namespace OpenAI;
+
+internal class MemoryStreamManager
+{
+    public static readonly RecyclableMemoryStreamManager Manager = new ();
+}

--- a/examples/Chat/Example08_ChatSerialization.cs
+++ b/examples/Chat/Example08_ChatSerialization.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using OpenAI.Chat;
 using System;
+using System.Buffers;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
@@ -23,11 +24,13 @@ public partial class ChatExamples
     }
     #endregion
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     #region
     public static BinaryData SerializeMessages(IEnumerable<ChatMessage> messages)
     {
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
+        using Microsoft.IO.RecyclableMemoryStream stream = Manager.GetStream();
+        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
 
         writer.WriteStartArray();
 

--- a/examples/Chat/Example08_ChatSerialization.cs
+++ b/examples/Chat/Example08_ChatSerialization.cs
@@ -30,7 +30,7 @@ public partial class ChatExamples
     public static BinaryData SerializeMessages(IEnumerable<ChatMessage> messages)
     {
         using Microsoft.IO.RecyclableMemoryStream stream = Manager.GetStream();
-        using Utf8JsonWriter writer = new(stream as IBufferWriter<byte>);
+        using Utf8JsonWriter writer = new(stream as System.IO.Stream);
 
         writer.WriteStartArray();
 

--- a/tests/Audio/TranscriptionMockTests.cs
+++ b/tests/Audio/TranscriptionMockTests.cs
@@ -137,11 +137,13 @@ public partial class TranscriptionMockTests : ClientTestBase
         Assert.That(segment.NoSpeechProbability, Is.EqualTo(0.2f));
     }
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     [Test]
     public void TranscribeAudioFromStreamRespectsTheCancellationToken()
     {
         AudioClient client = CreateProxyFromClient(new AudioClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Microsoft.IO.RecyclableMemoryStream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 

--- a/tests/Audio/TranslationMockTests.cs
+++ b/tests/Audio/TranslationMockTests.cs
@@ -113,11 +113,13 @@ public partial class TranslationMockTests : ClientTestBase
         Assert.That(segment.NoSpeechProbability, Is.EqualTo(0.2f));
     }
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     [Test]
     public void TranslateAudioFromStreamRespectsTheCancellationToken()
     {
         AudioClient client = CreateProxyFromClient(new AudioClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Stream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 

--- a/tests/Batch/BatchTests.cs
+++ b/tests/Batch/BatchTests.cs
@@ -107,10 +107,12 @@ public class BatchTests : OpenAIRecordedTestBase
         Assert.ThrowsAsync<TaskCanceledException>(async () => await enumerator.MoveNextAsync().AsTask());
     }
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     [RecordedTest]
     public async Task CreateGetAndCancelBatchProtocol()
     {
-        using MemoryStream testFileStream = new();
+        using Stream testFileStream = Manager.GetStream();
         using StreamWriter streamWriter = new(testFileStream);
         streamWriter.NewLine = "\r\n";
         string input = @"{""custom_id"": ""request-1"", ""method"": ""POST"", ""url"": ""/v1/chat/completions"", ""body"": {""model"": ""gpt-4o-mini"", ""messages"": [{""role"": ""system"", ""content"": ""You are a helpful assistant.""}, {""role"": ""user"", ""content"": ""What is 2+2?""}]}}";
@@ -172,7 +174,7 @@ public class BatchTests : OpenAIRecordedTestBase
     [TestCase(false)]
     public async Task CanRehydrateBatchOperation(bool useBatchId)
     {
-        using MemoryStream testFileStream = new();
+        using Stream testFileStream = Manager.GetStream();
         using StreamWriter streamWriter = new(testFileStream);
         streamWriter.NewLine = "\r\n";
         string input = @"{""custom_id"": ""request-1"", ""method"": ""POST"", ""url"": ""/v1/chat/completions"", ""body"": {""model"": ""gpt-4o-mini"", ""messages"": [{""role"": ""system"", ""content"": ""You are a helpful assistant.""}, {""role"": ""user"", ""content"": ""What is 2+2?""}]}}";

--- a/tests/Chat/ChatTests.cs
+++ b/tests/Chat/ChatTests.cs
@@ -139,6 +139,8 @@ public class ChatTests : OpenAIRecordedTestBase
         Assert.That(result.Value.Content[0].Text.ToLowerInvariant(), Does.Contain("dog").Or.Contain("cat").IgnoreCase);
     }
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     [RecordedTest]
     public async Task ChatWithBasicAudioOutput()
     {
@@ -151,7 +153,7 @@ public class ChatTests : OpenAIRecordedTestBase
         };
 
         StringBuilder transcriptBuilder = new();
-        using MemoryStream outputAudioStream = new();
+        using Stream outputAudioStream = Manager.GetStream();
         string streamedAudioId = null;
         ChatTokenUsage streamedUsage = null;
         DateTimeOffset? streamedExpiresAt = null;
@@ -241,7 +243,7 @@ public class ChatTests : OpenAIRecordedTestBase
         DateTimeOffset? streamedExpiresAt = null;
         StringBuilder streamedTranscriptBuilder = new();
         ChatTokenUsage streamedUsage = null;
-        using MemoryStream outputAudioStream = new();
+        using Stream outputAudioStream = Manager.GetStream();
         await foreach (StreamingChatCompletionUpdate update in client.CompleteChatStreamingAsync(messages, options))
         {
             Assert.That(update.ContentUpdate, Has.Count.EqualTo(0));

--- a/tests/Files/FilesMockTests.cs
+++ b/tests/Files/FilesMockTests.cs
@@ -230,6 +230,8 @@ public class FilesMockTests : ClientTestBase
         Assert.Throws<OverflowException>(() => _ = fileInfo.SizeInBytes);
     }
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     [Test]
     public async Task UploadFileWithPathUsesFileNameOnly()
     {
@@ -244,7 +246,7 @@ public class FilesMockTests : ClientTestBase
         {
             Transport = new MockPipelineTransport(message =>
             {
-                using MemoryStream stream = new();
+                using Microsoft.IO.RecyclableMemoryStream stream = Manager.GetStream();
                 message.Request.Content.WriteTo(stream);
                 requestBody = BinaryData.FromBytes(stream.ToArray()).ToString();
                 return response;
@@ -268,7 +270,7 @@ public class FilesMockTests : ClientTestBase
     public void UploadFileRespectsTheCancellationToken()
     {
         OpenAIFileClient client = CreateProxyFromClient(new OpenAIFileClient(s_fakeCredential));
-        using var stream = new MemoryStream(Array.Empty<byte>());
+        using Microsoft.IO.RecyclableMemoryStream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 

--- a/tests/Images/ImagesMockTests.cs
+++ b/tests/Images/ImagesMockTests.cs
@@ -106,6 +106,8 @@ public class ImagesMockTests : ClientTestBase
                 Throws.InstanceOf<OperationCanceledException>());
     }
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     [Test]
     [TestCaseSource(nameof(s_imageSourceKindSource))]
     public async Task GenerateImageEditDeserializesRevisedPrompt(ImageSourceKind imageSourceKind)
@@ -126,7 +128,7 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
+            using Stream stream = Manager.GetStream();
 
             image = await client.GenerateImageEditAsync(stream, "filename", "prompt");
         }
@@ -146,7 +148,7 @@ public class ImagesMockTests : ClientTestBase
     public void GenerateImageEditFromStreamRespectsTheCancellationToken()
     {
         ImageClient client = CreateProxyFromClient(new ImageClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Stream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -176,8 +178,8 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
-            using Stream mask = new MemoryStream();
+            using Stream stream = Manager.GetStream();
+            using Stream mask = Manager.GetStream();
 
             image = await client.GenerateImageEditAsync(stream, "filename", "prompt", mask, "maskFilename");
         }
@@ -197,7 +199,7 @@ public class ImagesMockTests : ClientTestBase
     public void GenerateImageEditFromStreamWithMaskRespectsTheCancellationToken()
     {
         ImageClient client = CreateProxyFromClient(new ImageClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Stream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -222,7 +224,7 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
+            using Stream stream = Manager.GetStream();
 
             images = await client.GenerateImageEditsAsync(stream, "filename", "prompt", 2);
         }
@@ -258,7 +260,7 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
+            using Stream stream = Manager.GetStream();
 
             images = await client.GenerateImageEditsAsync(stream, "filename", "prompt", 2);
         }
@@ -279,7 +281,7 @@ public class ImagesMockTests : ClientTestBase
     public void GenerateImageEditsFromStreamRespectsTheCancellationToken()
     {
         ImageClient client = CreateProxyFromClient(new ImageClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Stream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -309,8 +311,8 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
-            using Stream mask = new MemoryStream();
+            using Stream stream = Manager.GetStream();
+            using Stream mask = Manager.GetStream();
 
             images = await client.GenerateImageEditsAsync(stream, "filename", "prompt", mask, "maskFilename", 2);
         }
@@ -331,7 +333,7 @@ public class ImagesMockTests : ClientTestBase
     public void GenerateImageEditsFromStreamWithMaskRespectsTheCancellationToken()
     {
         ImageClient client = CreateProxyFromClient(new ImageClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Stream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -359,7 +361,7 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
+            using Stream stream = Manager.GetStream();
 
             image = await client.GenerateImageVariationAsync(stream, "filename");
         }
@@ -379,7 +381,7 @@ public class ImagesMockTests : ClientTestBase
     public void GenerateImageVariationFromStreamRespectsTheCancellationToken()
     {
         ImageClient client = CreateProxyFromClient(new ImageClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Stream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
         Assert.That(async () => await client.GenerateImageVariationAsync(stream, "filename", cancellationToken: cancellationSource.Token),
@@ -403,7 +405,7 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
+            using Stream stream = Manager.GetStream();
 
             images = await client.GenerateImageVariationsAsync(stream, "filename", 2);
         }
@@ -439,7 +441,7 @@ public class ImagesMockTests : ClientTestBase
 
         if (imageSourceKind == ImageSourceKind.UsingStream)
         {
-            using Stream stream = new MemoryStream();
+            using Stream stream = Manager.GetStream();
 
             images = await client.GenerateImageVariationsAsync(stream, "filename", 2);
         }
@@ -460,7 +462,7 @@ public class ImagesMockTests : ClientTestBase
     public void GenerateImageVariationsFromStreamRespectsTheCancellationToken()
     {
         ImageClient client = CreateProxyFromClient(new ImageClient("model", s_fakeCredential));
-        using Stream stream = new MemoryStream();
+        using Stream stream = Manager.GetStream();
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 

--- a/tests/Realtime/RealtimeTests.cs
+++ b/tests/Realtime/RealtimeTests.cs
@@ -611,6 +611,8 @@ public class RealtimeTests : RealtimeTestFixtureBase
         Assert.That(gotResponseDone, Is.True);
     }
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     [Test]
     public async Task AudioStreamConvenienceBlocksCorrectly()
     {
@@ -656,7 +658,7 @@ public class RealtimeTests : RealtimeTestFixtureBase
                         Assert.ThrowsAsync<InvalidOperationException>(
                             async () =>
                             {
-                                using MemoryStream dummyStream = new();
+                                using Stream dummyStream = Manager.GetStream();
                                 await sessionClient.SendInputAudioAsync(dummyStream, CancellationToken);
                             },
                             "Sending a Stream while another Stream is being sent should throw!");

--- a/tests/UserAgentTests.cs
+++ b/tests/UserAgentTests.cs
@@ -16,6 +16,8 @@ public class UserAgentTests
     [Test]
     public void UserAgentWithApplicationIdWorks() => UserAgentStringWorks(useApplicationId: true);
 
+    private static readonly Microsoft.IO.RecyclableMemoryStreamManager Manager = new ();
+
     private void UserAgentStringWorks(bool useApplicationId)
     {
         string userAgent = null;
@@ -33,7 +35,7 @@ public class UserAgentTests
         ChatClient client = TestEnvironment.GetTestClient<ChatClient>(options: options);
         RequestOptions noThrowOptions = new() { ErrorOptions = ClientErrorBehaviors.NoThrow };
 
-        using BinaryContent emptyContent = BinaryContent.Create(new MemoryStream());
+        using BinaryContent emptyContent = BinaryContent.Create(Manager.GetStream());
         _ = client.CompleteChat(emptyContent, noThrowOptions);
 
         Assert.That(userAgent, Is.Not.Null.Or.Empty);


### PR DESCRIPTION
`System.IO.MemoryStream` was replaced with `Microsoft.IO.RecyclableMemoryStream`

Changes:

1. added package reference `Microsoft.IO.RecyclableMemoryStream`
2. `System.IO.MemoryStream` instance occurences replaced with `Microsoft.IO.RecyclableMemoryStream`

`Microsoft.IO.RecyclableMemoryStream` replaces standard `MemoryStream` instances with pooled byte buffers, eliminating Large Object Heap (LOH) allocations and significantly reducing Garbage Collection (GC) pauses in high-throughput applications

* https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream

* https://github.com/ZiggyCreatures/FusionCache/issues/241

Utilities like Kiota do use `Microsoft.IO.RecyclableMemoryStream` as dependency

* https://www.nuget.org/packages/Microsoft.Kiota.Serialization.Form/

* https://www.nuget.org/packages/Microsoft.Kiota.Serialization.Json/

* https://www.nuget.org/packages/Microsoft.Kiota.Serialization.Multipart/

* https://www.nuget.org/packages/Microsoft.Kiota.Serialization.Text/
