### PR TITLE
Fix ResponseContentPart kind setter

### DIFF
--- a/OpenAI.Responses/src/Custom/ResponseContentPart.cs
+++ b/OpenAI.Responses/src/Custom/ResponseContentPart.cs
@@ -17,7 +17,7 @@ public partial class ResponseContentPart
     public ResponseContentPartKind Kind
     {
         get => InternalType.ToString().ToResponseContentPartKind();
-        private set => InternalType = Kind.ToSerialString();
+        private set => InternalType = value.ToSerialString();
     }
 
     // CUSTOM: Exposed input text properties.

--- a/tests/Responses/ResponsesSmokeTests.cs
+++ b/tests/Responses/ResponsesSmokeTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 
@@ -176,6 +177,27 @@ public partial class ResponsesSmokeTests
                 Assert.That(potatoPart.Kind, Is.EqualTo(ResponseContentPartKind.Unknown));
                 Assert.That(potatoPart.Text, Is.Null);
             });
+    }
+
+    [Test]
+    public void ContentPartKindSetterUpdatesBackingType()
+    {
+        ResponseContentPart contentPart = ResponseContentPart.CreateInputTextPart("hello");
+
+        PropertyInfo kindProperty = typeof(ResponseContentPart).GetProperty(
+            nameof(ResponseContentPart.Kind),
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        PropertyInfo internalTypeProperty = typeof(ResponseContentPart).GetProperty(
+            "InternalType",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.That(kindProperty, Is.Not.Null);
+        Assert.That(internalTypeProperty, Is.Not.Null);
+
+        kindProperty.SetValue(contentPart, ResponseContentPartKind.OutputText);
+
+        Assert.That(contentPart.Kind, Is.EqualTo(ResponseContentPartKind.OutputText));
+        Assert.That(internalTypeProperty.GetValue(contentPart)?.ToString(), Is.EqualTo("output_text"));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- fix `ResponseContentPart.Kind` to use the assigned `value` when updating `InternalType`
- add a smoke regression that exercises the private setter and verifies the backing type is updated

## Notes
- the current `ResponseContentPart` JSON deserialization path appears to set `InternalType` directly through concrete internal content types, so this looks like a latent correctness fix rather than a confirmed live deserialization failure