### PR TITLE
Add new expires_after parameter to file upload functions

### DIFF
--- a/OpenAI/src/Custom/Files/Internal/InternalFileUploadOptions.cs
+++ b/OpenAI/src/Custom/Files/Internal/InternalFileUploadOptions.cs
@@ -39,6 +39,12 @@ internal partial class InternalFileUploadOptions
 
         content.Add(Purpose.ToString(), "purpose");
 
+        if (ExpiresAfter is not null)
+        {
+            content.Add(ExpiresAfter.Value.Anchor, "expires_after[anchor]");
+            content.Add(ExpiresAfter.Value.Seconds, "expires_after[seconds]");
+        }
+
         return content;
     }
 }

--- a/OpenAI/src/Custom/Files/OpenAIFileClient.cs
+++ b/OpenAI/src/Custom/Files/OpenAIFileClient.cs
@@ -215,6 +215,7 @@ public partial class OpenAIFileClient
     {
         Argument.AssertNotNull(file, nameof(file));
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
+        Argument.AssertInRange(expiresAfterSeconds, 3600, 2592000, nameof(expiresAfterSeconds));
 
         InternalFileUploadOptions options = new()
         {

--- a/OpenAI/src/Custom/Files/OpenAIFileClient.cs
+++ b/OpenAI/src/Custom/Files/OpenAIFileClient.cs
@@ -143,6 +143,39 @@ public partial class OpenAIFileClient
     ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="expiresAfterSeconds">
+    ///     The number of seconds after creation that the file will expire.
+    ///     Must be between 3600 (1 hour) and 2592000 (30 days).
+    /// </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default)
+    {
+        Argument.AssertNotNull(file, nameof(file));
+        Argument.AssertNotNullOrEmpty(filename, nameof(filename));
+
+        InternalFileUploadOptions options = new()
+        {
+            Purpose = purpose,
+            ExpiresAfter = new InternalFileExpirationAfter("created_at", expiresAfterSeconds)
+        };
+
+        using MultiPartFormDataBinaryContent content = options.ToMultipartContent(file, filename);
+        ClientResult result = await UploadFileAsync(content, content.ContentType, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        return ClientResult.FromValue((OpenAIFile)result, result.GetRawResponse());
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file stream to upload. </param>
+    /// <param name="filename">
+    ///     The filename associated with the file stream. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
@@ -163,6 +196,39 @@ public partial class OpenAIFileClient
 
     /// <summary> Uploads a file that can be used across various operations. </summary>
     /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file stream to upload. </param>
+    /// <param name="filename">
+    ///     The filename associated with the file stream. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
+    /// </param>
+    /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="expiresAfterSeconds">
+    ///     The number of seconds after creation that the file will expire.
+    ///     Must be between 3600 (1 hour) and 2592000 (30 days).
+    /// </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
+    [Experimental("OPENAI001")]
+    public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default)
+    {
+        Argument.AssertNotNull(file, nameof(file));
+        Argument.AssertNotNullOrEmpty(filename, nameof(filename));
+
+        InternalFileUploadOptions options = new()
+        {
+            Purpose = purpose,
+            ExpiresAfter = new InternalFileExpirationAfter("created_at", expiresAfterSeconds)
+        };
+
+        using MultiPartFormDataBinaryContent content = options.ToMultipartContent(file, filename);
+        ClientResult result = UploadFile(content, content.ContentType, cancellationToken.ToRequestOptions());
+        return ClientResult.FromValue((OpenAIFile)result, result.GetRawResponse());
+    }
+
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
     /// <param name="file"> The file bytes to upload. </param>
     /// <param name="filename">
     ///     The filename associated with the file bytes. The filename's extension (for example: .json) will be used to
@@ -170,13 +236,22 @@ public partial class OpenAIFileClient
     ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="expiresAfterSeconds">
+    ///     The number of seconds after creation that the file will expire.
+    ///     Must be between 3600 (1 hour) and 2592000 (30 days).
+    /// </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
-    public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose)
+    [Experimental("OPENAI001")]
+    public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null)
     {
         Argument.AssertNotNull(file, nameof(file));
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
 
+        if (expiresAfterSeconds.HasValue)
+        {
+            return UploadFileAsync(file?.ToStream(), filename, purpose, expiresAfterSeconds.Value);
+        }
         return UploadFileAsync(file?.ToStream(), filename, purpose);
     }
 
@@ -189,13 +264,22 @@ public partial class OpenAIFileClient
     ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
+    /// <param name="expiresAfterSeconds">
+    ///     The number of seconds after creation that the file will expire.
+    ///     Must be between 3600 (1 hour) and 2592000 (30 days).
+    /// </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
-    public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose)
+    [Experimental("OPENAI001")]
+    public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null)
     {
         Argument.AssertNotNull(file, nameof(file));
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
 
+        if (expiresAfterSeconds.HasValue)
+        {
+            return UploadFile(file?.ToStream(), filename, purpose, expiresAfterSeconds.Value);
+        }
         return UploadFile(file?.ToStream(), filename, purpose);
     }
 
@@ -209,11 +293,16 @@ public partial class OpenAIFileClient
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filePath"/> is an empty string, and was expected to be non-empty. </exception>
-    public virtual async Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose)
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null)
     {
         Argument.AssertNotNullOrEmpty(filePath, nameof(filePath));
 
         using FileStream stream = File.OpenRead(filePath);
+        if (expiresAfterSeconds.HasValue)
+        {
+            return await UploadFileAsync(stream, Path.GetFileName(filePath), purpose, expiresAfterSeconds.Value).ConfigureAwait(false);
+        }
         return await UploadFileAsync(stream, Path.GetFileName(filePath), purpose).ConfigureAwait(false);
     }
 
@@ -227,11 +316,16 @@ public partial class OpenAIFileClient
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filePath"/> is an empty string, and was expected to be non-empty. </exception>
-    public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose)
+    [Experimental("OPENAI001")]
+    public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null)
     {
         Argument.AssertNotNullOrEmpty(filePath, nameof(filePath));
 
         using FileStream stream = File.OpenRead(filePath);
+        if (expiresAfterSeconds.HasValue)
+        {
+            return UploadFile(stream, Path.GetFileName(filePath), purpose, expiresAfterSeconds.Value);
+        }
         return UploadFile(stream, Path.GetFileName(filePath), purpose);
     }
 

--- a/OpenAI/src/Custom/Files/OpenAIFileClient.cs
+++ b/OpenAI/src/Custom/Files/OpenAIFileClient.cs
@@ -155,7 +155,7 @@ public partial class OpenAIFileClient
     {
         Argument.AssertNotNull(file, nameof(file));
         Argument.AssertNotNullOrEmpty(filename, nameof(filename));
-
+        Argument.AssertInRange(expiresAfterSeconds, 3600, 2592000, nameof(expiresAfterSeconds));
         InternalFileUploadOptions options = new()
         {
             Purpose = purpose,

--- a/api/OpenAI.net10.0.cs
+++ b/api/OpenAI.net10.0.cs
@@ -2830,14 +2830,22 @@ namespace OpenAI.Files {
         [Experimental("OPENAI001")]
         public virtual Task<ClientResult> GetFilesAsync(string purpose, int? limit, string order, string after, RequestOptions options);
         public virtual Task<ClientResult<OpenAIFileCollection>> GetFilesAsync(CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose);
+        [Experimental("OPENAI001")]
+        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
         public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null);
+        [Experimental("OPENAI001")]
+        public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default);
         public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose);
+        [Experimental("OPENAI001")]
+        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
+        [Experimental("OPENAI001")]
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
         public virtual Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions options = null);
+        [Experimental("OPENAI001")]
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
+        [Experimental("OPENAI001")]
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
     }
     [Experimental("SCME0002")]
     public sealed class OpenAIFileClientSettings : ClientSettings {

--- a/api/OpenAI.net8.0.cs
+++ b/api/OpenAI.net8.0.cs
@@ -2830,14 +2830,22 @@ namespace OpenAI.Files {
         [Experimental("OPENAI001")]
         public virtual Task<ClientResult> GetFilesAsync(string purpose, int? limit, string order, string after, RequestOptions options);
         public virtual Task<ClientResult<OpenAIFileCollection>> GetFilesAsync(CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose);
+        [Experimental("OPENAI001")]
+        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
         public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null);
+        [Experimental("OPENAI001")]
+        public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default);
         public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose);
+        [Experimental("OPENAI001")]
+        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
+        [Experimental("OPENAI001")]
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
         public virtual Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions options = null);
+        [Experimental("OPENAI001")]
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
+        [Experimental("OPENAI001")]
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
     }
     [Experimental("SCME0002")]
     public sealed class OpenAIFileClientSettings : ClientSettings {

--- a/api/OpenAI.netstandard2.0.cs
+++ b/api/OpenAI.netstandard2.0.cs
@@ -2464,14 +2464,16 @@ namespace OpenAI.Files {
         public virtual Task<ClientResult> GetFilesAsync(string purpose, RequestOptions options);
         public virtual Task<ClientResult> GetFilesAsync(string purpose, int? limit, string order, string after, RequestOptions options);
         public virtual Task<ClientResult<OpenAIFileCollection>> GetFilesAsync(CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose);
+        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
         public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default);
         public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose);
+        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
         public virtual Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, int expiresAfterSeconds, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose, int? expiresAfterSeconds = null);
     }
     public sealed class OpenAIFileClientSettings : ClientSettings {
         public OpenAIClientOptions Options { get; set; }

--- a/tests/Chat/ChatSmokeTests.cs
+++ b/tests/Chat/ChatSmokeTests.cs
@@ -22,6 +22,7 @@ public class ChatSmokeTests : ClientTestBase
 {
     public ChatSmokeTests(bool isAsync) : base(isAsync)
     {
+        TestTimeoutInSeconds = 30;
     }
 
     [Test]

--- a/tests/Files/FilesMockTests.cs
+++ b/tests/Files/FilesMockTests.cs
@@ -420,6 +420,104 @@ public class FilesMockTests : ClientTestBase
                 Throws.InstanceOf<OperationCanceledException>());
     }
 
+#pragma warning disable OPENAI001
+    [Test]
+    [TestCaseSource(nameof(s_fileSourceKindSource))]
+    public async Task UploadFileWithExpirationIncludesExpiresAfterFields(FileSourceKind fileSourceKind)
+    {
+        string requestBody = null;
+        MockPipelineResponse response = new MockPipelineResponse(200).WithContent("""
+        {
+            "id": "returned_file_id"
+        }
+        """);
+
+        OpenAIClientOptions clientOptions = new()
+        {
+            Transport = new MockPipelineTransport(message =>
+            {
+                using MemoryStream stream = new();
+                message.Request.Content.WriteTo(stream);
+                requestBody = BinaryData.FromBytes(stream.ToArray()).ToString();
+                return response;
+            })
+            {
+                ExpectSyncPipeline = !IsAsync
+            }
+        };
+
+        OpenAIFileClient client = CreateProxyFromClient(new OpenAIFileClient(s_fakeCredential, clientOptions));
+        string filename = "images_dog_and_cat.png";
+        string path = Path.Combine("Assets", filename);
+        int expiresAfterSeconds = 3600;
+
+        if (fileSourceKind == FileSourceKind.UsingStream)
+        {
+            using FileStream file = File.OpenRead(path);
+            await client.UploadFileAsync(file, filename, FileUploadPurpose.Assistants, expiresAfterSeconds);
+        }
+        else if (fileSourceKind == FileSourceKind.UsingFilePath)
+        {
+            await client.UploadFileAsync(path, FileUploadPurpose.Assistants, expiresAfterSeconds);
+        }
+        else if (fileSourceKind == FileSourceKind.UsingBinaryData)
+        {
+            using FileStream file = File.OpenRead(path);
+            BinaryData content = BinaryData.FromStream(file);
+            await client.UploadFileAsync(content, filename, FileUploadPurpose.Assistants, expiresAfterSeconds);
+        }
+
+        string[] lines = requestBody.Split(["\r\n", "\n"], StringSplitOptions.None);
+        Assert.That(lines, Has.Some.Contains("name=\"expires_after[anchor]\""));
+        Assert.That(lines, Has.Some.Contains("name=\"expires_after[seconds]\""));
+        Assert.That(lines, Has.Some.EqualTo("created_at"));
+        Assert.That(lines, Has.Some.EqualTo("3600"));
+    }
+
+    [Test]
+    [TestCaseSource(nameof(s_fileSourceKindSource))]
+    public async Task UploadFileWithoutExpirationOmitsExpiresAfterFields(FileSourceKind fileSourceKind)
+    {
+        string requestBody = null;
+        MockPipelineResponse response = new MockPipelineResponse(200).WithContent("""
+        {
+            "id": "returned_file_id"
+        }
+        """);
+
+        OpenAIClientOptions clientOptions = new()
+        {
+            Transport = new MockPipelineTransport(message =>
+            {
+                using MemoryStream stream = new();
+                message.Request.Content.WriteTo(stream);
+                requestBody = BinaryData.FromBytes(stream.ToArray()).ToString();
+                return response;
+            })
+            {
+                ExpectSyncPipeline = !IsAsync
+            }
+        };
+
+        await InvokeUploadFileSyncOrAsync(clientOptions, fileSourceKind);
+
+        Assert.That(requestBody, Does.Not.Contain("expires_after"));
+    }
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(3599)]
+    [TestCase(2592001)]
+    public void UploadFileWithOutOfRangeExpirationThrows(int expiresAfterSeconds)
+    {
+        OpenAIFileClient client = CreateProxyFromClient(new OpenAIFileClient(s_fakeCredential));
+        using var stream = new MemoryStream(Array.Empty<byte>());
+
+        Assert.That(async () => await client.UploadFileAsync(stream, "file.txt", FileUploadPurpose.Assistants, expiresAfterSeconds),
+            Throws.InstanceOf<ArgumentOutOfRangeException>());
+    }
+#pragma warning restore OPENAI001
+
     private OpenAIClientOptions GetClientOptionsWithMockResponse(int status, string content)
     {
         MockPipelineResponse response = new MockPipelineResponse(status).WithContent(content);


### PR DESCRIPTION
Addresses https://github.com/openai/openai-dotnet/issues/635

Create overloads for Stream variant file upload functions that has optional cancellationToken parameter, and add optional int expireAfterSeconds to BinaryData and FilePath upload functions.