### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+Thank you for helping us keep the OpenAI .NET library secure.
+
+## Reporting a Vulnerability
+
+Do not report security vulnerabilities through public GitHub issues or pull
+requests.
+
+Please report suspected vulnerabilities through OpenAI's
+[Bugcrowd program](https://bugcrowd.com/engagements/openai). The program page
+contains OpenAI's vulnerability disclosure guidelines and scope.
+
+When possible, include:
+
+- the affected package version or commit;
+- the .NET runtime, target framework, and operating system;
+- steps to reproduce the issue or a minimal proof of concept;
+- the potential impact; and
+- any known mitigations or workarounds.
+
+Please allow OpenAI a reasonable opportunity to investigate and address the
+issue before sharing it publicly.
+
+## Scope
+
+This policy applies to the source code in this repository and the official
+[`OpenAI` NuGet package](https://www.nuget.org/packages/OpenAI) published from
+it.
+
+For vulnerabilities in other OpenAI products or services, use the same
+[OpenAI Bugcrowd program](https://bugcrowd.com/engagements/openai) and select
+the appropriate target.


### PR DESCRIPTION
## Summary

- add a root `SECURITY.md` that directs vulnerability reports to OpenAI's Bugcrowd program
- ask reporters for .NET- and package-specific reproduction details
- define scope for repository source and the official `OpenAI` NuGet package
- route issues in other OpenAI products through the appropriate Bugcrowd target

## Rationale

This follows the current OpenAI-owned repository pattern used by projects such as Codex and the Realtime voice component: private reporting through OpenAI's disclosure program, an explicit warning against public reports, and repository-specific scope. It intentionally omits the Stainless reporting language used by generated SDKs because this SDK is maintained independently.

## Validation

- `git diff --check origin/main...HEAD`
- documentation-only change; no product tests required
