### PR TITLE
[Architecture] Replace `OPENAICUA001` experimental diagnostic with the standard `OPENAI001`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## (Unreleased)
+
+### Other Changes
+
+- OpenAI.Responses:
+  - Consolidated the experimental diagnostic used by the Computer Use tool types onto the standard `OPENAI001`. These types were previously marked with a dedicated `OPENAICUA001` code, which has been removed. Consumers who explicitly suppressed `OPENAICUA001` should suppress `OPENAI001` instead (the same code already used by the other experimental Responses APIs).
+
 ## 2.12.0 (2026-06-30)
 
 ### Acknowledgments

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
     <NoWarn>$(NoWarn);0169</NoWarn>
 
     <!-- Disable warnings for experimental APIs -->
-    <NoWarn>$(NoWarn);OPENAI001;OPENAI002;OPENAICUA001;SCME0001</NoWarn>
+    <NoWarn>$(NoWarn);OPENAI001;OPENAI002;SCME0001</NoWarn>
 
     <!-- Enable AOT for compatible target frameworks -->
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
@@ -112,6 +112,6 @@
       Reset the base ignores and reset to ignore XML doc comments
       on test types and members and experimental APIs.
     -->
-    <NoWarn>CS1591;OPENAI001;OPENAI002;OPENAICUA001;SCME0001</NoWarn>
+    <NoWarn>CS1591;OPENAI001;OPENAI002;SCME0001</NoWarn>
   </PropertyGroup>
 </Project>

--- a/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallActionKind.cs
+++ b/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallActionKind.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Responses;
 // CUSTOM:
 // - Added Experimental attribute.
 // - Renamed.
-[Experimental("OPENAICUA001")]
+[Experimental("OPENAI001")]
 [CodeGenType("ComputerActionType")]
 public enum ComputerCallActionKind
 {

--- a/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallActionMouseButton.cs
+++ b/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallActionMouseButton.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Responses;
 // CUSTOM:
 // - Added Experimental attribute.
 // - Renamed.
-[Experimental("OPENAICUA001")]
+[Experimental("OPENAI001")]
 [CodeGenType("ComputerActionClickButton")]
 public enum ComputerCallActionMouseButton
 {

--- a/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallOutputStatus.cs
+++ b/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallOutputStatus.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Responses;
 // CUSTOM:
 // - Added Experimental attribute.
 // - Renamed.
-[Experimental("OPENAICUA001")]
+[Experimental("OPENAI001")]
 [CodeGenType("ComputerToolCallOutputItemResourceStatus")]
 public enum ComputerCallOutputStatus
 {

--- a/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallStatus.cs
+++ b/OpenAI.Responses/src/Custom/Items/ComputerTool/ComputerCallStatus.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Responses;
 // CUSTOM:
 // - Added Experimental attribute.
 // - Renamed.
-[Experimental("OPENAICUA001")]
+[Experimental("OPENAI001")]
 [CodeGenType("ComputerToolCallItemResourceStatus")]
 public enum ComputerCallStatus
 {

--- a/OpenAI.Responses/src/Custom/Items/ResponseItem.cs
+++ b/OpenAI.Responses/src/Custom/Items/ResponseItem.cs
@@ -72,13 +72,13 @@ public partial class ResponseItem
             ]);
     }
 
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public static ComputerCallResponseItem CreateComputerCallItem(string callId, ComputerCallAction action, IEnumerable<ComputerCallSafetyCheck> pendingSafetyChecks)
     {
         return new ComputerCallResponseItem(callId, action, pendingSafetyChecks);
     }
 
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public static ComputerCallOutputResponseItem CreateComputerCallOutputItem(string callId, ComputerCallOutput output)
     {
         return new ComputerCallOutputResponseItem(callId, output);

--- a/OpenAI.Responses/src/Custom/Tools/ResponseTool.cs
+++ b/OpenAI.Responses/src/Custom/Tools/ResponseTool.cs
@@ -27,7 +27,7 @@ public partial class ResponseTool
     }
 
     // CUSTOM: Added factory method as a convenience.
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public static ComputerTool CreateComputerTool(ComputerToolEnvironment environment, int displayWidth, int displayHeight)
     {
         return new ComputerTool(

--- a/OpenAI.Responses/src/Custom/Tools/ResponseToolChoice.cs
+++ b/OpenAI.Responses/src/Custom/Tools/ResponseToolChoice.cs
@@ -28,7 +28,7 @@ public partial class ResponseToolChoice
     public static ResponseToolChoice CreateWebSearchChoice()
         => new(new InternalToolChoiceObjectWebSearch());
 
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public static ResponseToolChoice CreateComputerChoice()
         => new(new InternalToolChoiceObjectComputer());
 

--- a/OpenAI.Responses/src/Generated/Models/ComputerCallAction.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerCallAction.cs
@@ -9,7 +9,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenAI.Responses
 {
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public partial class ComputerCallAction
     {
         [Experimental("SCME0001")]

--- a/OpenAI.Responses/src/Generated/Models/ComputerCallOutput.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerCallOutput.cs
@@ -9,7 +9,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenAI.Responses
 {
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public partial class ComputerCallOutput
     {
         [Experimental("SCME0001")]

--- a/OpenAI.Responses/src/Generated/Models/ComputerCallOutputResponseItem.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerCallOutputResponseItem.cs
@@ -9,7 +9,7 @@ using OpenAI;
 
 namespace OpenAI.Responses
 {
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public partial class ComputerCallOutputResponseItem : ResponseItem
     {
         public ComputerCallOutputResponseItem(string callId, ComputerCallOutput output) : base(ResponseItemKind.ComputerCallOutput)

--- a/OpenAI.Responses/src/Generated/Models/ComputerCallResponseItem.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerCallResponseItem.cs
@@ -10,7 +10,7 @@ using OpenAI;
 
 namespace OpenAI.Responses
 {
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public partial class ComputerCallResponseItem : ResponseItem
     {
         public ComputerCallResponseItem(string callId, ComputerCallAction action, IEnumerable<ComputerCallSafetyCheck> pendingSafetyChecks) : base(ResponseItemKind.ComputerCall)

--- a/OpenAI.Responses/src/Generated/Models/ComputerCallSafetyCheck.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerCallSafetyCheck.cs
@@ -10,7 +10,7 @@ using OpenAI;
 
 namespace OpenAI.Responses
 {
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public partial class ComputerCallSafetyCheck
     {
         [Experimental("SCME0001")]

--- a/OpenAI.Responses/src/Generated/Models/ComputerToolEnvironment.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerToolEnvironment.cs
@@ -9,7 +9,7 @@ using OpenAI;
 
 namespace OpenAI.Responses
 {
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public readonly partial struct ComputerToolEnvironment : IEquatable<ComputerToolEnvironment>
     {
         private readonly string _value;

--- a/api/OpenAI.net10.0.cs
+++ b/api/OpenAI.net10.0.cs
@@ -5489,7 +5489,7 @@ namespace OpenAI.Responses {
         public ref JsonPatch Patch { get; }
         public static AutomaticCodeInterpreterToolContainerConfiguration CreateAutomaticContainerConfiguration(IEnumerable<string> fileIds = null);
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallAction : IJsonModel<ComputerCallAction>, IPersistableModel<ComputerCallAction> {
         public Drawing.Point? ClickCoordinates { get; }
         public ComputerCallActionMouseButton? ClickMouseButton { get; }
@@ -5516,7 +5516,7 @@ namespace OpenAI.Responses {
         public static ComputerCallAction CreateTypeAction(string typeText);
         public static ComputerCallAction CreateWaitAction();
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallActionKind {
         Click = 0,
         DoubleClick = 1,
@@ -5528,7 +5528,7 @@ namespace OpenAI.Responses {
         Type = 7,
         Wait = 8
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallActionMouseButton {
         Left = 0,
         Right = 1,
@@ -5536,7 +5536,7 @@ namespace OpenAI.Responses {
         Back = 3,
         Forward = 4
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallOutput : IJsonModel<ComputerCallOutput>, IPersistableModel<ComputerCallOutput> {
         [Serialization.JsonIgnore]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5546,7 +5546,7 @@ namespace OpenAI.Responses {
         public static ComputerCallOutput CreateScreenshotOutput(string screenshotImageFileId);
         public static ComputerCallOutput CreateScreenshotOutput(Uri screenshotImageUri);
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallOutputResponseItem : ResponseItem, IJsonModel<ComputerCallOutputResponseItem>, IPersistableModel<ComputerCallOutputResponseItem> {
         public ComputerCallOutputResponseItem(string callId, ComputerCallOutput output) : base(default);
         public IList<ComputerCallSafetyCheck> AcknowledgedSafetyChecks { get; }
@@ -5554,13 +5554,13 @@ namespace OpenAI.Responses {
         public ComputerCallOutput Output { get; set; }
         public ComputerCallOutputStatus? Status { get; set; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallOutputStatus {
         InProgress = 0,
         Completed = 1,
         Incomplete = 2
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallResponseItem : ResponseItem, IJsonModel<ComputerCallResponseItem>, IPersistableModel<ComputerCallResponseItem> {
         public ComputerCallResponseItem(string callId, ComputerCallAction action, IEnumerable<ComputerCallSafetyCheck> pendingSafetyChecks) : base(default);
         public ComputerCallAction Action { get; set; }
@@ -5568,7 +5568,7 @@ namespace OpenAI.Responses {
         public IList<ComputerCallSafetyCheck> PendingSafetyChecks { get; }
         public ComputerCallStatus? Status { get; set; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallSafetyCheck : IJsonModel<ComputerCallSafetyCheck>, IPersistableModel<ComputerCallSafetyCheck> {
         public ComputerCallSafetyCheck(string id, string code, string message);
         public string Code { get; set; }
@@ -5579,7 +5579,7 @@ namespace OpenAI.Responses {
         [Experimental("SCME0001")]
         public ref JsonPatch Patch { get; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallStatus {
         InProgress = 0,
         Completed = 1,
@@ -5592,7 +5592,7 @@ namespace OpenAI.Responses {
         public int DisplayWidth { get; set; }
         public ComputerToolEnvironment Environment { get; set; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public readonly partial struct ComputerToolEnvironment : IEquatable<ComputerToolEnvironment> {
         public ComputerToolEnvironment(string value);
         public static ComputerToolEnvironment Browser { get; }
@@ -6307,9 +6307,9 @@ namespace OpenAI.Responses {
         public static ApplyPatchCallOutputItem CreateApplyPatchCallOutputItem(string callId, ApplyPatchCallOutputStatus status);
         public static MessageResponseItem CreateAssistantMessageItem(IEnumerable<ResponseContentPart> contentParts);
         public static MessageResponseItem CreateAssistantMessageItem(string outputTextContent, IEnumerable<ResponseMessageAnnotation> annotations = null);
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ComputerCallResponseItem CreateComputerCallItem(string callId, ComputerCallAction action, IEnumerable<ComputerCallSafetyCheck> pendingSafetyChecks);
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ComputerCallOutputResponseItem CreateComputerCallOutputItem(string callId, ComputerCallOutput output);
         public static MessageResponseItem CreateDeveloperMessageItem(IEnumerable<ResponseContentPart> contentParts);
         public static MessageResponseItem CreateDeveloperMessageItem(string inputTextContent);
@@ -6695,7 +6695,7 @@ namespace OpenAI.Responses {
         public ref JsonPatch Patch { get; }
         public static ApplyPatchTool CreateApplyPatchTool();
         public static CodeInterpreterTool CreateCodeInterpreterTool(CodeInterpreterToolContainer container);
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ComputerTool CreateComputerTool(ComputerToolEnvironment environment, int displayWidth, int displayHeight);
         public static FileSearchTool CreateFileSearchTool(IEnumerable<string> vectorStoreIds, int? maxResultCount = null, FileSearchToolRankingOptions rankingOptions = null, BinaryData filters = null);
         public static FunctionTool CreateFunctionTool(string functionName, BinaryData functionParameters, bool? strictModeEnabled, string functionDescription = null);
@@ -6710,7 +6710,7 @@ namespace OpenAI.Responses {
         public string FunctionName { get; }
         public ResponseToolChoiceKind Kind { get; }
         public static ResponseToolChoice CreateAutoChoice();
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ResponseToolChoice CreateComputerChoice();
         public static ResponseToolChoice CreateFileSearchChoice();
         public static ResponseToolChoice CreateFunctionChoice(string functionName);

--- a/api/OpenAI.net8.0.cs
+++ b/api/OpenAI.net8.0.cs
@@ -5489,7 +5489,7 @@ namespace OpenAI.Responses {
         public ref JsonPatch Patch { get; }
         public static AutomaticCodeInterpreterToolContainerConfiguration CreateAutomaticContainerConfiguration(IEnumerable<string> fileIds = null);
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallAction : IJsonModel<ComputerCallAction>, IPersistableModel<ComputerCallAction> {
         public Drawing.Point? ClickCoordinates { get; }
         public ComputerCallActionMouseButton? ClickMouseButton { get; }
@@ -5516,7 +5516,7 @@ namespace OpenAI.Responses {
         public static ComputerCallAction CreateTypeAction(string typeText);
         public static ComputerCallAction CreateWaitAction();
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallActionKind {
         Click = 0,
         DoubleClick = 1,
@@ -5528,7 +5528,7 @@ namespace OpenAI.Responses {
         Type = 7,
         Wait = 8
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallActionMouseButton {
         Left = 0,
         Right = 1,
@@ -5536,7 +5536,7 @@ namespace OpenAI.Responses {
         Back = 3,
         Forward = 4
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallOutput : IJsonModel<ComputerCallOutput>, IPersistableModel<ComputerCallOutput> {
         [Serialization.JsonIgnore]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5546,7 +5546,7 @@ namespace OpenAI.Responses {
         public static ComputerCallOutput CreateScreenshotOutput(string screenshotImageFileId);
         public static ComputerCallOutput CreateScreenshotOutput(Uri screenshotImageUri);
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallOutputResponseItem : ResponseItem, IJsonModel<ComputerCallOutputResponseItem>, IPersistableModel<ComputerCallOutputResponseItem> {
         public ComputerCallOutputResponseItem(string callId, ComputerCallOutput output) : base(default);
         public IList<ComputerCallSafetyCheck> AcknowledgedSafetyChecks { get; }
@@ -5554,13 +5554,13 @@ namespace OpenAI.Responses {
         public ComputerCallOutput Output { get; set; }
         public ComputerCallOutputStatus? Status { get; set; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallOutputStatus {
         InProgress = 0,
         Completed = 1,
         Incomplete = 2
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallResponseItem : ResponseItem, IJsonModel<ComputerCallResponseItem>, IPersistableModel<ComputerCallResponseItem> {
         public ComputerCallResponseItem(string callId, ComputerCallAction action, IEnumerable<ComputerCallSafetyCheck> pendingSafetyChecks) : base(default);
         public ComputerCallAction Action { get; set; }
@@ -5568,7 +5568,7 @@ namespace OpenAI.Responses {
         public IList<ComputerCallSafetyCheck> PendingSafetyChecks { get; }
         public ComputerCallStatus? Status { get; set; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public class ComputerCallSafetyCheck : IJsonModel<ComputerCallSafetyCheck>, IPersistableModel<ComputerCallSafetyCheck> {
         public ComputerCallSafetyCheck(string id, string code, string message);
         public string Code { get; set; }
@@ -5579,7 +5579,7 @@ namespace OpenAI.Responses {
         [Experimental("SCME0001")]
         public ref JsonPatch Patch { get; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public enum ComputerCallStatus {
         InProgress = 0,
         Completed = 1,
@@ -5592,7 +5592,7 @@ namespace OpenAI.Responses {
         public int DisplayWidth { get; set; }
         public ComputerToolEnvironment Environment { get; set; }
     }
-    [Experimental("OPENAICUA001")]
+    [Experimental("OPENAI001")]
     public readonly partial struct ComputerToolEnvironment : IEquatable<ComputerToolEnvironment> {
         public ComputerToolEnvironment(string value);
         public static ComputerToolEnvironment Browser { get; }
@@ -6307,9 +6307,9 @@ namespace OpenAI.Responses {
         public static ApplyPatchCallOutputItem CreateApplyPatchCallOutputItem(string callId, ApplyPatchCallOutputStatus status);
         public static MessageResponseItem CreateAssistantMessageItem(IEnumerable<ResponseContentPart> contentParts);
         public static MessageResponseItem CreateAssistantMessageItem(string outputTextContent, IEnumerable<ResponseMessageAnnotation> annotations = null);
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ComputerCallResponseItem CreateComputerCallItem(string callId, ComputerCallAction action, IEnumerable<ComputerCallSafetyCheck> pendingSafetyChecks);
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ComputerCallOutputResponseItem CreateComputerCallOutputItem(string callId, ComputerCallOutput output);
         public static MessageResponseItem CreateDeveloperMessageItem(IEnumerable<ResponseContentPart> contentParts);
         public static MessageResponseItem CreateDeveloperMessageItem(string inputTextContent);
@@ -6695,7 +6695,7 @@ namespace OpenAI.Responses {
         public ref JsonPatch Patch { get; }
         public static ApplyPatchTool CreateApplyPatchTool();
         public static CodeInterpreterTool CreateCodeInterpreterTool(CodeInterpreterToolContainer container);
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ComputerTool CreateComputerTool(ComputerToolEnvironment environment, int displayWidth, int displayHeight);
         public static FileSearchTool CreateFileSearchTool(IEnumerable<string> vectorStoreIds, int? maxResultCount = null, FileSearchToolRankingOptions rankingOptions = null, BinaryData filters = null);
         public static FunctionTool CreateFunctionTool(string functionName, BinaryData functionParameters, bool? strictModeEnabled, string functionDescription = null);
@@ -6710,7 +6710,7 @@ namespace OpenAI.Responses {
         public string FunctionName { get; }
         public ResponseToolChoiceKind Kind { get; }
         public static ResponseToolChoice CreateAutoChoice();
-        [Experimental("OPENAICUA001")]
+        [Experimental("OPENAI001")]
         public static ResponseToolChoice CreateComputerChoice();
         public static ResponseToolChoice CreateFileSearchChoice();
         public static ResponseToolChoice CreateFunctionChoice(string functionName);

--- a/codegen/generator/src/Visitors/ExperimentalAttributeVisitor.cs
+++ b/codegen/generator/src/Visitors/ExperimentalAttributeVisitor.cs
@@ -20,7 +20,6 @@ namespace OpenAILibraryPlugin.Visitors
         private const string _realtimeNamespace = "OpenAI.Realtime";
         private static readonly AttributeStatement _experimental001Attribute = new(typeof(ExperimentalAttribute), Snippet.Literal("OPENAI001"));
         private static readonly AttributeStatement _experimental002Attribute = new(typeof(ExperimentalAttribute), Snippet.Literal("OPENAI002"));
-        private static readonly AttributeStatement _experimentalCUA001Attribute = new(typeof(ExperimentalAttribute), Snippet.Literal("OPENAICUA001"));
 
         // Stable sets loaded from the embedded ga-apis.yaml resource
         private static readonly HashSet<string> _stableClasses;
@@ -55,20 +54,6 @@ namespace OpenAILibraryPlugin.Visitors
                     current.Add(trimmed.Substring(2).Trim());
             }
         }
-
-        private static readonly HashSet<string> _OPENAICUA001AttributeTypes = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "ComputerCallAction",
-            "ComputerCallActionKind",
-            "ComputerCallActionMouseButton",
-            "ComputerCallOutputResponseItem",
-            "ComputerCallOutputStatus",
-            "ComputerCallResponseItem",
-            "ComputerCallSafetyCheck",
-            "ComputerCallStatus",
-            "ComputerCallOutput",
-            "ComputerToolEnvironment",
-        };
 
         protected override PropertyProvider? VisitProperty(PropertyProvider property)
         {
@@ -165,7 +150,6 @@ namespace OpenAILibraryPlugin.Visitors
                 AttributeStatement experimentalAttribute = type.Type.Namespace switch
                 {
                     _ when type.Type.Namespace.StartsWith(_realtimeNamespace) => _experimental002Attribute,
-                    _ when _OPENAICUA001AttributeTypes.Contains(type.Name) => _experimentalCUA001Attribute,
                     _ => _experimental001Attribute
                 };
                 type.Update(

--- a/tests/Containers/ContainerMockTests.cs
+++ b/tests/Containers/ContainerMockTests.cs
@@ -1,11 +1,11 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using OpenAI.Containers;
 using System;
 using System.ClientModel.Primitives;
 
 namespace OpenAI.Tests.Containers;
 
-#pragma warning disable OPENAICUA001
+#pragma warning disable OPENAI001
 
 [Category("Containers")]
 [Category("Smoke")]

--- a/tests/Responses/ResponseStoreTests.cs
+++ b/tests/Responses/ResponseStoreTests.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Tests.Responses;
 
-#pragma warning disable OPENAICUA001
+#pragma warning disable OPENAI001
 
 [Category("Responses")]
 [Category("ResponsesStore")]

--- a/tests/Responses/ResponsesSmokeTests.cs
+++ b/tests/Responses/ResponsesSmokeTests.cs
@@ -11,7 +11,7 @@ using System.Text.Json;
 
 namespace OpenAI.Tests.Responses;
 
-#pragma warning disable OPENAICUA001
+#pragma warning disable OPENAI001
 
 [Category("Responses")]
 [Category("Smoke")]

--- a/tests/Responses/ResponsesTests.cs
+++ b/tests/Responses/ResponsesTests.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Tests.Responses;
 
-#pragma warning disable OPENAICUA001
+#pragma warning disable OPENAI001
 
 [Category("Responses")]
 public partial class ResponsesTests : OpenAIRecordedTestBase


### PR DESCRIPTION
## Summary

The Computer Use (CUA) types were decorated with a separate experimental
diagnostic ID, `OPENAICUA001`, rather than the standard `OPENAI001` used
throughout the rest of the library. This change removes that one-off code so the
Computer Use surface is gated behind the same `[Experimental("OPENAI001")]`
diagnostic as every other experimental API.

## Motivation

Having a dedicated `OPENAICUA001` code for a single feature area added friction
for consumers (an extra warning code to suppress) with no offsetting benefit, and
was inconsistent with how the rest of the generated and hand-written surface is
attributed. Consolidating on `OPENAI001` simplifies the experimental opt-in story.

## Changes

- **Code generator (source of truth):** In `ExperimentalAttributeVisitor`, removed
  the `_experimentalCUA001Attribute` field, the `_OPENAICUA001AttributeTypes` set,
  and the corresponding `switch` branch in `VisitType`. The affected types now fall
  through to the standard `OPENAI001` attribute.

- **Custom (hand-written) code:** Updated 8 `[Experimental("OPENAICUA001")]`
  attributes across 7 files under `OpenAI.Responses/src/Custom/**`
  (`ComputerCallActionKind`, `ComputerCallActionMouseButton`,
  `ComputerCallOutputStatus`, `ComputerCallStatus`, `ResponseItem`,
  `ResponseTool`, `ResponseToolChoice`) to `OPENAI001`.

- **Generated code:** Updated the 6 generated model files
  (`ComputerCallAction`, `ComputerCallSafetyCheck`, `ComputerCallResponseItem`,
  `ComputerCallOutputResponseItem`, `ComputerCallOutput`, `ComputerToolEnvironment`)
  to `OPENAI001`.

- **API listings:** Updated `api/OpenAI.net10.0.cs` and `api/OpenAI.net8.0.cs`
  (`api/OpenAI.netstandard2.0.cs` had no occurrences).

- **Build configuration:** Removed `OPENAICUA001` from both `NoWarn` lists in
  `Directory.Build.props` (`OPENAI001` was already present).

- **Tests:** Updated 4 `#pragma warning disable OPENAICUA001` directives to
  `OPENAI001` (`ContainerMockTests`, `ResponseStoreTests`, `ResponsesSmokeTests`,
  `ResponsesTests`).