### PR TITLE
Defer streaming request content creation until enumeration

### DIFF
--- a/OpenAI/src/Custom/Assistants/AssistantClient.cs
+++ b/OpenAI/src/Custom/Assistants/AssistantClient.cs
@@ -690,10 +690,13 @@ public partial class AssistantClient
 
         runOptions ??= new();
         runOptions.Stream = true;
-        BinaryContent protocolContent = CreateThreadAndRunProtocolContent(assistantId, threadOptions, runOptions);
-
+        BinaryData protocolData = CreateThreadAndRunProtocolData(assistantId, threadOptions, runOptions);
         return new AsyncSseUpdateCollection<StreamingUpdate>(
-            async () => await CreateThreadAndRunAsync(protocolContent, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false),
+            async () =>
+            {
+                using BinaryContent protocolContent = BinaryContent.Create(protocolData);
+                return await CreateThreadAndRunAsync(protocolContent, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false);
+            },
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -715,10 +718,13 @@ public partial class AssistantClient
 
         runOptions ??= new();
         runOptions.Stream = true;
-        BinaryContent protocolContent = CreateThreadAndRunProtocolContent(assistantId, threadOptions, runOptions);
-
+        BinaryData protocolData = CreateThreadAndRunProtocolData(assistantId, threadOptions, runOptions);
         return new SseUpdateCollection<StreamingUpdate>(
-            () => CreateThreadAndRun(protocolContent, cancellationToken.ToRequestOptions(streaming: true)),
+            () =>
+            {
+                using BinaryContent protocolContent = BinaryContent.Create(protocolData);
+                return CreateThreadAndRun(protocolContent, cancellationToken.ToRequestOptions(streaming: true));
+            },
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -837,12 +843,15 @@ public partial class AssistantClient
     {
         Argument.AssertNotNullOrEmpty(threadId, nameof(threadId));
         Argument.AssertNotNullOrEmpty(runId, nameof(runId));
-
         var submitToolOutputsRunRequest = new InternalSubmitToolOutputsRunRequest(toolOutputs.ToList(), stream: true, null);
-        using BinaryContent content = BinaryContent.Create(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions);
+        BinaryData requestData = ModelReaderWriter.Write(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new AsyncSseUpdateCollection<StreamingUpdate>(
-            async () => await SubmitToolOutputsToRunAsync(threadId, runId, content, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false),
+            async () =>
+            {
+                using BinaryContent content = BinaryContent.Create(requestData);
+                return await SubmitToolOutputsToRunAsync(threadId, runId, content, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false);
+            },
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -864,12 +873,15 @@ public partial class AssistantClient
     {
         Argument.AssertNotNullOrEmpty(threadId, nameof(threadId));
         Argument.AssertNotNullOrEmpty(runId, nameof(runId));
-
         var submitToolOutputsRunRequest = new InternalSubmitToolOutputsRunRequest(toolOutputs.ToList(), stream: true, null);
-        using BinaryContent content = BinaryContent.Create(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions);
+        BinaryData requestData = ModelReaderWriter.Write(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new SseUpdateCollection<StreamingUpdate>(
-            () => SubmitToolOutputsToRun(threadId, runId, content, cancellationToken.ToRequestOptions(streaming: true)),
+            () =>
+            {
+                using BinaryContent content = BinaryContent.Create(requestData);
+                return SubmitToolOutputsToRun(threadId, runId, content, cancellationToken.ToRequestOptions(streaming: true));
+            },
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -962,6 +974,12 @@ public partial class AssistantClient
         string assistantId,
         ThreadCreationOptions threadOptions,
         RunCreationOptions runOptions)
+        => BinaryContent.Create(CreateThreadAndRunProtocolData(assistantId, threadOptions, runOptions));
+
+    private static BinaryData CreateThreadAndRunProtocolData(
+        string assistantId,
+        ThreadCreationOptions threadOptions,
+        RunCreationOptions runOptions)
     {
         Argument.AssertNotNullOrEmpty(assistantId, nameof(assistantId));
         InternalCreateThreadAndRunRequest internalRequest = new(
@@ -983,7 +1001,7 @@ public partial class AssistantClient
             responseFormat: runOptions.ResponseFormat,
             toolChoice: runOptions.ToolConstraint,
             additionalBinaryDataProperties: null);
-        return BinaryContent.Create(internalRequest, ModelSerializationExtensions.WireOptions);
+        return ModelReaderWriter.Write(internalRequest, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/OpenAI/src/Custom/Assistants/AssistantClient.cs
+++ b/OpenAI/src/Custom/Assistants/AssistantClient.cs
@@ -692,11 +692,12 @@ public partial class AssistantClient
         runOptions.Stream = true;
         BinaryData protocolData = CreateThreadAndRunProtocolData(assistantId, threadOptions, runOptions);
         return new AsyncSseUpdateCollection<StreamingUpdate>(
-            async () =>
+            async protocolData =>
             {
                 using BinaryContent protocolContent = BinaryContent.Create(protocolData);
                 return await CreateThreadAndRunAsync(protocolContent, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false);
             },
+            protocolData,
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -720,11 +721,12 @@ public partial class AssistantClient
         runOptions.Stream = true;
         BinaryData protocolData = CreateThreadAndRunProtocolData(assistantId, threadOptions, runOptions);
         return new SseUpdateCollection<StreamingUpdate>(
-            () =>
+            protocolData =>
             {
                 using BinaryContent protocolContent = BinaryContent.Create(protocolData);
                 return CreateThreadAndRun(protocolContent, cancellationToken.ToRequestOptions(streaming: true));
             },
+            protocolData,
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -847,11 +849,12 @@ public partial class AssistantClient
         BinaryData requestData = ModelReaderWriter.Write(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new AsyncSseUpdateCollection<StreamingUpdate>(
-            async () =>
+            async requestData =>
             {
                 using BinaryContent content = BinaryContent.Create(requestData);
                 return await SubmitToolOutputsToRunAsync(threadId, runId, content, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false);
             },
+            requestData,
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -877,11 +880,12 @@ public partial class AssistantClient
         BinaryData requestData = ModelReaderWriter.Write(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new SseUpdateCollection<StreamingUpdate>(
-            () =>
+            requestData =>
             {
                 using BinaryContent content = BinaryContent.Create(requestData);
                 return SubmitToolOutputsToRun(threadId, runId, content, cancellationToken.ToRequestOptions(streaming: true));
             },
+            requestData,
             StreamingUpdate.FromSseItem,
             cancellationToken);
     }
@@ -997,7 +1001,7 @@ public partial class AssistantClient
             truncationStrategy: runOptions.TruncationStrategy,
             parallelToolCalls: runOptions.AllowParallelToolCalls,
             model: runOptions.ModelOverride,
-            toolResources: threadOptions.ToolResources,
+            toolResources: threadOptions?.ToolResources,
             responseFormat: runOptions.ResponseFormat,
             toolChoice: runOptions.ToolConstraint,
             additionalBinaryDataProperties: null);

--- a/OpenAI/src/Custom/Assistants/AssistantClient.cs
+++ b/OpenAI/src/Custom/Assistants/AssistantClient.cs
@@ -691,6 +691,7 @@ public partial class AssistantClient
         runOptions ??= new();
         runOptions.Stream = true;
         BinaryData protocolData = CreateThreadAndRunProtocolData(assistantId, threadOptions, runOptions);
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new AsyncSseUpdateCollection<StreamingUpdate>(
             async protocolData =>
             {
@@ -720,6 +721,7 @@ public partial class AssistantClient
         runOptions ??= new();
         runOptions.Stream = true;
         BinaryData protocolData = CreateThreadAndRunProtocolData(assistantId, threadOptions, runOptions);
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new SseUpdateCollection<StreamingUpdate>(
             protocolData =>
             {
@@ -848,6 +850,7 @@ public partial class AssistantClient
         var submitToolOutputsRunRequest = new InternalSubmitToolOutputsRunRequest(toolOutputs.ToList(), stream: true, null);
         BinaryData requestData = ModelReaderWriter.Write(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new AsyncSseUpdateCollection<StreamingUpdate>(
             async requestData =>
             {
@@ -879,6 +882,7 @@ public partial class AssistantClient
         var submitToolOutputsRunRequest = new InternalSubmitToolOutputsRunRequest(toolOutputs.ToList(), stream: true, null);
         BinaryData requestData = ModelReaderWriter.Write(submitToolOutputsRunRequest, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new SseUpdateCollection<StreamingUpdate>(
             requestData =>
             {

--- a/OpenAI/src/Custom/Audio/AudioClient.cs
+++ b/OpenAI/src/Custom/Audio/AudioClient.cs
@@ -194,10 +194,14 @@ public partial class AudioClient
         options ??= new();
         options.StreamFormat = InternalCreateSpeechRequestStreamFormat.Sse;
         CreateSpeechGenerationOptions(text, voice, ref options);
+        BinaryData requestData = ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
-        using BinaryContent content = options.ToBinaryContent();
         return new AsyncSseUpdateCollection<StreamingSpeechUpdate>(
-            async () => await GenerateSpeechAsync(content, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false),
+            async () =>
+            {
+                using BinaryContent content = BinaryContent.Create(requestData);
+                return await GenerateSpeechAsync(content, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false);
+            },
             StreamingSpeechUpdate.DeserializeStreamingSpeechUpdate,
             cancellationToken);
     }
@@ -218,10 +222,14 @@ public partial class AudioClient
         options ??= new();
         options.StreamFormat = InternalCreateSpeechRequestStreamFormat.Sse;
         CreateSpeechGenerationOptions(text, voice, ref options);
+        BinaryData requestData = ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
-        using BinaryContent content = options.ToBinaryContent();
         return new SseUpdateCollection<StreamingSpeechUpdate>(
-            () => GenerateSpeech(content, cancellationToken.ToRequestOptions(streaming: true)),
+            () =>
+            {
+                using BinaryContent content = BinaryContent.Create(requestData);
+                return GenerateSpeech(content, cancellationToken.ToRequestOptions(streaming: true));
+            },
             StreamingSpeechUpdate.DeserializeStreamingSpeechUpdate,
             cancellationToken);
     }

--- a/OpenAI/src/Custom/Audio/AudioClient.cs
+++ b/OpenAI/src/Custom/Audio/AudioClient.cs
@@ -196,6 +196,7 @@ public partial class AudioClient
         CreateSpeechGenerationOptions(text, voice, ref options);
         BinaryData requestData = ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new AsyncSseUpdateCollection<StreamingSpeechUpdate>(
             async requestData =>
             {
@@ -225,6 +226,7 @@ public partial class AudioClient
         CreateSpeechGenerationOptions(text, voice, ref options);
         BinaryData requestData = ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new SseUpdateCollection<StreamingSpeechUpdate>(
             requestData =>
             {

--- a/OpenAI/src/Custom/Audio/AudioClient.cs
+++ b/OpenAI/src/Custom/Audio/AudioClient.cs
@@ -197,11 +197,12 @@ public partial class AudioClient
         BinaryData requestData = ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new AsyncSseUpdateCollection<StreamingSpeechUpdate>(
-            async () =>
+            async requestData =>
             {
                 using BinaryContent content = BinaryContent.Create(requestData);
                 return await GenerateSpeechAsync(content, cancellationToken.ToRequestOptions(streaming: true)).ConfigureAwait(false);
             },
+            requestData,
             StreamingSpeechUpdate.DeserializeStreamingSpeechUpdate,
             cancellationToken);
     }
@@ -225,11 +226,12 @@ public partial class AudioClient
         BinaryData requestData = ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new SseUpdateCollection<StreamingSpeechUpdate>(
-            () =>
+            requestData =>
             {
                 using BinaryContent content = BinaryContent.Create(requestData);
                 return GenerateSpeech(content, cancellationToken.ToRequestOptions(streaming: true));
             },
+            requestData,
             StreamingSpeechUpdate.DeserializeStreamingSpeechUpdate,
             cancellationToken);
     }

--- a/OpenAI/src/Custom/Chat/ChatClient.cs
+++ b/OpenAI/src/Custom/Chat/ChatClient.cs
@@ -250,10 +250,14 @@ public partial class ChatClient
 
         options ??= new();
         var clonedOptions = CreateChatCompletionOptions(messages, options, stream: true);
+        BinaryData requestData = ModelReaderWriter.Write(clonedOptions, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
-        using BinaryContent content = clonedOptions.ToBinaryContent();
         return new AsyncSseUpdateCollection<StreamingChatCompletionUpdate>(
-            async () => await CompleteChatAsync(content, requestOptions).ConfigureAwait(false),
+            async () =>
+            {
+                using BinaryContent content = BinaryContent.Create(requestData);
+                return await CompleteChatAsync(content, requestOptions).ConfigureAwait(false);
+            },
             StreamingChatCompletionUpdate.DeserializeStreamingChatCompletionUpdate,
             requestOptions.CancellationToken);
     }
@@ -277,10 +281,14 @@ public partial class ChatClient
 
         options ??= new();
         var clonedOptions = CreateChatCompletionOptions(messages, options, stream: true);
+        BinaryData requestData = ModelReaderWriter.Write(clonedOptions, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
-        using BinaryContent content = clonedOptions.ToBinaryContent();
         return new SseUpdateCollection<StreamingChatCompletionUpdate>(
-            () => CompleteChat(content, cancellationToken.ToRequestOptions(streaming: true)),
+            () =>
+            {
+                using BinaryContent content = BinaryContent.Create(requestData);
+                return CompleteChat(content, cancellationToken.ToRequestOptions(streaming: true));
+            },
             StreamingChatCompletionUpdate.DeserializeStreamingChatCompletionUpdate,
             cancellationToken);
     }

--- a/OpenAI/src/Custom/Chat/ChatClient.cs
+++ b/OpenAI/src/Custom/Chat/ChatClient.cs
@@ -253,11 +253,12 @@ public partial class ChatClient
         BinaryData requestData = ModelReaderWriter.Write(clonedOptions, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new AsyncSseUpdateCollection<StreamingChatCompletionUpdate>(
-            async () =>
+            async requestData =>
             {
                 using BinaryContent content = BinaryContent.Create(requestData);
                 return await CompleteChatAsync(content, requestOptions).ConfigureAwait(false);
             },
+            requestData,
             StreamingChatCompletionUpdate.DeserializeStreamingChatCompletionUpdate,
             requestOptions.CancellationToken);
     }
@@ -284,11 +285,12 @@ public partial class ChatClient
         BinaryData requestData = ModelReaderWriter.Write(clonedOptions, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
         return new SseUpdateCollection<StreamingChatCompletionUpdate>(
-            () =>
+            requestData =>
             {
                 using BinaryContent content = BinaryContent.Create(requestData);
                 return CompleteChat(content, cancellationToken.ToRequestOptions(streaming: true));
             },
+            requestData,
             StreamingChatCompletionUpdate.DeserializeStreamingChatCompletionUpdate,
             cancellationToken);
     }

--- a/OpenAI/src/Custom/Chat/ChatClient.cs
+++ b/OpenAI/src/Custom/Chat/ChatClient.cs
@@ -252,6 +252,7 @@ public partial class ChatClient
         var clonedOptions = CreateChatCompletionOptions(messages, options, stream: true);
         BinaryData requestData = ModelReaderWriter.Write(clonedOptions, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new AsyncSseUpdateCollection<StreamingChatCompletionUpdate>(
             async requestData =>
             {
@@ -284,6 +285,7 @@ public partial class ChatClient
         var clonedOptions = CreateChatCompletionOptions(messages, options, stream: true);
         BinaryData requestData = ModelReaderWriter.Write(clonedOptions, ModelSerializationExtensions.WireOptions, OpenAIContext.Default);
 
+        // CUSTOM: Defer BinaryContent creation to ensure it is not disposed before enumeration begins.
         return new SseUpdateCollection<StreamingChatCompletionUpdate>(
             requestData =>
             {

--- a/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
+++ b/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
@@ -17,7 +17,9 @@ namespace OpenAI;
 /// </summary>
 internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
 {
-    private readonly Func<Task<ClientResult>> _sendRequestAsync;
+    private readonly Func<Task<ClientResult>>? _sendRequestAsync;
+    private readonly Func<BinaryData, Task<ClientResult>>? _sendRequestWithDataAsync;
+    private readonly BinaryData? _requestData;
     private readonly Func<SseItem<byte[]>, IEnumerable<T>> _eventDeserializerFunc;
     private readonly CancellationToken _cancellationToken;
 
@@ -41,6 +43,20 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
         CancellationToken cancellationToken)
             : this(
                   sendRequestAsync,
+                  DeserializeSseToSingleViaJson(jsonSingleDeserializerFunc),
+                  cancellationToken)
+    {
+        Argument.AssertNotNull(jsonSingleDeserializerFunc, nameof(jsonSingleDeserializerFunc));
+    }
+
+    public AsyncSseUpdateCollection(
+        Func<BinaryData, Task<ClientResult>> sendRequestAsync,
+        BinaryData requestData,
+        Func<JsonElement, ModelReaderWriterOptions, T> jsonSingleDeserializerFunc,
+        CancellationToken cancellationToken)
+            : this(
+                  sendRequestAsync,
+                  requestData,
                   DeserializeSseToSingleViaJson(jsonSingleDeserializerFunc),
                   cancellationToken)
     {
@@ -72,6 +88,20 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
     }
 
     public AsyncSseUpdateCollection(
+        Func<BinaryData, Task<ClientResult>> sendRequestAsync,
+        BinaryData requestData,
+        Func<JsonElement, BinaryData, ModelReaderWriterOptions, T> jsonSingleDeserializerFunc,
+        CancellationToken cancellationToken)
+            : this(
+                  sendRequestAsync,
+                  requestData,
+                  DeserializeSseToSingleViaJson(jsonSingleDeserializerFunc),
+                  cancellationToken)
+    {
+        Argument.AssertNotNull(jsonSingleDeserializerFunc, nameof(jsonSingleDeserializerFunc));
+    }
+
+    public AsyncSseUpdateCollection(
         Func<Task<ClientResult>> sendRequestAsync,
         Func<SseItem<byte[]>, IEnumerable<T>> eventDeserializerFunc,
         CancellationToken cancellationToken)
@@ -84,6 +114,22 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
         _cancellationToken = cancellationToken;
     }
 
+    public AsyncSseUpdateCollection(
+        Func<BinaryData, Task<ClientResult>> sendRequestAsync,
+        BinaryData requestData,
+        Func<SseItem<byte[]>, IEnumerable<T>> eventDeserializerFunc,
+        CancellationToken cancellationToken)
+    {
+        Argument.AssertNotNull(sendRequestAsync, nameof(sendRequestAsync));
+        Argument.AssertNotNull(requestData, nameof(requestData));
+        Argument.AssertNotNull(eventDeserializerFunc, nameof(eventDeserializerFunc));
+
+        _sendRequestWithDataAsync = sendRequestAsync;
+        _requestData = requestData;
+        _eventDeserializerFunc = eventDeserializerFunc;
+        _cancellationToken = cancellationToken;
+    }
+
     public override ContinuationToken? GetContinuationToken(ClientResult page)
         // Continuation is not supported for SSE streams.
         => null;
@@ -92,7 +138,9 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
     {
         // We don't currently support resuming a dropped connection from the
         // last received event, so the response collection has a single element.
-        yield return await _sendRequestAsync();
+        yield return _sendRequestWithDataAsync is not null
+            ? await _sendRequestWithDataAsync(_requestData!)
+            : await _sendRequestAsync!();
     }
 
     protected async override IAsyncEnumerable<T> GetValuesFromPageAsync(ClientResult page)

--- a/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
+++ b/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
@@ -17,9 +17,7 @@ namespace OpenAI;
 /// </summary>
 internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
 {
-    private readonly Func<Task<ClientResult>>? _sendRequestAsync;
-    private readonly Func<BinaryData, Task<ClientResult>>? _sendRequestWithDataAsync;
-    private readonly BinaryData? _requestData;
+    private readonly Func<Task<ClientResult>> _sendRequestAsync;
     private readonly Func<SseItem<byte[]>, IEnumerable<T>> _eventDeserializerFunc;
     private readonly CancellationToken _cancellationToken;
 
@@ -119,15 +117,13 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
         BinaryData requestData,
         Func<SseItem<byte[]>, IEnumerable<T>> eventDeserializerFunc,
         CancellationToken cancellationToken)
+            : this(
+                  () => sendRequestAsync(requestData),
+                  eventDeserializerFunc,
+                  cancellationToken)
     {
         Argument.AssertNotNull(sendRequestAsync, nameof(sendRequestAsync));
         Argument.AssertNotNull(requestData, nameof(requestData));
-        Argument.AssertNotNull(eventDeserializerFunc, nameof(eventDeserializerFunc));
-
-        _sendRequestWithDataAsync = sendRequestAsync;
-        _requestData = requestData;
-        _eventDeserializerFunc = eventDeserializerFunc;
-        _cancellationToken = cancellationToken;
     }
 
     public override ContinuationToken? GetContinuationToken(ClientResult page)
@@ -138,9 +134,7 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
     {
         // We don't currently support resuming a dropped connection from the
         // last received event, so the response collection has a single element.
-        yield return _sendRequestWithDataAsync is not null
-            ? await _sendRequestWithDataAsync(_requestData!)
-            : await _sendRequestAsync!();
+        yield return await _sendRequestAsync();
     }
 
     protected async override IAsyncEnumerable<T> GetValuesFromPageAsync(ClientResult page)

--- a/OpenAI/src/Utility/SseUpdateCollection.cs
+++ b/OpenAI/src/Utility/SseUpdateCollection.cs
@@ -16,7 +16,9 @@ namespace OpenAI;
 /// </summary>
 internal class SseUpdateCollection<T> : CollectionResult<T>
 {
-    private readonly Func<ClientResult> _sendRequestFunc;
+    private readonly Func<ClientResult>? _sendRequestFunc;
+    private readonly Func<BinaryData, ClientResult>? _sendRequestWithDataFunc;
+    private readonly BinaryData? _requestData;
     private readonly Func<SseItem<byte[]>, IEnumerable<T>> _eventDeserializerFunc;
     private readonly CancellationToken _cancellationToken;
 
@@ -41,6 +43,20 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
         CancellationToken cancellationToken)
             : this(
                   sendRequestFunc,
+                  AsyncSseUpdateCollection<T>.DeserializeSseToSingleViaJson(jsonSingleDeserializerFunc),
+                  cancellationToken)
+    {
+        Argument.AssertNotNull(jsonSingleDeserializerFunc, nameof(jsonSingleDeserializerFunc));
+    }
+
+    public SseUpdateCollection(
+        Func<BinaryData, ClientResult> sendRequestFunc,
+        BinaryData requestData,
+        Func<JsonElement, ModelReaderWriterOptions, T> jsonSingleDeserializerFunc,
+        CancellationToken cancellationToken)
+            : this(
+                  sendRequestFunc,
+                  requestData,
                   AsyncSseUpdateCollection<T>.DeserializeSseToSingleViaJson(jsonSingleDeserializerFunc),
                   cancellationToken)
     {
@@ -73,6 +89,20 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
     }
 
     public SseUpdateCollection(
+        Func<BinaryData, ClientResult> sendRequestFunc,
+        BinaryData requestData,
+        Func<JsonElement, BinaryData, ModelReaderWriterOptions, T> jsonSingleDeserializerFunc,
+        CancellationToken cancellationToken)
+            : this(
+                  sendRequestFunc,
+                  requestData,
+                  AsyncSseUpdateCollection<T>.DeserializeSseToSingleViaJson(jsonSingleDeserializerFunc),
+                  cancellationToken)
+    {
+        Argument.AssertNotNull(jsonSingleDeserializerFunc, nameof(jsonSingleDeserializerFunc));
+    }
+
+    public SseUpdateCollection(
         Func<ClientResult> sendRequestFunc,
         Func<SseItem<byte[]>, IEnumerable<T>> eventDeserializerFunc,
         CancellationToken cancellationToken)
@@ -85,6 +115,22 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
         _cancellationToken = cancellationToken;
     }
 
+    public SseUpdateCollection(
+        Func<BinaryData, ClientResult> sendRequestFunc,
+        BinaryData requestData,
+        Func<SseItem<byte[]>, IEnumerable<T>> eventDeserializerFunc,
+        CancellationToken cancellationToken)
+    {
+        Argument.AssertNotNull(sendRequestFunc, nameof(sendRequestFunc));
+        Argument.AssertNotNull(requestData, nameof(requestData));
+        Argument.AssertNotNull(eventDeserializerFunc, nameof(eventDeserializerFunc));
+
+        _sendRequestWithDataFunc = sendRequestFunc;
+        _requestData = requestData;
+        _eventDeserializerFunc = eventDeserializerFunc;
+        _cancellationToken = cancellationToken;
+    }
+
     public override ContinuationToken? GetContinuationToken(ClientResult page)
         // Continuation is not supported for SSE streams.
         => null;
@@ -93,7 +139,9 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
     {
         // We don't currently support resuming a dropped connection from the
         // last received event, so the response collection has a single element.
-        yield return _sendRequestFunc();
+        yield return _sendRequestWithDataFunc is not null
+            ? _sendRequestWithDataFunc(_requestData!)
+            : _sendRequestFunc!();
     }
 
     protected override IEnumerable<T> GetValuesFromPage(ClientResult page)

--- a/OpenAI/src/Utility/SseUpdateCollection.cs
+++ b/OpenAI/src/Utility/SseUpdateCollection.cs
@@ -16,9 +16,7 @@ namespace OpenAI;
 /// </summary>
 internal class SseUpdateCollection<T> : CollectionResult<T>
 {
-    private readonly Func<ClientResult>? _sendRequestFunc;
-    private readonly Func<BinaryData, ClientResult>? _sendRequestWithDataFunc;
-    private readonly BinaryData? _requestData;
+    private readonly Func<ClientResult> _sendRequestFunc;
     private readonly Func<SseItem<byte[]>, IEnumerable<T>> _eventDeserializerFunc;
     private readonly CancellationToken _cancellationToken;
 
@@ -120,15 +118,13 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
         BinaryData requestData,
         Func<SseItem<byte[]>, IEnumerable<T>> eventDeserializerFunc,
         CancellationToken cancellationToken)
+            : this(
+                  () => sendRequestFunc(requestData),
+                  eventDeserializerFunc,
+                  cancellationToken)
     {
         Argument.AssertNotNull(sendRequestFunc, nameof(sendRequestFunc));
         Argument.AssertNotNull(requestData, nameof(requestData));
-        Argument.AssertNotNull(eventDeserializerFunc, nameof(eventDeserializerFunc));
-
-        _sendRequestWithDataFunc = sendRequestFunc;
-        _requestData = requestData;
-        _eventDeserializerFunc = eventDeserializerFunc;
-        _cancellationToken = cancellationToken;
     }
 
     public override ContinuationToken? GetContinuationToken(ClientResult page)
@@ -139,9 +135,7 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
     {
         // We don't currently support resuming a dropped connection from the
         // last received event, so the response collection has a single element.
-        yield return _sendRequestWithDataFunc is not null
-            ? _sendRequestWithDataFunc(_requestData!)
-            : _sendRequestFunc!();
+        yield return _sendRequestFunc();
     }
 
     protected override IEnumerable<T> GetValuesFromPage(ClientResult page)

--- a/tests/Assistants/AssistantsMockTests.cs
+++ b/tests/Assistants/AssistantsMockTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 using OpenAI.Assistants;
 using System.ClientModel;
 using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace OpenAI.Tests.Assistants;
@@ -127,4 +129,53 @@ public class AssistantsMockTests : ClientTestBase
         Assert.That(updates, Has.Count.EqualTo(1));
         Assert.That(updates[0].UpdateKind, Is.EqualTo(StreamingUpdateReason.RunCreated));
     }
+
+    [Test]
+    public async Task CreateThreadAndRunStreamingKeepsRequestContentAliveUntilEnumeration()
+    {
+        string requestBody = null;
+        MockPipelineResponse response = CreateStreamingRunResponse();
+        OpenAIClientOptions options = new()
+        {
+            Transport = new MockPipelineTransport(message =>
+            {
+                using MemoryStream stream = new();
+                message.Request.Content.WriteTo(stream);
+                requestBody = BinaryData.FromBytes(stream.ToArray()).ToString();
+                return response;
+            })
+            {
+                ExpectSyncPipeline = !IsAsync
+            }
+        };
+
+        AssistantClient client = new(s_fakeCredential, options);
+
+        if (IsAsync)
+        {
+            await foreach (StreamingUpdate _ in client.CreateThreadAndRunStreamingAsync("asst_abc"))
+            {
+            }
+        }
+        else
+        {
+            foreach (StreamingUpdate _ in client.CreateThreadAndRunStreaming("asst_abc"))
+            {
+            }
+        }
+
+        using JsonDocument requestDocument = JsonDocument.Parse(requestBody);
+        Assert.That(requestDocument.RootElement.GetProperty("assistant_id").GetString(), Is.EqualTo("asst_abc"));
+        Assert.That(requestDocument.RootElement.GetProperty("stream").GetBoolean(), Is.True);
+    }
+
+    private static MockPipelineResponse CreateStreamingRunResponse()
+        => new MockPipelineResponse(200).WithContent(
+            """
+            event: thread.run.created
+            data: {"id":"run_abc","object":"thread.run","status":"queued"}
+
+            event: done
+            data: [DONE]
+            """);
 }

--- a/tests/Assistants/AssistantsMockTests.cs
+++ b/tests/Assistants/AssistantsMockTests.cs
@@ -2,6 +2,7 @@ using Microsoft.ClientModel.TestFramework;
 using Microsoft.ClientModel.TestFramework.Mocks;
 using NUnit.Framework;
 using OpenAI.Assistants;
+using System;
 using System.ClientModel;
 using System.Collections.Generic;
 using System.IO;

--- a/tests/Audio/GenerateSpeechMockTests.cs
+++ b/tests/Audio/GenerateSpeechMockTests.cs
@@ -1,9 +1,13 @@
 ﻿using Microsoft.ClientModel.TestFramework;
+using Microsoft.ClientModel.TestFramework.Mocks;
 using NUnit.Framework;
 using OpenAI.Audio;
 using System;
 using System.ClientModel;
+using System.IO;
+using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenAI.Tests.Audio;
 
@@ -43,4 +47,52 @@ internal class GenerateSpeechMockTests : ClientTestBase
                 .With.Message.Contains(model)
                 .And.Message.Contains("OPENAI_ENABLE_TTS_SSE_STREAMING"));
     }
+
+    [Test]
+    public async Task GenerateSpeechStreamingKeepsRequestContentAliveUntilEnumeration()
+    {
+        string requestBody = null;
+        MockPipelineResponse response = CreateStreamingSpeechResponse();
+        OpenAIClientOptions options = new()
+        {
+            Transport = new MockPipelineTransport(message =>
+            {
+                using MemoryStream stream = new();
+                message.Request.Content.WriteTo(stream);
+                requestBody = BinaryData.FromBytes(stream.ToArray()).ToString();
+                return response;
+            })
+            {
+                ExpectSyncPipeline = !IsAsync
+            }
+        };
+        AudioClient client = CreateProxyFromClient(new AudioClient("gpt-4o-mini-tts", s_fakeCredential, options));
+
+        if (IsAsync)
+        {
+            await foreach (StreamingSpeechUpdate _ in client.GenerateSpeechStreamingAsync("text", GeneratedSpeechVoice.Alloy))
+            {
+            }
+        }
+        else
+        {
+            foreach (StreamingSpeechUpdate _ in client.GenerateSpeechStreaming("text", GeneratedSpeechVoice.Alloy))
+            {
+            }
+        }
+
+        using JsonDocument requestDocument = JsonDocument.Parse(requestBody);
+        Assert.That(requestDocument.RootElement.GetProperty("input").GetString(), Is.EqualTo("text"));
+        Assert.That(requestDocument.RootElement.GetProperty("stream_format").GetString(), Is.EqualTo("sse"));
+    }
+
+    private static MockPipelineResponse CreateStreamingSpeechResponse()
+        => new MockPipelineResponse(200).WithContent(
+            """
+            data: {"type":"speech.audio.delta","audio":"AQI="}
+
+            data: {"type":"speech.audio.done"}
+
+            data: [DONE]
+            """);
 }

--- a/tests/Audio/GenerateSpeechMockTests.cs
+++ b/tests/Audio/GenerateSpeechMockTests.cs
@@ -66,7 +66,7 @@ internal class GenerateSpeechMockTests : ClientTestBase
                 ExpectSyncPipeline = !IsAsync
             }
         };
-        AudioClient client = CreateProxyFromClient(new AudioClient("gpt-4o-mini-tts", s_fakeCredential, options));
+        AudioClient client = new("gpt-4o-mini-tts", s_fakeCredential, options);
 
         if (IsAsync)
         {

--- a/tests/Chat/ChatMockTests.cs
+++ b/tests/Chat/ChatMockTests.cs
@@ -6,7 +6,9 @@ using System;
 using System.ClientModel;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -288,6 +290,44 @@ public class ChatMockTests : ClientTestBase
         stopwatch.Stop();
 
         Assert.That(response.IsDisposed);
+    }
+
+    [Test]
+    public async Task CompleteChatStreamingKeepsRequestContentAliveUntilEnumeration()
+    {
+        string requestBody = null;
+        MockPipelineResponse response = CreateStreamingChatResponse();
+        OpenAIClientOptions clientOptions = new()
+        {
+            Transport = new MockPipelineTransport(message =>
+            {
+                using MemoryStream stream = new();
+                message.Request.Content.WriteTo(stream);
+                requestBody = BinaryData.FromBytes(stream.ToArray()).ToString();
+                return response;
+            })
+            {
+                ExpectSyncPipeline = !IsAsync
+            }
+        };
+        ChatClient client = CreateProxyFromClient(new ChatClient("model", s_fakeCredential, clientOptions));
+
+        if (IsAsync)
+        {
+            await foreach (StreamingChatCompletionUpdate _ in client.CompleteChatStreamingAsync(s_messages))
+            {
+            }
+        }
+        else
+        {
+            foreach (StreamingChatCompletionUpdate _ in client.CompleteChatStreaming(s_messages))
+            {
+            }
+        }
+
+        using JsonDocument requestDocument = JsonDocument.Parse(requestBody);
+        Assert.That(requestDocument.RootElement.GetProperty("stream").GetBoolean(), Is.True);
+        Assert.That(requestBody, Does.Contain("Message content."));
     }
 
     private OpenAIClientOptions GetClientOptionsWithMockResponse(int status, string content)

--- a/tests/Chat/ChatMockTests.cs
+++ b/tests/Chat/ChatMockTests.cs
@@ -310,7 +310,7 @@ public class ChatMockTests : ClientTestBase
                 ExpectSyncPipeline = !IsAsync
             }
         };
-        ChatClient client = CreateProxyFromClient(new ChatClient("model", s_fakeCredential, clientOptions));
+        ChatClient client = new("model", s_fakeCredential, clientOptions);
 
         if (IsAsync)
         {

--- a/tests/Chat/ChatMockTests.cs
+++ b/tests/Chat/ChatMockTests.cs
@@ -325,9 +325,54 @@ public class ChatMockTests : ClientTestBase
             }
         }
 
+        Assert.That(requestBody, Is.Not.Null, "Transport callback was never invoked");
         using JsonDocument requestDocument = JsonDocument.Parse(requestBody);
         Assert.That(requestDocument.RootElement.GetProperty("stream").GetBoolean(), Is.True);
         Assert.That(requestBody, Does.Contain("Message content."));
+    }
+
+    [Test]
+    public void CompleteChatWithDisposedRequestContentFailsWhenDeferredSendBegins()
+    {
+        MockPipelineResponse response = CreateStreamingChatResponse();
+        OpenAIClientOptions clientOptions = new()
+        {
+            Transport = new MockPipelineTransport(message =>
+            {
+                using MemoryStream stream = new();
+                message.Request.Content.WriteTo(stream);
+                return response;
+            })
+            {
+                ExpectSyncPipeline = !IsAsync
+            }
+        };
+        ChatClient client = new("model", s_fakeCredential, clientOptions);
+
+        if (IsAsync)
+        {
+            Func<Task<ClientResult>> deferredSend;
+            using (BinaryContent content = BinaryContent.Create(new MemoryStream("{}"u8.ToArray())))
+            {
+                deferredSend = async () => await client.CompleteChatAsync(content).ConfigureAwait(false);
+            }
+
+            Assert.That(
+                async () => await deferredSend(),
+                Throws.InstanceOf<ObjectDisposedException>());
+        }
+        else
+        {
+            Func<ClientResult> deferredSend;
+            using (BinaryContent content = BinaryContent.Create(new MemoryStream("{}"u8.ToArray())))
+            {
+                deferredSend = () => client.CompleteChat(content);
+            }
+
+            Assert.That(
+                () => deferredSend(),
+                Throws.InstanceOf<ObjectDisposedException>());
+        }
     }
 
     private OpenAIClientOptions GetClientOptionsWithMockResponse(int status, string content)


### PR DESCRIPTION
## Summary

- snapshot streaming JSON request payloads when the API is called
- create and dispose `BinaryContent` inside the deferred send when enumeration begins
- pass the snapshot through lightweight `SseUpdateCollection` and `AsyncSseUpdateCollection` adapter constructors
- cover chat, assistants, and speech streaming with request-serialization regressions

## Problem

Several streaming APIs created disposable request content before returning a lazy collection. The HTTP send does not begin until that collection is enumerated, so the request body could be disposed before the transport attempted to serialize it.

The affected paths were:

- chat completion streaming
- assistants thread-and-run streaming
- assistants submit-tool-outputs streaming
- speech generation streaming

## Approach

Each affected method serializes its request once to `BinaryData` at call time. This preserves the original call-time snapshot behavior while allowing a fresh `BinaryContent` instance to be created inside the deferred send and disposed only after that send completes.

The new collection constructors are adapters over the existing delegate-based constructors. They keep the collection internals on a single dispatch path while threading `BinaryData` explicitly at call sites.

Multipart transcription streaming is intentionally unchanged because its request content wraps a live stream and has different lifetime requirements.

## Tests

- added sync and async mock coverage for chat, assistants, and speech streaming that serializes request content only when enumeration starts
- added a negative chat regression demonstrating that stream-backed `BinaryContent` created outside a deferred send becomes unusable after disposal
- verified the transport callback ran before parsing the captured chat request
- ran the focused mock suite on .NET 10: 60 passed, 2 existing mode-specific skips
