### PR TITLE
Move model JSON usage setting out of the emitter

### DIFF
--- a/codegen/emitter/src/emitter.ts
+++ b/codegen/emitter/src/emitter.ts
@@ -1,5 +1,4 @@
 import { EmitContext } from "@typespec/compiler";
-import { UsageFlags } from "@azure-tools/typespec-client-generator-core";
 
 import {
     emitCodeModel,
@@ -11,14 +10,7 @@ export async function $onEmit(context: EmitContext<CSharpEmitterOptions>) {
     context.options["generator-name"] = "OpenAILibraryGenerator";
     context.options["emitter-extension-path"] = import.meta.url;
 
-    const [, diagnostics] = await emitCodeModel(context, (model: CodeModel) => {
-        for (const m of model.models) {
-            if (m.usage & UsageFlags.MultipartFormData) {
-                m.usage = m.usage | UsageFlags.Json;
-            }
-        }
-        return model;
-    });
+    const [, diagnostics] = await emitCodeModel(context);
 
     if (diagnostics.length > 0) {
         context.program.reportDiagnostics(diagnostics);

--- a/codegen/generator/src/Visitors/ModelSerializationVisitor.cs
+++ b/codegen/generator/src/Visitors/ModelSerializationVisitor.cs
@@ -13,6 +13,12 @@ public class ModelSerializationVisitor : ScmLibraryVisitor
 {
     protected override ModelProvider? PreVisitModel(InputModelType model, ModelProvider? type)
     {
+        // Ensure multipart form data models also get JSON usage so that MRW serialization is generated.
+        if (model.Usage.HasFlag(InputModelTypeUsage.MultipartFormData) && !model.Usage.HasFlag(InputModelTypeUsage.Json))
+        {
+            model.Update(usage: model.Usage | InputModelTypeUsage.Json);
+        }
+
         if (type is null || model.Usage.HasFlag(InputModelTypeUsage.Json))
         {
             return base.PreVisitModel(model, type);


### PR DESCRIPTION
Addresses https://github.com/openai/openai-dotnet/issues/1232

With the generator update to add InputModelType Update function, we can now move model JSON usage setting from the emitter to visitor. This ensures consistency of keeping all OpenAI customization in visitors.