### PR TITLE
Set GH_REPO on release-notes edit step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
             --notes "See full changelog: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.release.tag_name }}/CHANGELOG.md"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0


### PR DESCRIPTION
## Problem

The `Update GitHub release notes` step in the `publish-nuget` job runs `gh release edit`, but that job has no checkout. Without `GH_REPO`, `gh` tries to infer the repo from local git state and fails:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This fails the job **before** `NuGet login` / `Publish package to nuget.org`, so the nuget.org publish never runs.

## Fix

Add `GH_REPO: ${{ github.repository }}` to the release-notes step's `env`, matching the `Upload release asset` step that already has it.

## Scope

Minimal, single-line change required to unblock the OIDC nuget publish test. Versioning/hardening changes are intentionally kept in a separate PR.
