### PR TITLE
Implement synchronous realtime receive updates

### DIFF
--- a/OpenAI/src/Custom/Realtime/RealtimeSessionClient.Protocol.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeSessionClient.Protocol.cs
@@ -116,7 +116,35 @@ public partial class RealtimeSessionClient
 
     public virtual IEnumerable<ClientResult> ReceiveUpdates(RequestOptions options)
     {
-        throw new NotImplementedException();
+        lock (_singleReceiveLock)
+        {
+            _receiveCollectionResult ??= new(WebSocket, options?.CancellationToken ?? default);
+        }
+
+        return EnumerateSync();
+
+        IEnumerable<ClientResult> EnumerateSync()
+        {
+            IAsyncEnumerator<ClientResult> enumerator = _receiveCollectionResult.GetAsyncEnumerator();
+
+            try
+            {
+                while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
+                {
+                    ClientResult result = enumerator.Current;
+                    BinaryData incomingMessage = result?.GetRawResponse()?.Content;
+                    if (incomingMessage is not null)
+                    {
+                        _parentClient?.RaiseOnReceivingCommand(this, incomingMessage);
+                    }
+                    yield return result;
+                }
+            }
+            finally
+            {
+                enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
     }
 
     private static Uri BuildSessionUri(Uri endpoint, string model, string intent)

--- a/OpenAI/src/Custom/Realtime/RealtimeSessionClient.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeSessionClient.cs
@@ -368,7 +368,16 @@ public partial class RealtimeSessionClient : IDisposable
 
     public virtual IEnumerable<RealtimeServerUpdate> ReceiveUpdates(CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        foreach (ClientResult protocolEvent in ReceiveUpdates(cancellationToken.ToRequestOptions()))
+        {
+            using PipelineResponse response = protocolEvent.GetRawResponse();
+            RealtimeServerUpdate nextUpdate = ModelReaderWriter.Read<RealtimeServerUpdate>(response.Content, ModelReaderWriterOptions.Json, OpenAIContext.Default);
+            // Skip null updates (e.g., conversation.item.done events that are intentionally ignored)
+            if (nextUpdate is not null)
+            {
+                yield return nextUpdate;
+            }
+        }
     }
 
     public virtual async Task SendCommandAsync(RealtimeClientCommand command, CancellationToken cancellationToken = default)

--- a/tests/Realtime/RealtimeUnitTests.cs
+++ b/tests/Realtime/RealtimeUnitTests.cs
@@ -3,7 +3,13 @@ using OpenAI.Realtime;
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenAI.Tests.Realtime;
 
@@ -135,5 +141,108 @@ public class RealtimeUnitTests
         var audioEndMs = root.GetProperty("audio_end_ms");
         Assert.That(audioEndMs.TryGetInt64(out long value), Is.True);
         Assert.That(value, Is.EqualTo(1235));
+    }
+
+    [Test]
+    public void ProtocolReceiveUpdatesCanBeEnumeratedSynchronously()
+    {
+        const string payload = """{"type":"response.created","event_id":"event_123"}""";
+        TestRealtimeSessionClient client = CreateRealtimeSessionClient(payload);
+
+        ClientResult update = client.ReceiveUpdates(new RequestOptions()).Single();
+
+        Assert.That(update, Is.Not.Null);
+        Assert.That(update.GetRawResponse().Content.ToString(), Is.EqualTo(payload));
+    }
+
+    [Test]
+    public void TypedReceiveUpdatesCanBeEnumeratedSynchronously()
+    {
+        TestRealtimeSessionClient client = CreateRealtimeSessionClient("""{"type":"response.created","event_id":"event_123"}""");
+
+        RealtimeServerUpdate update = client.ReceiveUpdates().Single();
+
+        Assert.That(update, Is.InstanceOf<RealtimeServerUpdateResponseCreated>());
+        Assert.That(((RealtimeServerUpdateResponseCreated)update).EventId, Is.EqualTo("event_123"));
+    }
+
+    private static TestRealtimeSessionClient CreateRealtimeSessionClient(string payload)
+        => new(new FakeWebSocket([Encoding.UTF8.GetBytes(payload)]));
+
+    private sealed class TestRealtimeSessionClient : RealtimeSessionClient
+    {
+        public TestRealtimeSessionClient(WebSocket webSocket)
+            : base(new ApiKeyCredential("test-key"), new Uri("wss://example.com/v1/realtime"), "gpt-realtime", null, null)
+        {
+            WebSocket = webSocket;
+        }
+    }
+
+    private sealed class FakeWebSocket : WebSocket
+    {
+        private readonly Queue<byte[]> _messages;
+        private WebSocketCloseStatus? _closeStatus;
+        private string _closeStatusDescription;
+        private WebSocketState _state = WebSocketState.Open;
+
+        public FakeWebSocket(IEnumerable<byte[]> messages)
+        {
+            _messages = new Queue<byte[]>(messages);
+        }
+
+        public override WebSocketCloseStatus? CloseStatus => _closeStatus;
+
+        public override string CloseStatusDescription => _closeStatusDescription;
+
+        public override WebSocketState State => _state;
+
+        public override string SubProtocol => "realtime";
+
+        public override void Abort()
+        {
+            _state = WebSocketState.Aborted;
+        }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+        {
+            _closeStatus = closeStatus;
+            _closeStatusDescription = statusDescription;
+            _state = WebSocketState.Closed;
+            return Task.CompletedTask;
+        }
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+        {
+            _closeStatus = closeStatus;
+            _closeStatusDescription = statusDescription;
+            _state = WebSocketState.CloseSent;
+            return Task.CompletedTask;
+        }
+
+        public override void Dispose()
+        {
+            _state = WebSocketState.Closed;
+            base.Dispose();
+        }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_messages.Count == 0)
+            {
+                _closeStatus = WebSocketCloseStatus.NormalClosure;
+                _closeStatusDescription = "done";
+                _state = WebSocketState.CloseReceived;
+                return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true, _closeStatus, _closeStatusDescription));
+            }
+
+            byte[] message = _messages.Dequeue();
+            Array.Copy(message, 0, buffer.Array, buffer.Offset, message.Length);
+            return Task.FromResult(new WebSocketReceiveResult(message.Length, WebSocketMessageType.Text, endOfMessage: true));
+        }
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+            => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- implement the public sync realtime receive APIs instead of throwing `NotImplementedException`
- reuse the existing async websocket receive pipeline through a blocking sync wrapper, matching the current sync patterns used for realtime session start and command send
- add realtime unit coverage with a fake websocket for both raw protocol updates and typed server updates

## Why
The SDK already exposes public sync receive methods on `RealtimeSessionClient`, but today they only fail at runtime with `NotImplementedException`. That is a rough surprise for callers, especially in a client that already offers sync wrappers for other realtime operations.

## Impact
Sync callers can now enumerate both protocol-level and typed realtime updates without dropping down to the async API.

## Validation
- manual code review of the sync wrapper and fake-websocket tests
- added focused unit tests for `ReceiveUpdates(RequestOptions)` and `ReceiveUpdates(CancellationToken)`
- local `dotnet test` was not run here because this machine does not currently have a `dotnet` SDK on PATH