### PR TITLE
Fix data URI TryParse contract

### DIFF
--- a/OpenAI/src/Utility/DataEncodingHelpers.cs
+++ b/OpenAI/src/Utility/DataEncodingHelpers.cs
@@ -27,7 +27,17 @@ internal static partial class DataEncodingHelpers
         }
 
         string matchedBase64Data = parsedDataUri.Groups["data"].Value;
-        byte[] matchedBase64RawBytes = Convert.FromBase64String(matchedBase64Data);
+        byte[] matchedBase64RawBytes;
+        try
+        {
+            matchedBase64RawBytes = Convert.FromBase64String(matchedBase64Data);
+        }
+        catch (FormatException)
+        {
+            bytes = null;
+            bytesMediaType = null;
+            return false;
+        }
         
         bytes = BinaryData.FromBytes(matchedBase64RawBytes);
         bytesMediaType = parsedDataUri.Groups["type"].Value;

--- a/tests/Chat/ChatSmokeTests.cs
+++ b/tests/Chat/ChatSmokeTests.cs
@@ -1067,4 +1067,22 @@ public class ChatSmokeTests : ClientTestBase
 
         AssertExpectedFilePart(deserializedFilePart);
     }
+
+    [Test]
+    public void DeserializingInvalidFileDataUriThrowsArgumentException()
+    {
+        BinaryData data = BinaryData.FromString("""
+            {
+              "type": "file",
+              "file": {
+                "filename": "broken.txt",
+                "file_data": "data:text/plain;base64,%%"
+              }
+            }
+            """);
+
+        Assert.That(
+            () => ModelReaderWriter.Read<ChatMessageContentPart>(data),
+            Throws.TypeOf<ArgumentException>());
+    }
 }


### PR DESCRIPTION
## Summary
- catch invalid base64 payloads in `DataEncodingHelpers.TryParseDataUri` and return `false` instead of leaking `FormatException`
- add a chat smoke test that deserializes an invalid file data URI and verifies it is rejected with `ArgumentException`

## Notes
- this keeps the existing file-content validation behavior intact while fixing the `Try*` helper contract underneath it
- I intentionally did not change the separate `image_url` fallback behavior in this PR
- I was not able to run the test suite locally because the `dotnet` SDK is not installed in this environment