### PR TITLE
Update stale `gpt-4-vision-preview` comments in `CombinationExamples`

### DIFF
--- a/examples/CombinationExamples.cs
+++ b/examples/CombinationExamples.cs
@@ -27,7 +27,7 @@ public partial class CombinationExamples
         GeneratedImage imageGeneration = imageResult.Value;
         Console.WriteLine($"Majestic alpaca available at:\n{imageGeneration.ImageUri.AbsoluteUri}");
 
-        // Now, we'll ask a cranky art critic to evaluate the image using gpt-4-vision-preview:
+        // Now, we'll ask a cranky art critic to evaluate the image using gpt-4o-mini:
         ChatClient chatClient = new("gpt-4o-mini", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ChatCompletion chatCompletion = chatClient.CompleteChat(
             [
@@ -114,7 +114,7 @@ public partial class CombinationExamples
         Uri imageLocation = imageGenerationResult.Value.ImageUri;
         Console.WriteLine($"Creature image available at:\n{imageLocation.AbsoluteUri}");
 
-        // Now, we'll use gpt-4-vision-preview to get a hopelessly taken assessment from a usually exigent art connoisseur
+        // Now, we'll use gpt-4o-mini to get a hopelessly taken assessment from a usually exigent art connoisseur
         ChatClient imageCriticClient = new("gpt-4o-mini", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ClientResult<ChatCompletion> criticalAppraisalResult = await imageCriticClient.CompleteChatAsync(
             [


### PR DESCRIPTION
Fixes #1210.

### Summary

Two comments in `examples/CombinationExamples.cs` referred to `gpt-4-vision-preview` while the code below each comment was already instantiating a `ChatClient` with `gpt-4o-mini`. This patch updates the two comments to match the code.

### Diff (text only)

```diff
-        // Now, we'll ask a cranky art critic to evaluate the image using gpt-4-vision-preview:
+        // Now, we'll ask a cranky art critic to evaluate the image using gpt-4o-mini:
         ChatClient chatClient = new("gpt-4o-mini", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
```

```diff
-        // Now, we'll use gpt-4-vision-preview to get a hopelessly taken assessment from a usually exigent art connoisseur
+        // Now, we'll use gpt-4o-mini to get a hopelessly taken assessment from a usually exigent art connoisseur
         ChatClient imageCriticClient = new("gpt-4o-mini", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
```

### Why

A reader using `examples/` to learn the library might infer from the comments that `gpt-4-vision-preview` is the recommended model for the image-description sub-step, when the example code uses `gpt-4o-mini` and `gpt-4-vision-preview` is deprecated.

### Test plan

- Comments-only change — no executable code touched, no behavior change possible.
- `grep -n 'gpt-4-vision-preview' examples/CombinationExamples.cs` returns no matches after the change.
- Could not run `dotnet test OpenAI.slnx` locally (no .NET 10 SDK installed); CI will run the suite. The change cannot affect test outcomes.
- No public API impact → `./scripts/Export-Api.ps1` not required.
- `examples/CombinationExamples.cs` is not a snippet source (`tests/Snippets/` is) → `./scripts/Update-Snippets.ps1` not required.
- No regenerated code involved.