### PR TITLE
Add dedicated ClientOptions types for each client

### DIFF
--- a/OpenAI/src/Custom/Assistants/AssistantClient.cs
+++ b/OpenAI/src/Custom/Assistants/AssistantClient.cs
@@ -32,7 +32,7 @@ public partial class AssistantClient
     /// <summary> Initializes a new instance of <see cref="AssistantClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public AssistantClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public AssistantClient(string apiKey) : this(new ApiKeyCredential(apiKey), new AssistantClientOptions())
     {
     }
 
@@ -42,7 +42,7 @@ public partial class AssistantClient
     /// <summary> Initializes a new instance of <see cref="AssistantClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public AssistantClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public AssistantClient(ApiKeyCredential credential) : this(credential, new AssistantClientOptions())
     {
     }
 
@@ -53,7 +53,7 @@ public partial class AssistantClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public AssistantClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public AssistantClient(ApiKeyCredential credential, AssistantClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -61,7 +61,7 @@ public partial class AssistantClient
     /// <summary> Initializes a new instance of <see cref="AssistantClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public AssistantClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public AssistantClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new AssistantClientOptions())
     {
     }
 
@@ -70,16 +70,17 @@ public partial class AssistantClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public AssistantClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public AssistantClient(AuthenticationPolicy authenticationPolicy, AssistantClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
-        _messageSubClient = new(Pipeline, options);
-        _runSubClient = new(Pipeline, options);
-        _threadSubClient = new(Pipeline, options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
+        _messageSubClient = new(Pipeline, sharedOptions);
+        _runSubClient = new(Pipeline, sharedOptions);
+        _threadSubClient = new(Pipeline, sharedOptions);
     }
 
     [Experimental("SCME0002")]
@@ -103,16 +104,17 @@ public partial class AssistantClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal AssistantClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal AssistantClient(ClientPipeline pipeline, AssistantClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
-        _messageSubClient = new(Pipeline, options);
-        _runSubClient = new(Pipeline, options);
-        _threadSubClient = new(Pipeline, options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
+        _messageSubClient = new(Pipeline, sharedOptions);
+        _runSubClient = new(Pipeline, sharedOptions);
+        _threadSubClient = new(Pipeline, sharedOptions);
     }
 
     /// <summary> Creates a new assistant. </summary>

--- a/OpenAI/src/Custom/Assistants/AssistantClient.cs
+++ b/OpenAI/src/Custom/Assistants/AssistantClient.cs
@@ -77,10 +77,9 @@ public partial class AssistantClient
 
         Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
         _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
-        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
-        _messageSubClient = new(Pipeline, sharedOptions);
-        _runSubClient = new(Pipeline, sharedOptions);
-        _threadSubClient = new(Pipeline, sharedOptions);
+        _messageSubClient = new(Pipeline, options);
+        _runSubClient = new(Pipeline, options);
+        _threadSubClient = new(Pipeline, options);
     }
 
     [Experimental("SCME0002")]
@@ -111,10 +110,9 @@ public partial class AssistantClient
 
         Pipeline = pipeline;
         _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
-        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
-        _messageSubClient = new(Pipeline, sharedOptions);
-        _runSubClient = new(Pipeline, sharedOptions);
-        _threadSubClient = new(Pipeline, sharedOptions);
+        _messageSubClient = new(Pipeline, options);
+        _runSubClient = new(Pipeline, options);
+        _threadSubClient = new(Pipeline, options);
     }
 
     /// <summary> Creates a new assistant. </summary>

--- a/OpenAI/src/Custom/Assistants/AssistantClientOptions.cs
+++ b/OpenAI/src/Custom/Assistants/AssistantClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Assistants;
+
+/// <summary> The options to configure the <see cref="AssistantClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class AssistantClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public AssistantClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal AssistantClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Assistants/AssistantClientSettings.cs
+++ b/OpenAI/src/Custom/Assistants/AssistantClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Assistants;
 [Experimental("SCME0002")]
 public sealed class AssistantClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public AssistantClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new AssistantClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Assistants/Internal/InternalAssistantMessageClient.cs
+++ b/OpenAI/src/Custom/Assistants/Internal/InternalAssistantMessageClient.cs
@@ -24,7 +24,7 @@ internal partial class InternalAssistantMessageClient
     /// <summary> Initializes a new instance of <see cref="InternalAssistantMessageClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public InternalAssistantMessageClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public InternalAssistantMessageClient(ApiKeyCredential credential) : this(credential, new AssistantClientOptions())
     {
     }
 
@@ -35,7 +35,7 @@ internal partial class InternalAssistantMessageClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public InternalAssistantMessageClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public InternalAssistantMessageClient(ApiKeyCredential credential, AssistantClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -43,7 +43,7 @@ internal partial class InternalAssistantMessageClient
     /// <summary> Initializes a new instance of <see cref="InternalAssistantMessageClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalAssistantMessageClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public InternalAssistantMessageClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new AssistantClientOptions())
     {
     }
 
@@ -52,13 +52,13 @@ internal partial class InternalAssistantMessageClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalAssistantMessageClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public InternalAssistantMessageClient(AuthenticationPolicy authenticationPolicy, AssistantClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -69,12 +69,12 @@ internal partial class InternalAssistantMessageClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal InternalAssistantMessageClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal InternalAssistantMessageClient(ClientPipeline pipeline, AssistantClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 }

--- a/OpenAI/src/Custom/Assistants/Internal/InternalAssistantRunClient.cs
+++ b/OpenAI/src/Custom/Assistants/Internal/InternalAssistantRunClient.cs
@@ -27,7 +27,7 @@ internal partial class InternalAssistantRunClient
     /// <summary> Initializes a new instance of <see cref="InternalAssistantRunClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public InternalAssistantRunClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public InternalAssistantRunClient(ApiKeyCredential credential) : this(credential, new AssistantClientOptions())
     {
     }
 
@@ -38,7 +38,7 @@ internal partial class InternalAssistantRunClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public InternalAssistantRunClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public InternalAssistantRunClient(ApiKeyCredential credential, AssistantClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -46,7 +46,7 @@ internal partial class InternalAssistantRunClient
     /// <summary> Initializes a new instance of <see cref="InternalAssistantRunClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalAssistantRunClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public InternalAssistantRunClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new AssistantClientOptions())
     {
     }
 
@@ -55,13 +55,13 @@ internal partial class InternalAssistantRunClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalAssistantRunClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public InternalAssistantRunClient(AuthenticationPolicy authenticationPolicy, AssistantClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -72,12 +72,12 @@ internal partial class InternalAssistantRunClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal InternalAssistantRunClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal InternalAssistantRunClient(ClientPipeline pipeline, AssistantClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 }

--- a/OpenAI/src/Custom/Assistants/Internal/InternalAssistantThreadClient.cs
+++ b/OpenAI/src/Custom/Assistants/Internal/InternalAssistantThreadClient.cs
@@ -24,7 +24,7 @@ internal partial class InternalAssistantThreadClient
     /// <summary> Initializes a new instance of <see cref="InternalAssistantThreadClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public InternalAssistantThreadClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public InternalAssistantThreadClient(ApiKeyCredential credential) : this(credential, new AssistantClientOptions())
     {
     }
 
@@ -35,7 +35,7 @@ internal partial class InternalAssistantThreadClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public InternalAssistantThreadClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public InternalAssistantThreadClient(ApiKeyCredential credential, AssistantClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -43,7 +43,7 @@ internal partial class InternalAssistantThreadClient
     /// <summary> Initializes a new instance of <see cref="InternalAssistantThreadClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalAssistantThreadClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public InternalAssistantThreadClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new AssistantClientOptions())
     {
     }
 
@@ -52,13 +52,13 @@ internal partial class InternalAssistantThreadClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalAssistantThreadClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public InternalAssistantThreadClient(AuthenticationPolicy authenticationPolicy, AssistantClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -69,12 +69,12 @@ internal partial class InternalAssistantThreadClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal InternalAssistantThreadClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal InternalAssistantThreadClient(ClientPipeline pipeline, AssistantClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new AssistantClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 }

--- a/OpenAI/src/Custom/Audio/AudioClient.cs
+++ b/OpenAI/src/Custom/Audio/AudioClient.cs
@@ -112,6 +112,53 @@ public partial class AudioClient
         _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
+    /// <summary> Initializes a new instance of <see cref="AudioClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public AudioClient(string model, ApiKeyCredential credential, AudioClientOptions options) : this(model, OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    {
+    }
+
+    /// <summary> Initializes a new instance of <see cref="AudioClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="authenticationPolicy"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public AudioClient(string model, AuthenticationPolicy authenticationPolicy, AudioClientOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new AudioClientOptions();
+
+        _model = model;
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="AudioClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    protected internal AudioClient(ClientPipeline pipeline, string model, AudioClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new AudioClientOptions();
+
+        _model = model;
+        Pipeline = pipeline;
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
     [Experimental("SCME0002")]
     public AudioClient(AudioClientSettings settings)
         : this(settings?.Model, AuthenticationPolicy.Create(settings), settings?.Options)

--- a/OpenAI/src/Custom/Audio/AudioClientOptions.cs
+++ b/OpenAI/src/Custom/Audio/AudioClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Audio;
+
+/// <summary> The options to configure the <see cref="AudioClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class AudioClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public AudioClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal AudioClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Audio/AudioClientSettings.cs
+++ b/OpenAI/src/Custom/Audio/AudioClientSettings.cs
@@ -9,7 +9,7 @@ public sealed class AudioClientSettings : ClientSettings
 {
     public string Model { get; set; }
 
-    public OpenAIClientOptions Options { get; set; }
+    public AudioClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
@@ -18,7 +18,7 @@ public sealed class AudioClientSettings : ClientSettings
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new AudioClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Batch/BatchClient.cs
+++ b/OpenAI/src/Custom/Batch/BatchClient.cs
@@ -31,7 +31,7 @@ public partial class BatchClient
     /// <summary> Initializes a new instance of <see cref="BatchClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public BatchClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public BatchClient(string apiKey) : this(new ApiKeyCredential(apiKey), new BatchClientOptions())
     {
     }
 
@@ -41,7 +41,7 @@ public partial class BatchClient
     /// <summary> Initializes a new instance of <see cref="BatchClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public BatchClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public BatchClient(ApiKeyCredential credential) : this(credential, new BatchClientOptions())
     {
     }
 
@@ -51,7 +51,7 @@ public partial class BatchClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> Additional options to customize the client. </param>
     /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public BatchClient(ApiKeyCredential credential, BatchClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -59,7 +59,7 @@ public partial class BatchClient
     /// <summary> Initializes a new instance of <see cref="BatchClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public BatchClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public BatchClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new BatchClientOptions())
     {
     }
 
@@ -68,13 +68,13 @@ public partial class BatchClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public BatchClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public BatchClient(AuthenticationPolicy authenticationPolicy, BatchClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new BatchClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -85,13 +85,13 @@ public partial class BatchClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal BatchClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal BatchClient(ClientPipeline pipeline, BatchClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new BatchClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Batch/BatchClientOptions.cs
+++ b/OpenAI/src/Custom/Batch/BatchClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Batch;
+
+/// <summary> The options to configure the <see cref="BatchClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class BatchClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public BatchClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal BatchClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Batch/BatchClientSettings.cs
+++ b/OpenAI/src/Custom/Batch/BatchClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Batch;
 [Experimental("SCME0002")]
 public sealed class BatchClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public BatchClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new BatchClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Chat/ChatClient.cs
+++ b/OpenAI/src/Custom/Chat/ChatClient.cs
@@ -119,6 +119,55 @@ public partial class ChatClient
         _telemetry = new OpenTelemetrySource(model, _endpoint);
     }
 
+    /// <summary> Initializes a new instance of <see cref="ChatClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public ChatClient(string model, ApiKeyCredential credential, ChatClientOptions options) : this(model, OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    {
+    }
+
+    /// <summary> Initializes a new instance of <see cref="ChatClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="authenticationPolicy"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public ChatClient(string model, AuthenticationPolicy authenticationPolicy, ChatClientOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new ChatClientOptions();
+
+        _model = model;
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        _telemetry = new OpenTelemetrySource(model, _endpoint);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="ChatClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    protected internal ChatClient(ClientPipeline pipeline, string model, ChatClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new ChatClientOptions();
+
+        _model = model;
+        Pipeline = pipeline;
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        _telemetry = new OpenTelemetrySource(model, _endpoint);
+    }
+
     [Experimental("SCME0002")]
     public ChatClient(ChatClientSettings settings)
         : this(settings?.Model, AuthenticationPolicy.Create(settings), settings?.Options)

--- a/OpenAI/src/Custom/Chat/ChatClientOptions.cs
+++ b/OpenAI/src/Custom/Chat/ChatClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Chat;
+
+/// <summary> The options to configure the <see cref="ChatClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class ChatClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public ChatClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal ChatClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Chat/ChatClientSettings.cs
+++ b/OpenAI/src/Custom/Chat/ChatClientSettings.cs
@@ -9,7 +9,7 @@ public sealed class ChatClientSettings : ClientSettings
 {
     public string Model { get; set; }
 
-    public OpenAIClientOptions Options { get; set; }
+    public ChatClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
@@ -18,7 +18,7 @@ public sealed class ChatClientSettings : ClientSettings
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new ChatClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Containers/ContainerClient.cs
+++ b/OpenAI/src/Custom/Containers/ContainerClient.cs
@@ -14,7 +14,7 @@ public partial class ContainerClient
     /// <summary> Initializes a new instance of <see cref="ContainerClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public ContainerClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public ContainerClient(string apiKey) : this(new ApiKeyCredential(apiKey), new ContainerClientOptions())
     {
     }
 
@@ -24,7 +24,7 @@ public partial class ContainerClient
     /// <summary> Initializes a new instance of <see cref="ContainerClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public ContainerClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public ContainerClient(ApiKeyCredential credential) : this(credential, new ContainerClientOptions())
     {
     }
 
@@ -35,7 +35,7 @@ public partial class ContainerClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public ContainerClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public ContainerClient(ApiKeyCredential credential, ContainerClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -43,7 +43,7 @@ public partial class ContainerClient
     /// <summary> Initializes a new instance of <see cref="ContainerClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public ContainerClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public ContainerClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new ContainerClientOptions())
     {
     }
 
@@ -52,13 +52,13 @@ public partial class ContainerClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public ContainerClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public ContainerClient(AuthenticationPolicy authenticationPolicy, ContainerClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new ContainerClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -69,13 +69,13 @@ public partial class ContainerClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal ContainerClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal ContainerClient(ClientPipeline pipeline, ContainerClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new ContainerClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Containers/ContainerClientOptions.cs
+++ b/OpenAI/src/Custom/Containers/ContainerClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Containers;
+
+/// <summary> The options to configure the <see cref="ContainerClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class ContainerClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public ContainerClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal ContainerClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Containers/ContainerClientSettings.cs
+++ b/OpenAI/src/Custom/Containers/ContainerClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Containers;
 [Experimental("SCME0002")]
 public sealed class ContainerClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public ContainerClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new ContainerClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Conversations/ConversationClient.cs
+++ b/OpenAI/src/Custom/Conversations/ConversationClient.cs
@@ -18,7 +18,7 @@ public partial class ConversationClient
     /// <summary> Initializes a new instance of <see cref="ConversationClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public ConversationClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public ConversationClient(string apiKey) : this(new ApiKeyCredential(apiKey), new ConversationClientOptions())
     {
     }
 
@@ -28,7 +28,7 @@ public partial class ConversationClient
     /// <summary> Initializes a new instance of <see cref="ConversationClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public ConversationClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public ConversationClient(ApiKeyCredential credential) : this(credential, new ConversationClientOptions())
     {
     }
 
@@ -39,7 +39,7 @@ public partial class ConversationClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public ConversationClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public ConversationClient(ApiKeyCredential credential, ConversationClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -47,7 +47,7 @@ public partial class ConversationClient
     /// <summary> Initializes a new instance of <see cref="ConversationClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public ConversationClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public ConversationClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new ConversationClientOptions())
     {
     }
 
@@ -56,13 +56,13 @@ public partial class ConversationClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public ConversationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public ConversationClient(AuthenticationPolicy authenticationPolicy, ConversationClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new ConversationClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -73,13 +73,13 @@ public partial class ConversationClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal ConversationClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal ConversationClient(ClientPipeline pipeline, ConversationClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new ConversationClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Conversations/ConversationClientOptions.cs
+++ b/OpenAI/src/Custom/Conversations/ConversationClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Conversations;
+
+/// <summary> The options to configure the <see cref="ConversationClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class ConversationClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public ConversationClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal ConversationClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Conversations/ConversationClientSettings.cs
+++ b/OpenAI/src/Custom/Conversations/ConversationClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Conversations;
 [Experimental("SCME0002")]
 public sealed class ConversationClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public ConversationClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new ConversationClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/OpenAI/src/Custom/Embeddings/EmbeddingClient.cs
@@ -120,6 +120,53 @@ public partial class EmbeddingClient
         _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
+    /// <summary> Initializes a new instance of <see cref="EmbeddingClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public EmbeddingClient(string model, ApiKeyCredential credential, EmbeddingClientOptions options) : this(model, OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    {
+    }
+
+    /// <summary> Initializes a new instance of <see cref="EmbeddingClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="authenticationPolicy"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy, EmbeddingClientOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new EmbeddingClientOptions();
+
+        _model = model;
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="EmbeddingClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    protected internal EmbeddingClient(ClientPipeline pipeline, string model, EmbeddingClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new EmbeddingClientOptions();
+
+        _model = model;
+        Pipeline = pipeline;
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
     /// <summary>
     /// Gets the name of the model used in requests sent to the service.
     /// </summary>

--- a/OpenAI/src/Custom/Embeddings/EmbeddingClientOptions.cs
+++ b/OpenAI/src/Custom/Embeddings/EmbeddingClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Embeddings;
+
+/// <summary> The options to configure the <see cref="EmbeddingClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class EmbeddingClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public EmbeddingClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal EmbeddingClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Embeddings/EmbeddingClientSettings.cs
+++ b/OpenAI/src/Custom/Embeddings/EmbeddingClientSettings.cs
@@ -9,7 +9,7 @@ public sealed class EmbeddingClientSettings : ClientSettings
 {
     public string Model { get; set; }
 
-    public OpenAIClientOptions Options { get; set; }
+    public EmbeddingClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
@@ -18,7 +18,7 @@ public sealed class EmbeddingClientSettings : ClientSettings
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new EmbeddingClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Evals/EvaluationClient.cs
+++ b/OpenAI/src/Custom/Evals/EvaluationClient.cs
@@ -37,7 +37,7 @@ public partial class EvaluationClient
     /// <summary> Initializes a new instance of <see cref="EvaluationClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public EvaluationClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public EvaluationClient(string apiKey) : this(new ApiKeyCredential(apiKey), new EvaluationClientOptions())
     {
     }
 
@@ -47,7 +47,7 @@ public partial class EvaluationClient
     /// <summary> Initializes a new instance of <see cref="EvaluationClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public EvaluationClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public EvaluationClient(ApiKeyCredential credential) : this(credential, new EvaluationClientOptions())
     {
     }
 
@@ -57,7 +57,7 @@ public partial class EvaluationClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> Additional options to customize the client. </param>
     /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public EvaluationClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public EvaluationClient(ApiKeyCredential credential, EvaluationClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -65,7 +65,7 @@ public partial class EvaluationClient
     /// <summary> Initializes a new instance of <see cref="EvaluationClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public EvaluationClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public EvaluationClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new EvaluationClientOptions())
     {
     }
 
@@ -74,13 +74,13 @@ public partial class EvaluationClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public EvaluationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public EvaluationClient(AuthenticationPolicy authenticationPolicy, EvaluationClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new EvaluationClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -91,13 +91,13 @@ public partial class EvaluationClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal EvaluationClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal EvaluationClient(ClientPipeline pipeline, EvaluationClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new EvaluationClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Evals/EvaluationClientOptions.cs
+++ b/OpenAI/src/Custom/Evals/EvaluationClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Evals;
+
+/// <summary> The options to configure the <see cref="EvaluationClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class EvaluationClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public EvaluationClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal EvaluationClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Evals/EvaluationClientSettings.cs
+++ b/OpenAI/src/Custom/Evals/EvaluationClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Evals;
 [Experimental("SCME0002")]
 public sealed class EvaluationClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public EvaluationClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new EvaluationClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Files/Internal/InternalUploadsClient.cs
+++ b/OpenAI/src/Custom/Files/Internal/InternalUploadsClient.cs
@@ -14,7 +14,7 @@ internal partial class InternalUploadsClient
     /// <summary> Initializes a new instance of <see cref="InternalUploadsClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public InternalUploadsClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public InternalUploadsClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIFileClientOptions())
     {
     }
 
@@ -24,7 +24,7 @@ internal partial class InternalUploadsClient
     /// <summary> Initializes a new instance of <see cref="InternalUploadsClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    internal InternalUploadsClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    internal InternalUploadsClient(ApiKeyCredential credential) : this(credential, new OpenAIFileClientOptions())
     {
     }
 
@@ -35,7 +35,7 @@ internal partial class InternalUploadsClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    internal InternalUploadsClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    internal InternalUploadsClient(ApiKeyCredential credential, OpenAIFileClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -43,7 +43,7 @@ internal partial class InternalUploadsClient
     /// <summary> Initializes a new instance of <see cref="InternalUploadsClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalUploadsClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public InternalUploadsClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIFileClientOptions())
     {
     }
 
@@ -52,13 +52,13 @@ internal partial class InternalUploadsClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public InternalUploadsClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public InternalUploadsClient(AuthenticationPolicy authenticationPolicy, OpenAIFileClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new OpenAIFileClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -69,12 +69,12 @@ internal partial class InternalUploadsClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal InternalUploadsClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal InternalUploadsClient(ClientPipeline pipeline, OpenAIFileClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new OpenAIFileClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 }

--- a/OpenAI/src/Custom/Files/OpenAIFileClient.cs
+++ b/OpenAI/src/Custom/Files/OpenAIFileClient.cs
@@ -95,6 +95,47 @@ public partial class OpenAIFileClient
         _internalUploadsClient = new(pipeline, options);
     }
 
+    /// <summary> Initializes a new instance of <see cref="OpenAIFileClient"/>. </summary>
+    /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    public OpenAIFileClient(ApiKeyCredential credential, OpenAIFileClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    {
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAIFileClient"/>. </summary>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    public OpenAIFileClient(AuthenticationPolicy authenticationPolicy, OpenAIFileClientOptions options)
+    {
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new OpenAIFileClientOptions();
+
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
+        _internalUploadsClient = new(Pipeline, sharedOptions);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAIFileClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIFileClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIFileClientOptions();
+
+        Pipeline = pipeline;
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
+        _internalUploadsClient = new(pipeline, sharedOptions);
+    }
+
     [Experimental("SCME0002")]
     public OpenAIFileClient(OpenAIFileClientSettings settings)
         : this(AuthenticationPolicy.Create(settings), settings?.Options)

--- a/OpenAI/src/Custom/Files/OpenAIFileClient.cs
+++ b/OpenAI/src/Custom/Files/OpenAIFileClient.cs
@@ -74,7 +74,14 @@ public partial class OpenAIFileClient
 
         Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
         _endpoint = OpenAIClient.GetEndpoint(options);
-        _internalUploadsClient = new(Pipeline, options);
+        OpenAIFileClientOptions fileOptions = new()
+        {
+            Endpoint = options.Endpoint,
+            OrganizationId = options.OrganizationId,
+            ProjectId = options.ProjectId,
+            UserAgentApplicationId = options.UserAgentApplicationId,
+        };
+        _internalUploadsClient = new(Pipeline, fileOptions);
     }
 
     // CUSTOM:
@@ -92,7 +99,14 @@ public partial class OpenAIFileClient
 
         Pipeline = pipeline;
         _endpoint = OpenAIClient.GetEndpoint(options);
-        _internalUploadsClient = new(pipeline, options);
+        OpenAIFileClientOptions fileOptions = new()
+        {
+            Endpoint = options.Endpoint,
+            OrganizationId = options.OrganizationId,
+            ProjectId = options.ProjectId,
+            UserAgentApplicationId = options.UserAgentApplicationId,
+        };
+        _internalUploadsClient = new(pipeline, fileOptions);
     }
 
     /// <summary> Initializes a new instance of <see cref="OpenAIFileClient"/>. </summary>
@@ -116,8 +130,7 @@ public partial class OpenAIFileClient
 
         Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
         _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
-        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
-        _internalUploadsClient = new(Pipeline, sharedOptions);
+        _internalUploadsClient = new(Pipeline, options);
     }
 
     /// <summary> Initializes a new instance of <see cref="OpenAIFileClient"/>. </summary>
@@ -132,8 +145,7 @@ public partial class OpenAIFileClient
 
         Pipeline = pipeline;
         _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
-        var sharedOptions = new OpenAIClientOptions { Endpoint = options.Endpoint };
-        _internalUploadsClient = new(pipeline, sharedOptions);
+        _internalUploadsClient = new(pipeline, options);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Files/OpenAIFileClientOptions.cs
+++ b/OpenAI/src/Custom/Files/OpenAIFileClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Files;
+
+/// <summary> The options to configure the <see cref="OpenAIFileClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class OpenAIFileClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public OpenAIFileClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal OpenAIFileClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Files/OpenAIFileClientSettings.cs
+++ b/OpenAI/src/Custom/Files/OpenAIFileClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Files;
 [Experimental("SCME0002")]
 public sealed class OpenAIFileClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public OpenAIFileClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new OpenAIFileClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/FineTuning/FineTuningClient.cs
+++ b/OpenAI/src/Custom/FineTuning/FineTuningClient.cs
@@ -52,7 +52,7 @@ public partial class FineTuningClient
     /// <summary> Initializes a new instance of <see cref="FineTuningClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public FineTuningClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public FineTuningClient(string apiKey) : this(new ApiKeyCredential(apiKey), new FineTuningClientOptions())
     {
     }
 
@@ -62,7 +62,7 @@ public partial class FineTuningClient
     /// <summary> Initializes a new instance of <see cref="FineTuningClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public FineTuningClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public FineTuningClient(ApiKeyCredential credential) : this(credential, new FineTuningClientOptions())
     {
     }
 
@@ -72,7 +72,7 @@ public partial class FineTuningClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> Additional options to customize the client. </param>
     /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public FineTuningClient(ApiKeyCredential credential, FineTuningClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -80,7 +80,7 @@ public partial class FineTuningClient
     /// <summary> Initializes a new instance of <see cref="FineTuningClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public FineTuningClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public FineTuningClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new FineTuningClientOptions())
     {
     }
 
@@ -89,13 +89,13 @@ public partial class FineTuningClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public FineTuningClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public FineTuningClient(AuthenticationPolicy authenticationPolicy, FineTuningClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new FineTuningClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -106,13 +106,13 @@ public partial class FineTuningClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal FineTuningClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal FineTuningClient(ClientPipeline pipeline, FineTuningClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new FineTuningClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     protected internal FineTuningClient(ClientPipeline pipeline, Uri endpoint)

--- a/OpenAI/src/Custom/FineTuning/FineTuningClientOptions.cs
+++ b/OpenAI/src/Custom/FineTuning/FineTuningClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.FineTuning;
+
+/// <summary> The options to configure the <see cref="FineTuningClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class FineTuningClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public FineTuningClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal FineTuningClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/FineTuning/FineTuningClientSettings.cs
+++ b/OpenAI/src/Custom/FineTuning/FineTuningClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.FineTuning;
 [Experimental("SCME0002")]
 public sealed class FineTuningClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public FineTuningClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new FineTuningClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Graders/GraderClient.cs
+++ b/OpenAI/src/Custom/Graders/GraderClient.cs
@@ -14,7 +14,7 @@ public partial class GraderClient
     /// <summary> Initializes a new instance of <see cref="GraderClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public GraderClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public GraderClient(string apiKey) : this(new ApiKeyCredential(apiKey), new GraderClientOptions())
     {
     }
 
@@ -24,7 +24,7 @@ public partial class GraderClient
     /// <summary> Initializes a new instance of <see cref="GraderClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public GraderClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public GraderClient(ApiKeyCredential credential) : this(credential, new GraderClientOptions())
     {
     }
 
@@ -35,7 +35,7 @@ public partial class GraderClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public GraderClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public GraderClient(ApiKeyCredential credential, GraderClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -43,7 +43,7 @@ public partial class GraderClient
     /// <summary> Initializes a new instance of <see cref="GraderClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public GraderClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public GraderClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new GraderClientOptions())
     {
     }
 
@@ -52,13 +52,13 @@ public partial class GraderClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public GraderClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public GraderClient(AuthenticationPolicy authenticationPolicy, GraderClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new GraderClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -69,13 +69,13 @@ public partial class GraderClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal GraderClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal GraderClient(ClientPipeline pipeline, GraderClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new GraderClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Graders/GraderClientOptions.cs
+++ b/OpenAI/src/Custom/Graders/GraderClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Graders;
+
+/// <summary> The options to configure the <see cref="GraderClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class GraderClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public GraderClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal GraderClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Graders/GraderClientSettings.cs
+++ b/OpenAI/src/Custom/Graders/GraderClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Graders;
 [Experimental("SCME0002")]
 public sealed class GraderClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public GraderClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new GraderClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Images/ImageClient.cs
+++ b/OpenAI/src/Custom/Images/ImageClient.cs
@@ -118,6 +118,53 @@ public partial class ImageClient
         _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
+    /// <summary> Initializes a new instance of <see cref="ImageClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public ImageClient(string model, ApiKeyCredential credential, ImageClientOptions options) : this(model, OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    {
+    }
+
+    /// <summary> Initializes a new instance of <see cref="ImageClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="authenticationPolicy"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public ImageClient(string model, AuthenticationPolicy authenticationPolicy, ImageClientOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new ImageClientOptions();
+
+        _model = model;
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="ImageClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    protected internal ImageClient(ClientPipeline pipeline, string model, ImageClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new ImageClientOptions();
+
+        _model = model;
+        Pipeline = pipeline;
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
     /// <summary>
     /// Gets the name of the model used in requests sent to the service.
     /// </summary>

--- a/OpenAI/src/Custom/Images/ImageClientOptions.cs
+++ b/OpenAI/src/Custom/Images/ImageClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Images;
+
+/// <summary> The options to configure the <see cref="ImageClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class ImageClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public ImageClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal ImageClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Images/ImageClientSettings.cs
+++ b/OpenAI/src/Custom/Images/ImageClientSettings.cs
@@ -9,7 +9,7 @@ public sealed class ImageClientSettings : ClientSettings
 {
     public string Model { get; set; }
 
-    public OpenAIClientOptions Options { get; set; }
+    public ImageClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
@@ -18,7 +18,7 @@ public sealed class ImageClientSettings : ClientSettings
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new ImageClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Models/OpenAIModelClient.cs
+++ b/OpenAI/src/Custom/Models/OpenAIModelClient.cs
@@ -92,6 +92,43 @@ public partial class OpenAIModelClient
         _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
+    /// <summary> Initializes a new instance of <see cref="OpenAIModelClient"/>. </summary>
+    /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    public OpenAIModelClient(ApiKeyCredential credential, OpenAIModelClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    {
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAIModelClient"/>. </summary>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    public OpenAIModelClient(AuthenticationPolicy authenticationPolicy, OpenAIModelClientOptions options)
+    {
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new OpenAIModelClientOptions();
+
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAIModelClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    [Experimental("OPENAI001")]
+    protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIModelClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIModelClientOptions();
+
+        Pipeline = pipeline;
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
     [Experimental("SCME0002")]
     public OpenAIModelClient(OpenAIModelClientSettings settings)
         : this(AuthenticationPolicy.Create(settings), settings?.Options)

--- a/OpenAI/src/Custom/Models/OpenAIModelClientOptions.cs
+++ b/OpenAI/src/Custom/Models/OpenAIModelClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Models;
+
+/// <summary> The options to configure the <see cref="OpenAIModelClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class OpenAIModelClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public OpenAIModelClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal OpenAIModelClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Models/OpenAIModelClientSettings.cs
+++ b/OpenAI/src/Custom/Models/OpenAIModelClientSettings.cs
@@ -8,14 +8,14 @@ namespace OpenAI.Models;
 [Experimental("SCME0002")]
 public sealed class OpenAIModelClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public OpenAIModelClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new OpenAIModelClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Moderations/ModerationClient.cs
+++ b/OpenAI/src/Custom/Moderations/ModerationClient.cs
@@ -120,6 +120,53 @@ public partial class ModerationClient
         _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
+    /// <summary> Initializes a new instance of <see cref="ModerationClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public ModerationClient(string model, ApiKeyCredential credential, ModerationClientOptions options) : this(model, OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    {
+    }
+
+    /// <summary> Initializes a new instance of <see cref="ModerationClient"/>. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="authenticationPolicy"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public ModerationClient(string model, AuthenticationPolicy authenticationPolicy, ModerationClientOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
+        options ??= new ModerationClientOptions();
+
+        _model = model;
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="ModerationClient"/>. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    protected internal ModerationClient(ClientPipeline pipeline, string model, ModerationClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new ModerationClientOptions();
+
+        _model = model;
+        Pipeline = pipeline;
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+    }
+
     /// <summary>
     /// Gets the name of the model used in requests sent to the service.
     /// </summary>

--- a/OpenAI/src/Custom/Moderations/ModerationClientOptions.cs
+++ b/OpenAI/src/Custom/Moderations/ModerationClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Moderations;
+
+/// <summary> The options to configure the <see cref="ModerationClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class ModerationClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public ModerationClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal ModerationClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Moderations/ModerationClientSettings.cs
+++ b/OpenAI/src/Custom/Moderations/ModerationClientSettings.cs
@@ -9,7 +9,7 @@ public sealed class ModerationClientSettings : ClientSettings
 {
     public string Model { get; set; }
 
-    public OpenAIClientOptions Options { get; set; }
+    public ModerationClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
@@ -18,7 +18,7 @@ public sealed class ModerationClientSettings : ClientSettings
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new ModerationClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/OpenAIClient.cs
+++ b/OpenAI/src/Custom/OpenAIClient.cs
@@ -413,7 +413,7 @@ public partial class OpenAIClient
     /// This method is functionally equivalent to using the <see cref="VectorStoreClient"/> constructor directly with
     /// the same configuration details.
     /// </remarks>
-    /// <returns> A new <see cref="OpenAIModelClient"/>. </returns>
+    /// <returns> A new <see cref="VectorStoreClient"/>. </returns>
     [Experimental("OPENAI001")]
     public virtual VectorStoreClient GetVectorStoreClient() => new(Pipeline, new VectorStoreClientOptions
     {

--- a/OpenAI/src/Custom/OpenAIClient.cs
+++ b/OpenAI/src/Custom/OpenAIClient.cs
@@ -188,7 +188,13 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="AssistantClient"/>. </returns>
     [Experimental("OPENAI001")]
-    public virtual AssistantClient GetAssistantClient() => new(Pipeline, _options);
+    public virtual AssistantClient GetAssistantClient() => new(Pipeline, new AssistantClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="AudioClient"/> that reuses the client configuration details provided to
@@ -211,7 +217,13 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="BatchClient"/>. </returns>
     [Experimental("OPENAI001")]
-    public virtual BatchClient GetBatchClient() => new(Pipeline, _options);
+    public virtual BatchClient GetBatchClient() => new(Pipeline, new BatchClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="ChatClient"/> that reuses the client configuration details provided to
@@ -230,7 +242,13 @@ public partial class OpenAIClient
     /// </summary>
     /// <returns></returns>
     [Experimental("OPENAI001")]
-    public virtual ContainerClient GetContainerClient() => new(Pipeline, _options);
+    public virtual ContainerClient GetContainerClient() => new(Pipeline, new ContainerClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="ConversationClient"/> that reuses the client configuration details provided to
@@ -238,7 +256,13 @@ public partial class OpenAIClient
     /// </summary>
     /// <returns></returns>
     [Experimental("OPENAI001")]
-    public virtual ConversationClient GetConversationClient() => new(Pipeline, _options);
+    public virtual ConversationClient GetConversationClient() => new(Pipeline, new ConversationClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="EmbeddingClient"/> that reuses the client configuration details provided to
@@ -257,7 +281,13 @@ public partial class OpenAIClient
     /// </summary>
     /// <returns></returns>
     [Experimental("OPENAI001")]
-    public virtual EvaluationClient GetEvaluationClient() => new(Pipeline, _options);
+    public virtual EvaluationClient GetEvaluationClient() => new(Pipeline, new EvaluationClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="OpenAIFileClient"/> that reuses the client configuration details provided to
@@ -280,7 +310,13 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="FineTuningClient"/>. </returns>
     [Experimental("OPENAI001")]
-    public virtual FineTuningClient GetFineTuningClient() => new(Pipeline, _options);
+    public virtual FineTuningClient GetFineTuningClient() => new(Pipeline, new FineTuningClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="GraderClient"/> that reuses the client configuration details provided to
@@ -288,7 +324,13 @@ public partial class OpenAIClient
     /// </summary>
     /// <returns></returns>
     [Experimental("OPENAI001")]
-    public virtual GraderClient GetGraderClient() => new(Pipeline, _options);
+    public virtual GraderClient GetGraderClient() => new(Pipeline, new GraderClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="ImageClient"/> that reuses the client configuration details provided to
@@ -373,7 +415,13 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="OpenAIModelClient"/>. </returns>
     [Experimental("OPENAI001")]
-    public virtual VectorStoreClient GetVectorStoreClient() => new(Pipeline, _options);
+    public virtual VectorStoreClient GetVectorStoreClient() => new(Pipeline, new VectorStoreClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="SkillClient"/> that reuses the client configuration details provided to
@@ -381,7 +429,13 @@ public partial class OpenAIClient
     /// </summary>
     /// <returns></returns>
     [Experimental("OPENAI001")]
-    public virtual SkillClient GetSkillClient() => new(Pipeline, _options);
+    public virtual SkillClient GetSkillClient() => new(Pipeline, new SkillClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     /// <summary>
     /// Gets a new instance of <see cref="VideoClient"/> that reuses the client configuration details provided to
@@ -389,7 +443,13 @@ public partial class OpenAIClient
     /// </summary>
     /// <returns></returns>
     [Experimental("OPENAI001")]
-    public virtual VideoClient GetVideoClient() => new(Pipeline, _options);
+    public virtual VideoClient GetVideoClient() => new(Pipeline, new VideoClientOptions
+    {
+        Endpoint = _options.Endpoint,
+        OrganizationId = _options.OrganizationId,
+        ProjectId = _options.ProjectId,
+        UserAgentApplicationId = _options.UserAgentApplicationId,
+    });
 
     internal static AuthenticationPolicy CreateApiKeyAuthenticationPolicy(ApiKeyCredential credential)
         => OpenAIClientUtilities.CreateApiKeyAuthenticationPolicy(credential);

--- a/OpenAI/src/Custom/Skills/SkillClient.cs
+++ b/OpenAI/src/Custom/Skills/SkillClient.cs
@@ -18,7 +18,7 @@ public partial class SkillClient
     /// <summary> Initializes a new instance of <see cref="SkillClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public SkillClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public SkillClient(string apiKey) : this(new ApiKeyCredential(apiKey), new SkillClientOptions())
     {
     }
 
@@ -28,7 +28,7 @@ public partial class SkillClient
     /// <summary> Initializes a new instance of <see cref="SkillClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public SkillClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public SkillClient(ApiKeyCredential credential) : this(credential, new SkillClientOptions())
     {
     }
 
@@ -39,7 +39,7 @@ public partial class SkillClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public SkillClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public SkillClient(ApiKeyCredential credential, SkillClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -47,7 +47,7 @@ public partial class SkillClient
     /// <summary> Initializes a new instance of <see cref="SkillClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public SkillClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public SkillClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new SkillClientOptions())
     {
     }
 
@@ -56,13 +56,13 @@ public partial class SkillClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public SkillClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public SkillClient(AuthenticationPolicy authenticationPolicy, SkillClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new SkillClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -73,13 +73,13 @@ public partial class SkillClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal SkillClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal SkillClient(ClientPipeline pipeline, SkillClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new SkillClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Skills/SkillClientOptions.cs
+++ b/OpenAI/src/Custom/Skills/SkillClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Skills;
+
+/// <summary> The options to configure the <see cref="SkillClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class SkillClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public SkillClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal SkillClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Skills/SkillClientSettings.cs
+++ b/OpenAI/src/Custom/Skills/SkillClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Skills;
 [Experimental("SCME0002")]
 public sealed class SkillClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public SkillClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new SkillClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/VectorStores/VectorStoreClient.cs
+++ b/OpenAI/src/Custom/VectorStores/VectorStoreClient.cs
@@ -39,7 +39,7 @@ public partial class VectorStoreClient
     /// <summary> Initializes a new instance of <see cref="VectorStoreClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public VectorStoreClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public VectorStoreClient(string apiKey) : this(new ApiKeyCredential(apiKey), new VectorStoreClientOptions())
     {
     }
 
@@ -49,7 +49,7 @@ public partial class VectorStoreClient
     /// <summary> Initializes a new instance of <see cref="VectorStoreClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public VectorStoreClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public VectorStoreClient(ApiKeyCredential credential) : this(credential, new VectorStoreClientOptions())
     {
     }
 
@@ -59,7 +59,7 @@ public partial class VectorStoreClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> Additional options to customize the client. </param>
     /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public VectorStoreClient(ApiKeyCredential credential, VectorStoreClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -67,7 +67,7 @@ public partial class VectorStoreClient
     /// <summary> Initializes a new instance of <see cref="VectorStoreClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public VectorStoreClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public VectorStoreClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new VectorStoreClientOptions())
     {
     }
 
@@ -76,13 +76,13 @@ public partial class VectorStoreClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public VectorStoreClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public VectorStoreClient(AuthenticationPolicy authenticationPolicy, VectorStoreClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new VectorStoreClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -93,13 +93,13 @@ public partial class VectorStoreClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal VectorStoreClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal VectorStoreClient(ClientPipeline pipeline, VectorStoreClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new VectorStoreClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/VectorStores/VectorStoreClientOptions.cs
+++ b/OpenAI/src/Custom/VectorStores/VectorStoreClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.VectorStores;
+
+/// <summary> The options to configure the <see cref="VectorStoreClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class VectorStoreClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public VectorStoreClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal VectorStoreClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/VectorStores/VectorStoreClientSettings.cs
+++ b/OpenAI/src/Custom/VectorStores/VectorStoreClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.VectorStores;
 [Experimental("SCME0002")]
 public sealed class VectorStoreClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public VectorStoreClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new VectorStoreClientOptions(optionsSection);
         }
     }
 }

--- a/OpenAI/src/Custom/Videos/VideoClient.cs
+++ b/OpenAI/src/Custom/Videos/VideoClient.cs
@@ -18,7 +18,7 @@ public partial class VideoClient
     /// <summary> Initializes a new instance of <see cref="VideoClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public VideoClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public VideoClient(string apiKey) : this(new ApiKeyCredential(apiKey), new VideoClientOptions())
     {
     }
 
@@ -28,7 +28,7 @@ public partial class VideoClient
     /// <summary> Initializes a new instance of <see cref="VideoClient"/>. </summary>
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public VideoClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public VideoClient(ApiKeyCredential credential) : this(credential, new VideoClientOptions())
     {
     }
 
@@ -39,7 +39,7 @@ public partial class VideoClient
     /// <param name="credential"> The <see cref="ApiKeyCredential"/> to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public VideoClient(ApiKeyCredential credential, OpenAIClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
+    public VideoClient(ApiKeyCredential credential, VideoClientOptions options) : this(OpenAIClient.CreateApiKeyAuthenticationPolicy(credential), options)
     {
     }
 
@@ -47,7 +47,7 @@ public partial class VideoClient
     /// <summary> Initializes a new instance of <see cref="VideoClient"/>. </summary>
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public VideoClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new OpenAIClientOptions())
+    public VideoClient(AuthenticationPolicy authenticationPolicy) : this(authenticationPolicy, new VideoClientOptions())
     {
     }
 
@@ -56,13 +56,13 @@ public partial class VideoClient
     /// <param name="authenticationPolicy"> The authentication policy used to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="authenticationPolicy"/> is null. </exception>
-    public VideoClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options)
+    public VideoClient(AuthenticationPolicy authenticationPolicy, VideoClientOptions options)
     {
         Argument.AssertNotNull(authenticationPolicy, nameof(authenticationPolicy));
-        options ??= new OpenAIClientOptions();
+        options ??= new VideoClientOptions();
 
-        Pipeline = OpenAIClient.CreatePipeline(authenticationPolicy, options);
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     // CUSTOM:
@@ -73,13 +73,13 @@ public partial class VideoClient
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal VideoClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal VideoClient(ClientPipeline pipeline, VideoClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
-        options ??= new OpenAIClientOptions();
+        options ??= new VideoClientOptions();
 
         Pipeline = pipeline;
-        _endpoint = OpenAIClient.GetEndpoint(options);
+        _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
     }
 
     [Experimental("SCME0002")]

--- a/OpenAI/src/Custom/Videos/VideoClientOptions.cs
+++ b/OpenAI/src/Custom/Videos/VideoClientOptions.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenAI.Videos;
+
+/// <summary> The options to configure the <see cref="VideoClient"/>. </summary>
+[Experimental("OPENAI001")]
+public class VideoClientOptions : ClientPipelineOptions
+{
+    private Uri _endpoint;
+    private string _organizationId;
+    private string _projectId;
+    private string _userAgentApplicationId;
+
+    /// <summary>
+    /// The service endpoint that the client will send requests to. If not set, the default endpoint will be used.
+    /// </summary>
+    public Uri Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            AssertNotFrozen();
+            _endpoint = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Organization</c> request header. Users who belong to multiple organizations
+    /// can set this value to specify which organization is used for an API request. Usage from these API requests will
+    /// count against the specified organization's quota. If not set, the header will be omitted, and the default
+    /// organization will be billed. You can change your default organization in your user settings.
+    /// <see href="https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization">Learn more</see>.
+    /// </summary>
+    public string OrganizationId
+    {
+        get => _organizationId;
+        set
+        {
+            AssertNotFrozen();
+            _organizationId = value;
+        }
+    }
+
+    /// <summary>
+    /// The value to use for the <c>OpenAI-Project</c> request header. Users who are accessing their projects through
+    /// their legacy user API key can set this value to specify which project is used for an API request. Usage from
+    /// these API requests will count as usage for the specified project. If not set, the header will be omitted, and
+    /// the default project will be accessed.
+    /// </summary>
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            AssertNotFrozen();
+            _projectId = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional application ID to use as part of the request User-Agent header.
+    /// </summary>
+    public string UserAgentApplicationId
+    {
+        get => _userAgentApplicationId;
+        set
+        {
+            AssertNotFrozen();
+            _userAgentApplicationId = value;
+        }
+    }
+
+    public VideoClientOptions()
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for binding from a configuration section.
+    /// Used by ClientSettings classes to bind nested "Options" section.
+    /// </summary>
+    [Experimental("SCME0002")]
+    internal VideoClientOptions(IConfigurationSection section) : base(section)
+    {
+        if (Uri.TryCreate(section[nameof(Endpoint)], UriKind.Absolute, out Uri endpoint))
+        {
+            Endpoint = endpoint;
+        }
+
+        if (section[nameof(OrganizationId)] is string organizationId)
+        {
+            OrganizationId = organizationId;
+        }
+
+        if (section[nameof(ProjectId)] is string projectId)
+        {
+            ProjectId = projectId;
+        }
+
+        if (section[nameof(UserAgentApplicationId)] is string userAgentApplicationId)
+        {
+            UserAgentApplicationId = userAgentApplicationId;
+        }
+    }
+}

--- a/OpenAI/src/Custom/Videos/VideoClientSettings.cs
+++ b/OpenAI/src/Custom/Videos/VideoClientSettings.cs
@@ -7,14 +7,14 @@ namespace OpenAI.Videos;
 [Experimental("SCME0002")]
 public sealed class VideoClientSettings : ClientSettings
 {
-    public OpenAIClientOptions Options { get; set; }
+    public VideoClientOptions Options { get; set; }
 
     protected override void BindCore(IConfigurationSection section)
     {
         var optionsSection = section.GetSection("Options");
         if (optionsSection.Exists())
         {
-            Options ??= new OpenAIClientOptions(optionsSection);
+            Options ??= new VideoClientOptions(optionsSection);
         }
     }
 }

--- a/api/OpenAI.net10.0.cs
+++ b/api/OpenAI.net10.0.cs
@@ -124,11 +124,11 @@ namespace OpenAI.Assistants {
         protected AssistantClient();
         [Experimental("SCME0002")]
         public AssistantClient(AssistantClientSettings settings);
-        public AssistantClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public AssistantClient(ApiKeyCredential credential, AssistantClientOptions options);
         public AssistantClient(ApiKeyCredential credential);
-        public AssistantClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public AssistantClient(AuthenticationPolicy authenticationPolicy, AssistantClientOptions options);
         public AssistantClient(AuthenticationPolicy authenticationPolicy);
-        protected internal AssistantClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal AssistantClient(ClientPipeline pipeline, AssistantClientOptions options);
         public AssistantClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -230,9 +230,16 @@ namespace OpenAI.Assistants {
         public virtual CollectionResult<StreamingUpdate> SubmitToolOutputsToRunStreaming(string threadId, string runId, IEnumerable<ToolOutput> toolOutputs, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult<StreamingUpdate> SubmitToolOutputsToRunStreamingAsync(string threadId, string runId, IEnumerable<ToolOutput> toolOutputs, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class AssistantClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class AssistantClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public AssistantClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -963,9 +970,15 @@ namespace OpenAI.Audio {
         protected AudioClient();
         [Experimental("SCME0002")]
         public AudioClient(AudioClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal AudioClient(ClientPipeline pipeline, string model, AudioClientOptions options);
         protected internal AudioClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public AudioClient(string model, ApiKeyCredential credential, AudioClientOptions options);
         public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public AudioClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public AudioClient(string model, AuthenticationPolicy authenticationPolicy, AudioClientOptions options);
         [Experimental("OPENAI001")]
         public AudioClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -1037,10 +1050,17 @@ namespace OpenAI.Audio {
         [Experimental("OPENAI001")]
         public virtual Task<ClientResult> UpdateVoiceConsentAsync(string consentId, BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class AudioClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class AudioClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public AudioClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Flags]
@@ -1337,11 +1357,11 @@ namespace OpenAI.Batch {
         protected BatchClient();
         [Experimental("SCME0002")]
         public BatchClient(BatchClientSettings settings);
-        public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public BatchClient(ApiKeyCredential credential, BatchClientOptions options);
         public BatchClient(ApiKeyCredential credential);
-        public BatchClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public BatchClient(AuthenticationPolicy authenticationPolicy, BatchClientOptions options);
         public BatchClient(AuthenticationPolicy authenticationPolicy);
-        protected internal BatchClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal BatchClient(ClientPipeline pipeline, BatchClientOptions options);
         public BatchClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -1355,9 +1375,16 @@ namespace OpenAI.Batch {
         public virtual AsyncCollectionResult<BatchJob> GetBatchesAsync(BatchCollectionOptions options = null, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult GetBatchesAsync(string after, int? limit, RequestOptions options);
     }
+    [Experimental("OPENAI001")]
+    public class BatchClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class BatchClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public BatchClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -1435,9 +1462,15 @@ namespace OpenAI.Chat {
         protected ChatClient();
         [Experimental("SCME0002")]
         public ChatClient(ChatClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal ChatClient(ClientPipeline pipeline, string model, ChatClientOptions options);
         protected internal ChatClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public ChatClient(string model, ApiKeyCredential credential, ChatClientOptions options);
         public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ChatClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public ChatClient(string model, AuthenticationPolicy authenticationPolicy, ChatClientOptions options);
         [Experimental("OPENAI001")]
         public ChatClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -1499,10 +1532,17 @@ namespace OpenAI.Chat {
         [Experimental("OPENAI001")]
         public virtual Task<ClientResult<ChatCompletion>> UpdateChatCompletionAsync(string completionId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class ChatClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ChatClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ChatClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ChatCompletion : IJsonModel<ChatCompletion>, IPersistableModel<ChatCompletion> {
@@ -2190,11 +2230,11 @@ namespace OpenAI.Containers {
         protected ContainerClient();
         [Experimental("SCME0002")]
         public ContainerClient(ContainerClientSettings settings);
-        public ContainerClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public ContainerClient(ApiKeyCredential credential, ContainerClientOptions options);
         public ContainerClient(ApiKeyCredential credential);
-        public ContainerClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public ContainerClient(AuthenticationPolicy authenticationPolicy, ContainerClientOptions options);
         public ContainerClient(AuthenticationPolicy authenticationPolicy);
-        protected internal ContainerClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal ContainerClient(ClientPipeline pipeline, ContainerClientOptions options);
         public ContainerClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2234,9 +2274,16 @@ namespace OpenAI.Containers {
         public virtual ClientResult UploadContainerFile(string containerId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual Task<ClientResult> UploadContainerFileAsync(string containerId, BinaryContent content, string contentType, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class ContainerClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ContainerClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public ContainerClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -2349,11 +2396,11 @@ namespace OpenAI.Conversations {
         protected ConversationClient();
         [Experimental("SCME0002")]
         public ConversationClient(ConversationClientSettings settings);
-        public ConversationClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public ConversationClient(ApiKeyCredential credential, ConversationClientOptions options);
         public ConversationClient(ApiKeyCredential credential);
-        public ConversationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public ConversationClient(AuthenticationPolicy authenticationPolicy, ConversationClientOptions options);
         public ConversationClient(AuthenticationPolicy authenticationPolicy);
-        protected internal ConversationClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal ConversationClient(ClientPipeline pipeline, ConversationClientOptions options);
         public ConversationClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2375,9 +2422,16 @@ namespace OpenAI.Conversations {
         public virtual ClientResult UpdateConversation(string conversationId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> UpdateConversationAsync(string conversationId, BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class ConversationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ConversationClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public ConversationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -2408,9 +2462,15 @@ namespace OpenAI.Embeddings {
         protected EmbeddingClient();
         [Experimental("SCME0002")]
         public EmbeddingClient(EmbeddingClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal EmbeddingClient(ClientPipeline pipeline, string model, EmbeddingClientOptions options);
         protected internal EmbeddingClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public EmbeddingClient(string model, ApiKeyCredential credential, EmbeddingClientOptions options);
         public EmbeddingClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public EmbeddingClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy, EmbeddingClientOptions options);
         [Experimental("OPENAI001")]
         public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -2430,10 +2490,17 @@ namespace OpenAI.Embeddings {
         public virtual Task<ClientResult<OpenAIEmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<ReadOnlyMemory<int>> inputs, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIEmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<string> inputs, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class EmbeddingClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class EmbeddingClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public EmbeddingClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class EmbeddingGenerationOptions : IJsonModel<EmbeddingGenerationOptions>, IPersistableModel<EmbeddingGenerationOptions> {
@@ -2482,11 +2549,11 @@ namespace OpenAI.Evals {
         protected EvaluationClient();
         [Experimental("SCME0002")]
         public EvaluationClient(EvaluationClientSettings settings);
-        public EvaluationClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public EvaluationClient(ApiKeyCredential credential, EvaluationClientOptions options);
         public EvaluationClient(ApiKeyCredential credential);
-        public EvaluationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public EvaluationClient(AuthenticationPolicy authenticationPolicy, EvaluationClientOptions options);
         public EvaluationClient(AuthenticationPolicy authenticationPolicy);
-        protected internal EvaluationClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal EvaluationClient(ClientPipeline pipeline, EvaluationClientOptions options);
         public EvaluationClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2516,9 +2583,16 @@ namespace OpenAI.Evals {
         public virtual ClientResult UpdateEvaluation(string evaluationId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> UpdateEvaluationAsync(string evaluationId, BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class EvaluationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class EvaluationClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public EvaluationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }
@@ -2589,12 +2663,18 @@ namespace OpenAI.Files {
         protected OpenAIFileClient();
         [Experimental("SCME0002")]
         public OpenAIFileClient(OpenAIFileClientSettings settings);
+        [Experimental("OPENAI001")]
+        public OpenAIFileClient(ApiKeyCredential credential, OpenAIFileClientOptions options);
         public OpenAIFileClient(ApiKeyCredential credential, OpenAIClientOptions options);
         public OpenAIFileClient(ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public OpenAIFileClient(AuthenticationPolicy authenticationPolicy, OpenAIFileClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIFileClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIFileClient(AuthenticationPolicy authenticationPolicy);
+        [Experimental("OPENAI001")]
+        protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIFileClientOptions options);
         protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public OpenAIFileClient(string apiKey);
         [Experimental("OPENAI001")]
@@ -2647,9 +2727,16 @@ namespace OpenAI.Files {
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
     }
+    [Experimental("OPENAI001")]
+    public class OpenAIFileClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class OpenAIFileClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public OpenAIFileClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class OpenAIFileCollection : ObjectModel.ReadOnlyCollection<OpenAIFile>, IJsonModel<OpenAIFileCollection>, IPersistableModel<OpenAIFileCollection> {
@@ -2691,11 +2778,11 @@ namespace OpenAI.FineTuning {
         protected FineTuningClient();
         [Experimental("SCME0002")]
         public FineTuningClient(FineTuningClientSettings settings);
-        public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public FineTuningClient(ApiKeyCredential credential, FineTuningClientOptions options);
         public FineTuningClient(ApiKeyCredential credential);
-        public FineTuningClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public FineTuningClient(AuthenticationPolicy authenticationPolicy, FineTuningClientOptions options);
         public FineTuningClient(AuthenticationPolicy authenticationPolicy);
-        protected internal FineTuningClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal FineTuningClient(ClientPipeline pipeline, FineTuningClientOptions options);
         protected internal FineTuningClient(ClientPipeline pipeline, Uri endpoint);
         public FineTuningClient(string apiKey);
         [Experimental("OPENAI001")]
@@ -2720,9 +2807,16 @@ namespace OpenAI.FineTuning {
         public virtual ClientResult ResumeFineTuningJob(string fineTuningJobId, RequestOptions options);
         public virtual Task<ClientResult> ResumeFineTuningJobAsync(string fineTuningJobId, RequestOptions options);
     }
+    [Experimental("OPENAI001")]
+    public class FineTuningClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class FineTuningClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public FineTuningClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -2985,11 +3079,11 @@ namespace OpenAI.Graders {
         protected GraderClient();
         [Experimental("SCME0002")]
         public GraderClient(GraderClientSettings settings);
-        public GraderClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public GraderClient(ApiKeyCredential credential, GraderClientOptions options);
         public GraderClient(ApiKeyCredential credential);
-        public GraderClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public GraderClient(AuthenticationPolicy authenticationPolicy, GraderClientOptions options);
         public GraderClient(AuthenticationPolicy authenticationPolicy);
-        protected internal GraderClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal GraderClient(ClientPipeline pipeline, GraderClientOptions options);
         public GraderClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2999,9 +3093,16 @@ namespace OpenAI.Graders {
         public virtual ClientResult ValidateGrader(BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> ValidateGraderAsync(BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class GraderClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class GraderClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public GraderClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -3314,9 +3415,15 @@ namespace OpenAI.Images {
         protected ImageClient();
         [Experimental("SCME0002")]
         public ImageClient(ImageClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal ImageClient(ClientPipeline pipeline, string model, ImageClientOptions options);
         protected internal ImageClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public ImageClient(string model, ApiKeyCredential credential, ImageClientOptions options);
         public ImageClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ImageClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public ImageClient(string model, AuthenticationPolicy authenticationPolicy, ImageClientOptions options);
         [Experimental("OPENAI001")]
         public ImageClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -3362,10 +3469,17 @@ namespace OpenAI.Images {
         public virtual Task<ClientResult<GeneratedImageCollection>> GenerateImageVariationsAsync(Stream image, string imageFilename, int imageCount, ImageVariationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<GeneratedImageCollection>> GenerateImageVariationsAsync(string imageFilePath, int imageCount, ImageVariationOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class ImageClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ImageClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ImageClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ImageEditOptions : IJsonModel<ImageEditOptions>, IPersistableModel<ImageEditOptions> {
@@ -3467,12 +3581,18 @@ namespace OpenAI.Models {
         protected OpenAIModelClient();
         [Experimental("SCME0002")]
         public OpenAIModelClient(OpenAIModelClientSettings settings);
+        [Experimental("OPENAI001")]
+        public OpenAIModelClient(ApiKeyCredential credential, OpenAIModelClientOptions options);
         public OpenAIModelClient(ApiKeyCredential credential, OpenAIClientOptions options);
         public OpenAIModelClient(ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public OpenAIModelClient(AuthenticationPolicy authenticationPolicy, OpenAIModelClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIModelClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIModelClient(AuthenticationPolicy authenticationPolicy);
+        [Experimental("OPENAI001")]
+        protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIModelClientOptions options);
         protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public OpenAIModelClient(string apiKey);
         [Experimental("OPENAI001")]
@@ -3491,9 +3611,16 @@ namespace OpenAI.Models {
         public virtual Task<ClientResult> GetModelsAsync(RequestOptions options);
         public virtual Task<ClientResult<OpenAIModelCollection>> GetModelsAsync(CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class OpenAIModelClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class OpenAIModelClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public OpenAIModelClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class OpenAIModelCollection : ObjectModel.ReadOnlyCollection<OpenAIModel>, IJsonModel<OpenAIModelCollection>, IPersistableModel<OpenAIModelCollection> {
@@ -3525,9 +3652,15 @@ namespace OpenAI.Moderations {
         protected ModerationClient();
         [Experimental("SCME0002")]
         public ModerationClient(ModerationClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal ModerationClient(ClientPipeline pipeline, string model, ModerationClientOptions options);
         protected internal ModerationClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public ModerationClient(string model, ApiKeyCredential credential, ModerationClientOptions options);
         public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ModerationClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public ModerationClient(string model, AuthenticationPolicy authenticationPolicy, ModerationClientOptions options);
         [Experimental("OPENAI001")]
         public ModerationClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -3553,10 +3686,17 @@ namespace OpenAI.Moderations {
         public virtual Task<ClientResult<ModerationResultCollection>> ClassifyTextAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<ModerationResult>> ClassifyTextAsync(string input, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class ModerationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ModerationClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ModerationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -7067,11 +7207,11 @@ namespace OpenAI.Skills {
         protected SkillClient();
         [Experimental("SCME0002")]
         public SkillClient(SkillClientSettings settings);
-        public SkillClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public SkillClient(ApiKeyCredential credential, SkillClientOptions options);
         public SkillClient(ApiKeyCredential credential);
-        public SkillClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public SkillClient(AuthenticationPolicy authenticationPolicy, SkillClientOptions options);
         public SkillClient(AuthenticationPolicy authenticationPolicy);
-        protected internal SkillClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal SkillClient(ClientPipeline pipeline, SkillClientOptions options);
         public SkillClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -7099,9 +7239,16 @@ namespace OpenAI.Skills {
         public virtual ClientResult UploadSkillVersion(string skillId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual Task<ClientResult> UploadSkillVersionAsync(string skillId, BinaryContent content, string contentType, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class SkillClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class SkillClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public SkillClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }
@@ -7143,11 +7290,11 @@ namespace OpenAI.VectorStores {
         protected VectorStoreClient();
         [Experimental("SCME0002")]
         public VectorStoreClient(VectorStoreClientSettings settings);
-        public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public VectorStoreClient(ApiKeyCredential credential, VectorStoreClientOptions options);
         public VectorStoreClient(ApiKeyCredential credential);
-        public VectorStoreClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public VectorStoreClient(AuthenticationPolicy authenticationPolicy, VectorStoreClientOptions options);
         public VectorStoreClient(AuthenticationPolicy authenticationPolicy);
-        protected internal VectorStoreClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal VectorStoreClient(ClientPipeline pipeline, VectorStoreClientOptions options);
         public VectorStoreClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -7213,9 +7360,16 @@ namespace OpenAI.VectorStores {
         public virtual Task<ClientResult> UpdateVectorStoreFileAttributesAsync(string vectorStoreId, string fileId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult<VectorStoreFile>> UpdateVectorStoreFileAttributesAsync(string vectorStoreId, string fileId, IDictionary<string, BinaryData> attributes, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class VectorStoreClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class VectorStoreClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public VectorStoreClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -7406,11 +7560,11 @@ namespace OpenAI.Videos {
         protected VideoClient();
         [Experimental("SCME0002")]
         public VideoClient(VideoClientSettings settings);
-        public VideoClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public VideoClient(ApiKeyCredential credential, VideoClientOptions options);
         public VideoClient(ApiKeyCredential credential);
-        public VideoClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public VideoClient(AuthenticationPolicy authenticationPolicy, VideoClientOptions options);
         public VideoClient(AuthenticationPolicy authenticationPolicy);
-        protected internal VideoClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal VideoClient(ClientPipeline pipeline, VideoClientOptions options);
         public VideoClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -7428,9 +7582,16 @@ namespace OpenAI.Videos {
         public virtual CollectionResult GetVideos(int? limit = null, string order = null, string after = null, RequestOptions options = null);
         public virtual AsyncCollectionResult GetVideosAsync(int? limit = null, string order = null, string after = null, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class VideoClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class VideoClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public VideoClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }

--- a/api/OpenAI.net8.0.cs
+++ b/api/OpenAI.net8.0.cs
@@ -124,11 +124,11 @@ namespace OpenAI.Assistants {
         protected AssistantClient();
         [Experimental("SCME0002")]
         public AssistantClient(AssistantClientSettings settings);
-        public AssistantClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public AssistantClient(ApiKeyCredential credential, AssistantClientOptions options);
         public AssistantClient(ApiKeyCredential credential);
-        public AssistantClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public AssistantClient(AuthenticationPolicy authenticationPolicy, AssistantClientOptions options);
         public AssistantClient(AuthenticationPolicy authenticationPolicy);
-        protected internal AssistantClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal AssistantClient(ClientPipeline pipeline, AssistantClientOptions options);
         public AssistantClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -230,9 +230,16 @@ namespace OpenAI.Assistants {
         public virtual CollectionResult<StreamingUpdate> SubmitToolOutputsToRunStreaming(string threadId, string runId, IEnumerable<ToolOutput> toolOutputs, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult<StreamingUpdate> SubmitToolOutputsToRunStreamingAsync(string threadId, string runId, IEnumerable<ToolOutput> toolOutputs, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class AssistantClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class AssistantClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public AssistantClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -963,9 +970,15 @@ namespace OpenAI.Audio {
         protected AudioClient();
         [Experimental("SCME0002")]
         public AudioClient(AudioClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal AudioClient(ClientPipeline pipeline, string model, AudioClientOptions options);
         protected internal AudioClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public AudioClient(string model, ApiKeyCredential credential, AudioClientOptions options);
         public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public AudioClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public AudioClient(string model, AuthenticationPolicy authenticationPolicy, AudioClientOptions options);
         [Experimental("OPENAI001")]
         public AudioClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -1037,10 +1050,17 @@ namespace OpenAI.Audio {
         [Experimental("OPENAI001")]
         public virtual Task<ClientResult> UpdateVoiceConsentAsync(string consentId, BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class AudioClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class AudioClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public AudioClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Flags]
@@ -1337,11 +1357,11 @@ namespace OpenAI.Batch {
         protected BatchClient();
         [Experimental("SCME0002")]
         public BatchClient(BatchClientSettings settings);
-        public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public BatchClient(ApiKeyCredential credential, BatchClientOptions options);
         public BatchClient(ApiKeyCredential credential);
-        public BatchClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public BatchClient(AuthenticationPolicy authenticationPolicy, BatchClientOptions options);
         public BatchClient(AuthenticationPolicy authenticationPolicy);
-        protected internal BatchClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal BatchClient(ClientPipeline pipeline, BatchClientOptions options);
         public BatchClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -1355,9 +1375,16 @@ namespace OpenAI.Batch {
         public virtual AsyncCollectionResult<BatchJob> GetBatchesAsync(BatchCollectionOptions options = null, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult GetBatchesAsync(string after, int? limit, RequestOptions options);
     }
+    [Experimental("OPENAI001")]
+    public class BatchClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class BatchClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public BatchClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -1435,9 +1462,15 @@ namespace OpenAI.Chat {
         protected ChatClient();
         [Experimental("SCME0002")]
         public ChatClient(ChatClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal ChatClient(ClientPipeline pipeline, string model, ChatClientOptions options);
         protected internal ChatClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public ChatClient(string model, ApiKeyCredential credential, ChatClientOptions options);
         public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ChatClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public ChatClient(string model, AuthenticationPolicy authenticationPolicy, ChatClientOptions options);
         [Experimental("OPENAI001")]
         public ChatClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -1499,10 +1532,17 @@ namespace OpenAI.Chat {
         [Experimental("OPENAI001")]
         public virtual Task<ClientResult<ChatCompletion>> UpdateChatCompletionAsync(string completionId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class ChatClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ChatClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ChatClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ChatCompletion : IJsonModel<ChatCompletion>, IPersistableModel<ChatCompletion> {
@@ -2190,11 +2230,11 @@ namespace OpenAI.Containers {
         protected ContainerClient();
         [Experimental("SCME0002")]
         public ContainerClient(ContainerClientSettings settings);
-        public ContainerClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public ContainerClient(ApiKeyCredential credential, ContainerClientOptions options);
         public ContainerClient(ApiKeyCredential credential);
-        public ContainerClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public ContainerClient(AuthenticationPolicy authenticationPolicy, ContainerClientOptions options);
         public ContainerClient(AuthenticationPolicy authenticationPolicy);
-        protected internal ContainerClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal ContainerClient(ClientPipeline pipeline, ContainerClientOptions options);
         public ContainerClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2234,9 +2274,16 @@ namespace OpenAI.Containers {
         public virtual ClientResult UploadContainerFile(string containerId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual Task<ClientResult> UploadContainerFileAsync(string containerId, BinaryContent content, string contentType, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class ContainerClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ContainerClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public ContainerClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -2349,11 +2396,11 @@ namespace OpenAI.Conversations {
         protected ConversationClient();
         [Experimental("SCME0002")]
         public ConversationClient(ConversationClientSettings settings);
-        public ConversationClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public ConversationClient(ApiKeyCredential credential, ConversationClientOptions options);
         public ConversationClient(ApiKeyCredential credential);
-        public ConversationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public ConversationClient(AuthenticationPolicy authenticationPolicy, ConversationClientOptions options);
         public ConversationClient(AuthenticationPolicy authenticationPolicy);
-        protected internal ConversationClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal ConversationClient(ClientPipeline pipeline, ConversationClientOptions options);
         public ConversationClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2375,9 +2422,16 @@ namespace OpenAI.Conversations {
         public virtual ClientResult UpdateConversation(string conversationId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> UpdateConversationAsync(string conversationId, BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class ConversationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ConversationClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public ConversationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -2408,9 +2462,15 @@ namespace OpenAI.Embeddings {
         protected EmbeddingClient();
         [Experimental("SCME0002")]
         public EmbeddingClient(EmbeddingClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal EmbeddingClient(ClientPipeline pipeline, string model, EmbeddingClientOptions options);
         protected internal EmbeddingClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public EmbeddingClient(string model, ApiKeyCredential credential, EmbeddingClientOptions options);
         public EmbeddingClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public EmbeddingClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy, EmbeddingClientOptions options);
         [Experimental("OPENAI001")]
         public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -2430,10 +2490,17 @@ namespace OpenAI.Embeddings {
         public virtual Task<ClientResult<OpenAIEmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<ReadOnlyMemory<int>> inputs, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIEmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<string> inputs, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class EmbeddingClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class EmbeddingClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public EmbeddingClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class EmbeddingGenerationOptions : IJsonModel<EmbeddingGenerationOptions>, IPersistableModel<EmbeddingGenerationOptions> {
@@ -2482,11 +2549,11 @@ namespace OpenAI.Evals {
         protected EvaluationClient();
         [Experimental("SCME0002")]
         public EvaluationClient(EvaluationClientSettings settings);
-        public EvaluationClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public EvaluationClient(ApiKeyCredential credential, EvaluationClientOptions options);
         public EvaluationClient(ApiKeyCredential credential);
-        public EvaluationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public EvaluationClient(AuthenticationPolicy authenticationPolicy, EvaluationClientOptions options);
         public EvaluationClient(AuthenticationPolicy authenticationPolicy);
-        protected internal EvaluationClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal EvaluationClient(ClientPipeline pipeline, EvaluationClientOptions options);
         public EvaluationClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2516,9 +2583,16 @@ namespace OpenAI.Evals {
         public virtual ClientResult UpdateEvaluation(string evaluationId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> UpdateEvaluationAsync(string evaluationId, BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class EvaluationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class EvaluationClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public EvaluationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }
@@ -2589,12 +2663,18 @@ namespace OpenAI.Files {
         protected OpenAIFileClient();
         [Experimental("SCME0002")]
         public OpenAIFileClient(OpenAIFileClientSettings settings);
+        [Experimental("OPENAI001")]
+        public OpenAIFileClient(ApiKeyCredential credential, OpenAIFileClientOptions options);
         public OpenAIFileClient(ApiKeyCredential credential, OpenAIClientOptions options);
         public OpenAIFileClient(ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public OpenAIFileClient(AuthenticationPolicy authenticationPolicy, OpenAIFileClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIFileClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIFileClient(AuthenticationPolicy authenticationPolicy);
+        [Experimental("OPENAI001")]
+        protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIFileClientOptions options);
         protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public OpenAIFileClient(string apiKey);
         [Experimental("OPENAI001")]
@@ -2647,9 +2727,16 @@ namespace OpenAI.Files {
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
     }
+    [Experimental("OPENAI001")]
+    public class OpenAIFileClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class OpenAIFileClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public OpenAIFileClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class OpenAIFileCollection : ObjectModel.ReadOnlyCollection<OpenAIFile>, IJsonModel<OpenAIFileCollection>, IPersistableModel<OpenAIFileCollection> {
@@ -2691,11 +2778,11 @@ namespace OpenAI.FineTuning {
         protected FineTuningClient();
         [Experimental("SCME0002")]
         public FineTuningClient(FineTuningClientSettings settings);
-        public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public FineTuningClient(ApiKeyCredential credential, FineTuningClientOptions options);
         public FineTuningClient(ApiKeyCredential credential);
-        public FineTuningClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public FineTuningClient(AuthenticationPolicy authenticationPolicy, FineTuningClientOptions options);
         public FineTuningClient(AuthenticationPolicy authenticationPolicy);
-        protected internal FineTuningClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal FineTuningClient(ClientPipeline pipeline, FineTuningClientOptions options);
         protected internal FineTuningClient(ClientPipeline pipeline, Uri endpoint);
         public FineTuningClient(string apiKey);
         [Experimental("OPENAI001")]
@@ -2720,9 +2807,16 @@ namespace OpenAI.FineTuning {
         public virtual ClientResult ResumeFineTuningJob(string fineTuningJobId, RequestOptions options);
         public virtual Task<ClientResult> ResumeFineTuningJobAsync(string fineTuningJobId, RequestOptions options);
     }
+    [Experimental("OPENAI001")]
+    public class FineTuningClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class FineTuningClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public FineTuningClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -2985,11 +3079,11 @@ namespace OpenAI.Graders {
         protected GraderClient();
         [Experimental("SCME0002")]
         public GraderClient(GraderClientSettings settings);
-        public GraderClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public GraderClient(ApiKeyCredential credential, GraderClientOptions options);
         public GraderClient(ApiKeyCredential credential);
-        public GraderClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public GraderClient(AuthenticationPolicy authenticationPolicy, GraderClientOptions options);
         public GraderClient(AuthenticationPolicy authenticationPolicy);
-        protected internal GraderClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal GraderClient(ClientPipeline pipeline, GraderClientOptions options);
         public GraderClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -2999,9 +3093,16 @@ namespace OpenAI.Graders {
         public virtual ClientResult ValidateGrader(BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> ValidateGraderAsync(BinaryContent content, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class GraderClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class GraderClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public GraderClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -3314,9 +3415,15 @@ namespace OpenAI.Images {
         protected ImageClient();
         [Experimental("SCME0002")]
         public ImageClient(ImageClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal ImageClient(ClientPipeline pipeline, string model, ImageClientOptions options);
         protected internal ImageClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public ImageClient(string model, ApiKeyCredential credential, ImageClientOptions options);
         public ImageClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ImageClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public ImageClient(string model, AuthenticationPolicy authenticationPolicy, ImageClientOptions options);
         [Experimental("OPENAI001")]
         public ImageClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -3362,10 +3469,17 @@ namespace OpenAI.Images {
         public virtual Task<ClientResult<GeneratedImageCollection>> GenerateImageVariationsAsync(Stream image, string imageFilename, int imageCount, ImageVariationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<GeneratedImageCollection>> GenerateImageVariationsAsync(string imageFilePath, int imageCount, ImageVariationOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class ImageClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ImageClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ImageClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ImageEditOptions : IJsonModel<ImageEditOptions>, IPersistableModel<ImageEditOptions> {
@@ -3467,12 +3581,18 @@ namespace OpenAI.Models {
         protected OpenAIModelClient();
         [Experimental("SCME0002")]
         public OpenAIModelClient(OpenAIModelClientSettings settings);
+        [Experimental("OPENAI001")]
+        public OpenAIModelClient(ApiKeyCredential credential, OpenAIModelClientOptions options);
         public OpenAIModelClient(ApiKeyCredential credential, OpenAIClientOptions options);
         public OpenAIModelClient(ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public OpenAIModelClient(AuthenticationPolicy authenticationPolicy, OpenAIModelClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIModelClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
         public OpenAIModelClient(AuthenticationPolicy authenticationPolicy);
+        [Experimental("OPENAI001")]
+        protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIModelClientOptions options);
         protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public OpenAIModelClient(string apiKey);
         [Experimental("OPENAI001")]
@@ -3491,9 +3611,16 @@ namespace OpenAI.Models {
         public virtual Task<ClientResult> GetModelsAsync(RequestOptions options);
         public virtual Task<ClientResult<OpenAIModelCollection>> GetModelsAsync(CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class OpenAIModelClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class OpenAIModelClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public OpenAIModelClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class OpenAIModelCollection : ObjectModel.ReadOnlyCollection<OpenAIModel>, IJsonModel<OpenAIModelCollection>, IPersistableModel<OpenAIModelCollection> {
@@ -3525,9 +3652,15 @@ namespace OpenAI.Moderations {
         protected ModerationClient();
         [Experimental("SCME0002")]
         public ModerationClient(ModerationClientSettings settings);
+        [Experimental("OPENAI001")]
+        protected internal ModerationClient(ClientPipeline pipeline, string model, ModerationClientOptions options);
         protected internal ModerationClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        [Experimental("OPENAI001")]
+        public ModerationClient(string model, ApiKeyCredential credential, ModerationClientOptions options);
         public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ModerationClient(string model, ApiKeyCredential credential);
+        [Experimental("OPENAI001")]
+        public ModerationClient(string model, AuthenticationPolicy authenticationPolicy, ModerationClientOptions options);
         [Experimental("OPENAI001")]
         public ModerationClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         [Experimental("OPENAI001")]
@@ -3553,10 +3686,17 @@ namespace OpenAI.Moderations {
         public virtual Task<ClientResult<ModerationResultCollection>> ClassifyTextAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<ModerationResult>> ClassifyTextAsync(string input, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class ModerationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class ModerationClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ModerationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -7067,11 +7207,11 @@ namespace OpenAI.Skills {
         protected SkillClient();
         [Experimental("SCME0002")]
         public SkillClient(SkillClientSettings settings);
-        public SkillClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public SkillClient(ApiKeyCredential credential, SkillClientOptions options);
         public SkillClient(ApiKeyCredential credential);
-        public SkillClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public SkillClient(AuthenticationPolicy authenticationPolicy, SkillClientOptions options);
         public SkillClient(AuthenticationPolicy authenticationPolicy);
-        protected internal SkillClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal SkillClient(ClientPipeline pipeline, SkillClientOptions options);
         public SkillClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -7099,9 +7239,16 @@ namespace OpenAI.Skills {
         public virtual ClientResult UploadSkillVersion(string skillId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual Task<ClientResult> UploadSkillVersionAsync(string skillId, BinaryContent content, string contentType, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class SkillClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class SkillClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public SkillClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }
@@ -7143,11 +7290,11 @@ namespace OpenAI.VectorStores {
         protected VectorStoreClient();
         [Experimental("SCME0002")]
         public VectorStoreClient(VectorStoreClientSettings settings);
-        public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public VectorStoreClient(ApiKeyCredential credential, VectorStoreClientOptions options);
         public VectorStoreClient(ApiKeyCredential credential);
-        public VectorStoreClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public VectorStoreClient(AuthenticationPolicy authenticationPolicy, VectorStoreClientOptions options);
         public VectorStoreClient(AuthenticationPolicy authenticationPolicy);
-        protected internal VectorStoreClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal VectorStoreClient(ClientPipeline pipeline, VectorStoreClientOptions options);
         public VectorStoreClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -7213,9 +7360,16 @@ namespace OpenAI.VectorStores {
         public virtual Task<ClientResult> UpdateVectorStoreFileAttributesAsync(string vectorStoreId, string fileId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult<VectorStoreFile>> UpdateVectorStoreFileAttributesAsync(string vectorStoreId, string fileId, IDictionary<string, BinaryData> attributes, CancellationToken cancellationToken = default);
     }
+    [Experimental("OPENAI001")]
+    public class VectorStoreClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class VectorStoreClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public VectorStoreClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Experimental("OPENAI001")]
@@ -7406,11 +7560,11 @@ namespace OpenAI.Videos {
         protected VideoClient();
         [Experimental("SCME0002")]
         public VideoClient(VideoClientSettings settings);
-        public VideoClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public VideoClient(ApiKeyCredential credential, VideoClientOptions options);
         public VideoClient(ApiKeyCredential credential);
-        public VideoClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public VideoClient(AuthenticationPolicy authenticationPolicy, VideoClientOptions options);
         public VideoClient(AuthenticationPolicy authenticationPolicy);
-        protected internal VideoClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal VideoClient(ClientPipeline pipeline, VideoClientOptions options);
         public VideoClient(string apiKey);
         [Experimental("OPENAI001")]
         public Uri Endpoint { get; }
@@ -7428,9 +7582,16 @@ namespace OpenAI.Videos {
         public virtual CollectionResult GetVideos(int? limit = null, string order = null, string after = null, RequestOptions options = null);
         public virtual AsyncCollectionResult GetVideosAsync(int? limit = null, string order = null, string after = null, RequestOptions options = null);
     }
+    [Experimental("OPENAI001")]
+    public class VideoClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     [Experimental("SCME0002")]
     public sealed class VideoClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public VideoClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }

--- a/api/OpenAI.netstandard2.0.cs
+++ b/api/OpenAI.netstandard2.0.cs
@@ -104,11 +104,11 @@ namespace OpenAI.Assistants {
     public class AssistantClient {
         protected AssistantClient();
         public AssistantClient(AssistantClientSettings settings);
-        public AssistantClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public AssistantClient(ApiKeyCredential credential, AssistantClientOptions options);
         public AssistantClient(ApiKeyCredential credential);
-        public AssistantClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public AssistantClient(AuthenticationPolicy authenticationPolicy, AssistantClientOptions options);
         public AssistantClient(AuthenticationPolicy authenticationPolicy);
-        protected internal AssistantClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal AssistantClient(ClientPipeline pipeline, AssistantClientOptions options);
         public AssistantClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -209,8 +209,14 @@ namespace OpenAI.Assistants {
         public virtual CollectionResult<StreamingUpdate> SubmitToolOutputsToRunStreaming(string threadId, string runId, IEnumerable<ToolOutput> toolOutputs, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult<StreamingUpdate> SubmitToolOutputsToRunStreamingAsync(string threadId, string runId, IEnumerable<ToolOutput> toolOutputs, CancellationToken cancellationToken = default);
     }
+    public class AssistantClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class AssistantClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public AssistantClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class AssistantCollectionOptions : IJsonModel<AssistantCollectionOptions>, IPersistableModel<AssistantCollectionOptions> {
@@ -863,9 +869,12 @@ namespace OpenAI.Audio {
     public class AudioClient {
         protected AudioClient();
         public AudioClient(AudioClientSettings settings);
+        protected internal AudioClient(ClientPipeline pipeline, string model, AudioClientOptions options);
         protected internal AudioClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public AudioClient(string model, ApiKeyCredential credential, AudioClientOptions options);
         public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public AudioClient(string model, ApiKeyCredential credential);
+        public AudioClient(string model, AuthenticationPolicy authenticationPolicy, AudioClientOptions options);
         public AudioClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         public AudioClient(string model, AuthenticationPolicy authenticationPolicy);
         public AudioClient(string model, string apiKey);
@@ -911,9 +920,15 @@ namespace OpenAI.Audio {
         public virtual ClientResult UpdateVoiceConsent(string consentId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> UpdateVoiceConsentAsync(string consentId, BinaryContent content, RequestOptions options = null);
     }
+    public class AudioClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class AudioClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public AudioClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     [Flags]
@@ -1172,11 +1187,11 @@ namespace OpenAI.Batch {
     public class BatchClient {
         protected BatchClient();
         public BatchClient(BatchClientSettings settings);
-        public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public BatchClient(ApiKeyCredential credential, BatchClientOptions options);
         public BatchClient(ApiKeyCredential credential);
-        public BatchClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public BatchClient(AuthenticationPolicy authenticationPolicy, BatchClientOptions options);
         public BatchClient(AuthenticationPolicy authenticationPolicy);
-        protected internal BatchClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal BatchClient(ClientPipeline pipeline, BatchClientOptions options);
         public BatchClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -1189,8 +1204,14 @@ namespace OpenAI.Batch {
         public virtual AsyncCollectionResult<BatchJob> GetBatchesAsync(BatchCollectionOptions options = null, CancellationToken cancellationToken = default);
         public virtual AsyncCollectionResult GetBatchesAsync(string after, int? limit, RequestOptions options);
     }
+    public class BatchClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class BatchClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public BatchClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class BatchCollectionOptions : IJsonModel<BatchCollectionOptions>, IPersistableModel<BatchCollectionOptions> {
@@ -1260,9 +1281,12 @@ namespace OpenAI.Chat {
     public class ChatClient {
         protected ChatClient();
         public ChatClient(ChatClientSettings settings);
+        protected internal ChatClient(ClientPipeline pipeline, string model, ChatClientOptions options);
         protected internal ChatClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public ChatClient(string model, ApiKeyCredential credential, ChatClientOptions options);
         public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ChatClient(string model, ApiKeyCredential credential);
+        public ChatClient(string model, AuthenticationPolicy authenticationPolicy, ChatClientOptions options);
         public ChatClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         public ChatClient(string model, AuthenticationPolicy authenticationPolicy);
         public ChatClient(string model, string apiKey);
@@ -1300,9 +1324,15 @@ namespace OpenAI.Chat {
         public virtual Task<ClientResult> UpdateChatCompletionAsync(string completionId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult<ChatCompletion>> UpdateChatCompletionAsync(string completionId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default);
     }
+    public class ChatClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class ChatClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ChatClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ChatCompletion : IJsonModel<ChatCompletion>, IPersistableModel<ChatCompletion> {
@@ -1903,11 +1933,11 @@ namespace OpenAI.Containers {
     public class ContainerClient {
         protected ContainerClient();
         public ContainerClient(ContainerClientSettings settings);
-        public ContainerClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public ContainerClient(ApiKeyCredential credential, ContainerClientOptions options);
         public ContainerClient(ApiKeyCredential credential);
-        public ContainerClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public ContainerClient(AuthenticationPolicy authenticationPolicy, ContainerClientOptions options);
         public ContainerClient(AuthenticationPolicy authenticationPolicy);
-        protected internal ContainerClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal ContainerClient(ClientPipeline pipeline, ContainerClientOptions options);
         public ContainerClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -1946,8 +1976,14 @@ namespace OpenAI.Containers {
         public virtual ClientResult UploadContainerFile(string containerId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual Task<ClientResult> UploadContainerFileAsync(string containerId, BinaryContent content, string contentType, RequestOptions options = null);
     }
+    public class ContainerClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class ContainerClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public ContainerClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ContainerCollectionOptions : IJsonModel<ContainerCollectionOptions>, IPersistableModel<ContainerCollectionOptions> {
@@ -2046,11 +2082,11 @@ namespace OpenAI.Conversations {
     public class ConversationClient {
         protected ConversationClient();
         public ConversationClient(ConversationClientSettings settings);
-        public ConversationClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public ConversationClient(ApiKeyCredential credential, ConversationClientOptions options);
         public ConversationClient(ApiKeyCredential credential);
-        public ConversationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public ConversationClient(AuthenticationPolicy authenticationPolicy, ConversationClientOptions options);
         public ConversationClient(AuthenticationPolicy authenticationPolicy);
-        protected internal ConversationClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal ConversationClient(ClientPipeline pipeline, ConversationClientOptions options);
         public ConversationClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -2071,8 +2107,14 @@ namespace OpenAI.Conversations {
         public virtual ClientResult UpdateConversation(string conversationId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> UpdateConversationAsync(string conversationId, BinaryContent content, RequestOptions options = null);
     }
+    public class ConversationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class ConversationClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public ConversationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public readonly partial struct IncludedConversationItemProperty : IEquatable<IncludedConversationItemProperty> {
@@ -2101,9 +2143,12 @@ namespace OpenAI.Embeddings {
     public class EmbeddingClient {
         protected EmbeddingClient();
         public EmbeddingClient(EmbeddingClientSettings settings);
+        protected internal EmbeddingClient(ClientPipeline pipeline, string model, EmbeddingClientOptions options);
         protected internal EmbeddingClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public EmbeddingClient(string model, ApiKeyCredential credential, EmbeddingClientOptions options);
         public EmbeddingClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public EmbeddingClient(string model, ApiKeyCredential credential);
+        public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy, EmbeddingClientOptions options);
         public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         public EmbeddingClient(string model, AuthenticationPolicy authenticationPolicy);
         public EmbeddingClient(string model, string apiKey);
@@ -2119,9 +2164,15 @@ namespace OpenAI.Embeddings {
         public virtual Task<ClientResult<OpenAIEmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<ReadOnlyMemory<int>> inputs, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIEmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<string> inputs, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
     }
+    public class EmbeddingClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class EmbeddingClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public EmbeddingClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class EmbeddingGenerationOptions : IJsonModel<EmbeddingGenerationOptions>, IPersistableModel<EmbeddingGenerationOptions> {
@@ -2163,11 +2214,11 @@ namespace OpenAI.Evals {
     public class EvaluationClient {
         protected EvaluationClient();
         public EvaluationClient(EvaluationClientSettings settings);
-        public EvaluationClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public EvaluationClient(ApiKeyCredential credential, EvaluationClientOptions options);
         public EvaluationClient(ApiKeyCredential credential);
-        public EvaluationClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public EvaluationClient(AuthenticationPolicy authenticationPolicy, EvaluationClientOptions options);
         public EvaluationClient(AuthenticationPolicy authenticationPolicy);
-        protected internal EvaluationClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal EvaluationClient(ClientPipeline pipeline, EvaluationClientOptions options);
         public EvaluationClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -2196,8 +2247,14 @@ namespace OpenAI.Evals {
         public virtual ClientResult UpdateEvaluation(string evaluationId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> UpdateEvaluationAsync(string evaluationId, BinaryContent content, RequestOptions options = null);
     }
+    public class EvaluationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class EvaluationClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public EvaluationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }
@@ -2261,10 +2318,13 @@ namespace OpenAI.Files {
     public class OpenAIFileClient {
         protected OpenAIFileClient();
         public OpenAIFileClient(OpenAIFileClientSettings settings);
+        public OpenAIFileClient(ApiKeyCredential credential, OpenAIFileClientOptions options);
         public OpenAIFileClient(ApiKeyCredential credential, OpenAIClientOptions options);
         public OpenAIFileClient(ApiKeyCredential credential);
+        public OpenAIFileClient(AuthenticationPolicy authenticationPolicy, OpenAIFileClientOptions options);
         public OpenAIFileClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         public OpenAIFileClient(AuthenticationPolicy authenticationPolicy);
+        protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIFileClientOptions options);
         protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public OpenAIFileClient(string apiKey);
         public Uri Endpoint { get; }
@@ -2306,8 +2366,14 @@ namespace OpenAI.Files {
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
     }
+    public class OpenAIFileClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class OpenAIFileClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public OpenAIFileClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class OpenAIFileCollection : ObjectModel.ReadOnlyCollection<OpenAIFile>, IJsonModel<OpenAIFileCollection>, IPersistableModel<OpenAIFileCollection> {
@@ -2343,11 +2409,11 @@ namespace OpenAI.FineTuning {
     public class FineTuningClient {
         protected FineTuningClient();
         public FineTuningClient(FineTuningClientSettings settings);
-        public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public FineTuningClient(ApiKeyCredential credential, FineTuningClientOptions options);
         public FineTuningClient(ApiKeyCredential credential);
-        public FineTuningClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public FineTuningClient(AuthenticationPolicy authenticationPolicy, FineTuningClientOptions options);
         public FineTuningClient(AuthenticationPolicy authenticationPolicy);
-        protected internal FineTuningClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal FineTuningClient(ClientPipeline pipeline, FineTuningClientOptions options);
         protected internal FineTuningClient(ClientPipeline pipeline, Uri endpoint);
         public FineTuningClient(string apiKey);
         public Uri Endpoint { get; }
@@ -2371,8 +2437,14 @@ namespace OpenAI.FineTuning {
         public virtual ClientResult ResumeFineTuningJob(string fineTuningJobId, RequestOptions options);
         public virtual Task<ClientResult> ResumeFineTuningJobAsync(string fineTuningJobId, RequestOptions options);
     }
+    public class FineTuningClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class FineTuningClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public FineTuningClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class FineTuningError : IJsonModel<FineTuningError>, IPersistableModel<FineTuningError> {
@@ -2611,11 +2683,11 @@ namespace OpenAI.Graders {
     public class GraderClient {
         protected GraderClient();
         public GraderClient(GraderClientSettings settings);
-        public GraderClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public GraderClient(ApiKeyCredential credential, GraderClientOptions options);
         public GraderClient(ApiKeyCredential credential);
-        public GraderClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public GraderClient(AuthenticationPolicy authenticationPolicy, GraderClientOptions options);
         public GraderClient(AuthenticationPolicy authenticationPolicy);
-        protected internal GraderClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal GraderClient(ClientPipeline pipeline, GraderClientOptions options);
         public GraderClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -2624,8 +2696,14 @@ namespace OpenAI.Graders {
         public virtual ClientResult ValidateGrader(BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult> ValidateGraderAsync(BinaryContent content, RequestOptions options = null);
     }
+    public class GraderClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class GraderClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public GraderClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class GraderLabelModel : Grader, IJsonModel<GraderLabelModel>, IPersistableModel<GraderLabelModel> {
@@ -2905,9 +2983,12 @@ namespace OpenAI.Images {
     public class ImageClient {
         protected ImageClient();
         public ImageClient(ImageClientSettings settings);
+        protected internal ImageClient(ClientPipeline pipeline, string model, ImageClientOptions options);
         protected internal ImageClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public ImageClient(string model, ApiKeyCredential credential, ImageClientOptions options);
         public ImageClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ImageClient(string model, ApiKeyCredential credential);
+        public ImageClient(string model, AuthenticationPolicy authenticationPolicy, ImageClientOptions options);
         public ImageClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         public ImageClient(string model, AuthenticationPolicy authenticationPolicy);
         public ImageClient(string model, string apiKey);
@@ -2949,9 +3030,15 @@ namespace OpenAI.Images {
         public virtual Task<ClientResult<GeneratedImageCollection>> GenerateImageVariationsAsync(Stream image, string imageFilename, int imageCount, ImageVariationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<GeneratedImageCollection>> GenerateImageVariationsAsync(string imageFilePath, int imageCount, ImageVariationOptions options = null);
     }
+    public class ImageClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class ImageClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ImageClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ImageEditOptions : IJsonModel<ImageEditOptions>, IPersistableModel<ImageEditOptions> {
@@ -3034,10 +3121,13 @@ namespace OpenAI.Models {
     public class OpenAIModelClient {
         protected OpenAIModelClient();
         public OpenAIModelClient(OpenAIModelClientSettings settings);
+        public OpenAIModelClient(ApiKeyCredential credential, OpenAIModelClientOptions options);
         public OpenAIModelClient(ApiKeyCredential credential, OpenAIClientOptions options);
         public OpenAIModelClient(ApiKeyCredential credential);
+        public OpenAIModelClient(AuthenticationPolicy authenticationPolicy, OpenAIModelClientOptions options);
         public OpenAIModelClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         public OpenAIModelClient(AuthenticationPolicy authenticationPolicy);
+        protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIModelClientOptions options);
         protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public OpenAIModelClient(string apiKey);
         public Uri Endpoint { get; }
@@ -3055,8 +3145,14 @@ namespace OpenAI.Models {
         public virtual Task<ClientResult> GetModelsAsync(RequestOptions options);
         public virtual Task<ClientResult<OpenAIModelCollection>> GetModelsAsync(CancellationToken cancellationToken = default);
     }
+    public class OpenAIModelClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class OpenAIModelClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public OpenAIModelClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class OpenAIModelCollection : ObjectModel.ReadOnlyCollection<OpenAIModel>, IJsonModel<OpenAIModelCollection>, IPersistableModel<OpenAIModelCollection> {
@@ -3084,9 +3180,12 @@ namespace OpenAI.Moderations {
     public class ModerationClient {
         protected ModerationClient();
         public ModerationClient(ModerationClientSettings settings);
+        protected internal ModerationClient(ClientPipeline pipeline, string model, ModerationClientOptions options);
         protected internal ModerationClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public ModerationClient(string model, ApiKeyCredential credential, ModerationClientOptions options);
         public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ModerationClient(string model, ApiKeyCredential credential);
+        public ModerationClient(string model, AuthenticationPolicy authenticationPolicy, ModerationClientOptions options);
         public ModerationClient(string model, AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
         public ModerationClient(string model, AuthenticationPolicy authenticationPolicy);
         public ModerationClient(string model, string apiKey);
@@ -3104,9 +3203,15 @@ namespace OpenAI.Moderations {
         public virtual Task<ClientResult<ModerationResultCollection>> ClassifyTextAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<ModerationResult>> ClassifyTextAsync(string input, CancellationToken cancellationToken = default);
     }
+    public class ModerationClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class ModerationClientSettings : ClientSettings {
         public string Model { get; set; }
-        public OpenAIClientOptions Options { get; set; }
+        public ModerationClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class ModerationInputPart : IJsonModel<ModerationInputPart>, IPersistableModel<ModerationInputPart> {
@@ -6173,11 +6278,11 @@ namespace OpenAI.Skills {
     public class SkillClient {
         protected SkillClient();
         public SkillClient(SkillClientSettings settings);
-        public SkillClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public SkillClient(ApiKeyCredential credential, SkillClientOptions options);
         public SkillClient(ApiKeyCredential credential);
-        public SkillClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public SkillClient(AuthenticationPolicy authenticationPolicy, SkillClientOptions options);
         public SkillClient(AuthenticationPolicy authenticationPolicy);
-        protected internal SkillClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal SkillClient(ClientPipeline pipeline, SkillClientOptions options);
         public SkillClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -6204,8 +6309,14 @@ namespace OpenAI.Skills {
         public virtual ClientResult UploadSkillVersion(string skillId, BinaryContent content, string contentType, RequestOptions options = null);
         public virtual Task<ClientResult> UploadSkillVersionAsync(string skillId, BinaryContent content, string contentType, RequestOptions options = null);
     }
+    public class SkillClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class SkillClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public SkillClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }
@@ -6241,11 +6352,11 @@ namespace OpenAI.VectorStores {
     public class VectorStoreClient {
         protected VectorStoreClient();
         public VectorStoreClient(VectorStoreClientSettings settings);
-        public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public VectorStoreClient(ApiKeyCredential credential, VectorStoreClientOptions options);
         public VectorStoreClient(ApiKeyCredential credential);
-        public VectorStoreClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public VectorStoreClient(AuthenticationPolicy authenticationPolicy, VectorStoreClientOptions options);
         public VectorStoreClient(AuthenticationPolicy authenticationPolicy);
-        protected internal VectorStoreClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal VectorStoreClient(ClientPipeline pipeline, VectorStoreClientOptions options);
         public VectorStoreClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -6310,8 +6421,14 @@ namespace OpenAI.VectorStores {
         public virtual Task<ClientResult> UpdateVectorStoreFileAttributesAsync(string vectorStoreId, string fileId, BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult<VectorStoreFile>> UpdateVectorStoreFileAttributesAsync(string vectorStoreId, string fileId, IDictionary<string, BinaryData> attributes, CancellationToken cancellationToken = default);
     }
+    public class VectorStoreClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class VectorStoreClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public VectorStoreClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
     public class VectorStoreCollectionOptions : IJsonModel<VectorStoreCollectionOptions>, IPersistableModel<VectorStoreCollectionOptions> {
@@ -6482,11 +6599,11 @@ namespace OpenAI.Videos {
     public class VideoClient {
         protected VideoClient();
         public VideoClient(VideoClientSettings settings);
-        public VideoClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public VideoClient(ApiKeyCredential credential, VideoClientOptions options);
         public VideoClient(ApiKeyCredential credential);
-        public VideoClient(AuthenticationPolicy authenticationPolicy, OpenAIClientOptions options);
+        public VideoClient(AuthenticationPolicy authenticationPolicy, VideoClientOptions options);
         public VideoClient(AuthenticationPolicy authenticationPolicy);
-        protected internal VideoClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        protected internal VideoClient(ClientPipeline pipeline, VideoClientOptions options);
         public VideoClient(string apiKey);
         public Uri Endpoint { get; }
         public ClientPipeline Pipeline { get; }
@@ -6503,8 +6620,14 @@ namespace OpenAI.Videos {
         public virtual CollectionResult GetVideos(int? limit = null, string order = null, string after = null, RequestOptions options = null);
         public virtual AsyncCollectionResult GetVideosAsync(int? limit = null, string order = null, string after = null, RequestOptions options = null);
     }
+    public class VideoClientOptions : ClientPipelineOptions {
+        public Uri Endpoint { get; set; }
+        public string OrganizationId { get; set; }
+        public string ProjectId { get; set; }
+        public string UserAgentApplicationId { get; set; }
+    }
     public sealed class VideoClientSettings : ClientSettings {
-        public OpenAIClientOptions Options { get; set; }
+        public VideoClientOptions Options { get; set; }
         protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section);
     }
 }

--- a/tests/Assistants/AssistantsMockTests.cs
+++ b/tests/Assistants/AssistantsMockTests.cs
@@ -43,7 +43,7 @@ public class AssistantsMockTests : ClientTestBase
             data: [DONE]
             """);
 
-        OpenAIClientOptions options = new()
+        AssistantClientOptions options = new()
         {
             Transport = new MockPipelineTransport(_ => response)
             {
@@ -97,7 +97,7 @@ public class AssistantsMockTests : ClientTestBase
             data: [DONE]
             """);
 
-        OpenAIClientOptions options = new()
+        AssistantClientOptions options = new()
         {
             Transport = new MockPipelineTransport(_ => response)
             {

--- a/tests/Miscellaneous/ErrorHandlingMockTests.cs
+++ b/tests/Miscellaneous/ErrorHandlingMockTests.cs
@@ -74,7 +74,7 @@ public class ErrorHandlingMockTests : ClientTestBase
             }
             """;
         MockPipelineResponse response = new MockPipelineResponse(400).WithContent(content);
-        OpenAIClientOptions options = new OpenAIClientOptions
+        EvaluationClientOptions options = new EvaluationClientOptions
         {
             Transport = new MockPipelineTransport(_ => response) { ExpectSyncPipeline = !IsAsync },
         };

--- a/tests/UserAgentTests.cs
+++ b/tests/UserAgentTests.cs
@@ -24,7 +24,7 @@ public class UserAgentTests
             _ = m?.Request?.Headers?.TryGetValue("User-Agent", out userAgent);
         });
 
-        OpenAIClientOptions options = useApplicationId
+        ChatClientOptions options = useApplicationId
             ? new() { UserAgentApplicationId = "test-application-id",}
             : new();
 

--- a/tests/Utility/OpenAIRecordedTestBase.cs
+++ b/tests/Utility/OpenAIRecordedTestBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.ClientModel.TestFramework;
+﻿using System.ClientModel.Primitives;
+using Microsoft.ClientModel.TestFramework;
 using Microsoft.ClientModel.TestFramework.TestProxy.Admin;
 using NUnit.Framework;
 using OpenAI.Realtime;
@@ -29,11 +30,9 @@ namespace OpenAI.Tests.Utility
             JsonPathSanitizers.Add("$..encrypted_content");
         }
 
-        internal T GetProxiedOpenAIClient<T>(string overrideModel = null, OpenAIClientOptions options = default) where T : class
+        internal T GetProxiedOpenAIClient<T>(string overrideModel = null, ClientPipelineOptions options = default) where T : class
         {
-            options ??= new OpenAIClientOptions();
-
-            OpenAIClientOptions instrumentedOptions = InstrumentClientOptions(options);
+            ClientPipelineOptions instrumentedOptions = InstrumentClientOptions(options);
             T client = TestEnvironment.GetTestClient<T>(overrideModel, instrumentedOptions);
             T proxiedClient = CreateProxyFromClient<T>(client, null);
 

--- a/tests/Utility/OpenAIRecordedTestBase.cs
+++ b/tests/Utility/OpenAIRecordedTestBase.cs
@@ -32,6 +32,8 @@ namespace OpenAI.Tests.Utility
 
         internal T GetProxiedOpenAIClient<T>(string overrideModel = null, ClientPipelineOptions options = default) where T : class
         {
+            options ??= new OpenAIClientOptions();
+
             ClientPipelineOptions instrumentedOptions = InstrumentClientOptions(options);
             T client = TestEnvironment.GetTestClient<T>(overrideModel, instrumentedOptions);
             T proxiedClient = CreateProxyFromClient<T>(client, null);

--- a/tests/Utility/OpenAITestEnvironment.cs
+++ b/tests/Utility/OpenAITestEnvironment.cs
@@ -133,32 +133,50 @@ public class OpenAITestEnvironment : TestEnvironment
         }
     }
 
-    public T GetTestClient<T>(string modelName = default, OpenAIClientOptions options = default)
+    public T GetTestClient<T>(string modelName = default, ClientPipelineOptions options = default)
     {
-        options ??= new();
         var credential = ApiKeyCredential;
 
         object clientObject = typeof(T).Name switch
         {
-            nameof(AssistantClient) => new AssistantClient(credential, options),
-            nameof(AudioClient) => new AudioClient(modelName ?? TestModel.Audio_Whisper, credential, options),
-            nameof(BatchClient) => new BatchClient(credential, options),
-            nameof(ChatClient) => new ChatClient(modelName ?? TestModel.Chat, credential, options),
-            nameof(ContainerClient) => new ContainerClient(credential, options),
-            nameof(ConversationClient) => new ConversationClient(credential, options),
-            nameof(EmbeddingClient) => new EmbeddingClient(modelName ?? TestModel.Embeddings, credential, options),
-            nameof(OpenAIFileClient) => new OpenAIFileClient(credential, options),
-            nameof(FineTuningClient) => new FineTuningClient(credential, options),
-            nameof(ImageClient) => new ImageClient(modelName ?? TestModel.Images, credential, options),
-            nameof(OpenAIModelClient) => new OpenAIModelClient(credential, options),
-            nameof(ModerationClient) => new ModerationClient(modelName ?? TestModel.Moderations, credential, options),
-            nameof(VectorStoreClient) => new VectorStoreClient(credential, options),
-            nameof(OpenAIClient) => new OpenAIClient(credential, options),
-            nameof(SkillClient) => new SkillClient(credential, options),
+            nameof(AssistantClient) => new AssistantClient(credential, NormalizeOptions<AssistantClientOptions>(options)),
+            nameof(AudioClient) => new AudioClient(modelName ?? TestModel.Audio_Whisper, credential, NormalizeOptions<AudioClientOptions>(options)),
+            nameof(BatchClient) => new BatchClient(credential, NormalizeOptions<BatchClientOptions>(options)),
+            nameof(ChatClient) => new ChatClient(modelName ?? TestModel.Chat, credential, NormalizeOptions<ChatClientOptions>(options)),
+            nameof(ContainerClient) => new ContainerClient(credential, NormalizeOptions<ContainerClientOptions>(options)),
+            nameof(ConversationClient) => new ConversationClient(credential, NormalizeOptions<ConversationClientOptions>(options)),
+            nameof(EmbeddingClient) => new EmbeddingClient(modelName ?? TestModel.Embeddings, credential, NormalizeOptions<EmbeddingClientOptions>(options)),
+            nameof(OpenAIFileClient) => new OpenAIFileClient(credential, NormalizeOptions<OpenAIFileClientOptions>(options)),
+            nameof(FineTuningClient) => new FineTuningClient(credential, NormalizeOptions<FineTuningClientOptions>(options)),
+            nameof(ImageClient) => new ImageClient(modelName ?? TestModel.Images, credential, NormalizeOptions<ImageClientOptions>(options)),
+            nameof(OpenAIModelClient) => new OpenAIModelClient(credential, NormalizeOptions<OpenAIModelClientOptions>(options)),
+            nameof(ModerationClient) => new ModerationClient(modelName ?? TestModel.Moderations, credential, NormalizeOptions<ModerationClientOptions>(options)),
+            nameof(VectorStoreClient) => new VectorStoreClient(credential, NormalizeOptions<VectorStoreClientOptions>(options)),
+            nameof(OpenAIClient) => new OpenAIClient(credential, NormalizeOptions<OpenAIClientOptions>(options)),
+            nameof(SkillClient) => new SkillClient(credential, NormalizeOptions<SkillClientOptions>(options)),
             _ => throw new NotImplementedException($"Unsupported client type: {typeof(T).Name}"),
         };
 
         return (T)clientObject;
+    }
+
+    private static TOptions NormalizeOptions<TOptions>(ClientPipelineOptions options)
+        where TOptions : ClientPipelineOptions, new()
+    {
+        if (options is TOptions typedOptions)
+        {
+            return typedOptions;
+        }
+
+        TOptions normalizedOptions = new();
+
+        if (options is not null)
+        {
+            // Preserve mock transport when callers pass a different options type.
+            normalizedOptions.Transport = options.Transport;
+        }
+
+        return normalizedOptions;
     }
 
     public RealtimeClient GetTestRealtimeClient(RealtimeClientOptions options = default)


### PR DESCRIPTION
Addresses https://github.com/openai/openai-dotnet/issues/1111

GA Clients: AudioClient, ChatClient, EmbeddingClient, ImageClient, ModerationClient, OpenAIFileClient, OpenAIModelClient - keep both OpenAIClientOptions entry points along side new dedicated ClientOptions type.

Experimental Clients: AssistantClient, BatchClient, ContainerClient, ConversationClient, EvaluationClient, FineTuningClient, GraderClient, SkillClient, VectorStoreClient, VideoClient - fully replaced OpenAIClientOptions with dedicated ClientOptions types.