### PR TITLE
Reset release VersionSuffix and clobber re-uploaded assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,7 @@ jobs:
       - name: Upload release asset
         run: gh release upload ${{ github.event.release.tag_name }}
           ${{ github.workspace }}/build-artifacts/packages/*.*nupkg
+          --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -179,6 +180,7 @@ jobs:
             --notes "See full changelog: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.release.tag_name }}/CHANGELOG.md"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
   <!-- Versioning -->
   <PropertyGroup>
     <VersionPrefix>2.11.0</VersionPrefix>
-    <VersionSuffix>oidc.test1</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Two small release-pipeline fixes. Tag-derived versioning was split out into a separate, lower-priority PR (#1220).

### 1. Reset `VersionSuffix` (`Directory.Build.props`)
`VersionSuffix` was left as `oidc.test1` from the OIDC publish test. Reset to empty so the next release publishes as stable `2.11.0` instead of a `-oidc.test1` prerelease.

### 2. `--clobber` on release asset upload (`.github/workflows/release.yml`)
`gh release upload` fails if an asset of the same name already exists, which breaks re-runs. `--clobber` makes re-publishing the same release idempotent.
