### PR TITLE
Fix conversation include query serialization

### DIFF
--- a/OpenAI/src/Generated/ConversationClient.RestClient.cs
+++ b/OpenAI/src/Generated/ConversationClient.RestClient.cs
@@ -37,7 +37,10 @@ namespace OpenAI.Conversations
             }
             if (include != null && !(include is ChangeTrackingList<IncludedConversationItemProperty> changeTrackingList && changeTrackingList.IsUndefined))
             {
-                uri.AppendQueryDelimited("include", include, ",", escape: true);
+                foreach (var @param in include)
+                {
+                    uri.AppendQuery("include", @param.ToString(), true);
+                }
             }
             PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "GET", PipelineMessageClassifier200);
             PipelineRequest request = message.Request;
@@ -56,7 +59,10 @@ namespace OpenAI.Conversations
             uri.AppendPath("/items", false);
             if (include != null && !(include is ChangeTrackingList<IncludedConversationItemProperty> changeTrackingList && changeTrackingList.IsUndefined))
             {
-                uri.AppendQueryDelimited("include", include, ",", escape: true);
+                foreach (var @param in include)
+                {
+                    uri.AppendQuery("include", @param.ToString(), true);
+                }
             }
             PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "POST", PipelineMessageClassifier200);
             PipelineRequest request = message.Request;
@@ -94,7 +100,10 @@ namespace OpenAI.Conversations
             uri.AppendPath(itemId, true);
             if (include != null && !(include is ChangeTrackingList<IncludedConversationItemProperty> changeTrackingList && changeTrackingList.IsUndefined))
             {
-                uri.AppendQueryDelimited("include", include, ",", escape: true);
+                foreach (var @param in include)
+                {
+                    uri.AppendQuery("include", @param.ToString(), true);
+                }
             }
             PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "GET", PipelineMessageClassifier200);
             PipelineRequest request = message.Request;

--- a/OpenAI/src/Generated/ConversationClient.RestClient.cs
+++ b/OpenAI/src/Generated/ConversationClient.RestClient.cs
@@ -39,7 +39,7 @@ namespace OpenAI.Conversations
             {
                 foreach (var @param in include)
                 {
-                    uri.AppendQuery("include", @param.ToString(), true);
+                    uri.AppendQuery("include[]", @param.ToString(), true);
                 }
             }
             PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "GET", PipelineMessageClassifier200);
@@ -61,7 +61,7 @@ namespace OpenAI.Conversations
             {
                 foreach (var @param in include)
                 {
-                    uri.AppendQuery("include", @param.ToString(), true);
+                    uri.AppendQuery("include[]", @param.ToString(), true);
                 }
             }
             PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "POST", PipelineMessageClassifier200);
@@ -102,7 +102,7 @@ namespace OpenAI.Conversations
             {
                 foreach (var @param in include)
                 {
-                    uri.AppendQuery("include", @param.ToString(), true);
+                    uri.AppendQuery("include[]", @param.ToString(), true);
                 }
             }
             PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "GET", PipelineMessageClassifier200);

--- a/specification/base/typespec/conversations/models.tsp
+++ b/specification/base/typespec/conversations/models.tsp
@@ -113,7 +113,7 @@ model ConversationItemCollectionOptions {
    * This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, 
    * or when an organization is enrolled in the zero data retention program).
    * */
-  @query(#{ explode: true })
+  @query(#{ name: "include[]", explode: true })
   include?: IncludeEnum[],
 }
 

--- a/specification/base/typespec/conversations/models.tsp
+++ b/specification/base/typespec/conversations/models.tsp
@@ -113,7 +113,7 @@ model ConversationItemCollectionOptions {
    * This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, 
    * or when an organization is enrolled in the zero data retention program).
    * */
-  @query
+  @query(#{ explode: true })
   include?: IncludeEnum[],
 }
 

--- a/specification/base/typespec/conversations/operations.tsp
+++ b/specification/base/typespec/conversations/operations.tsp
@@ -31,7 +31,7 @@ op createConversationItems(
   /** Additional fields to include in the response. See the `include`
     * parameter for [listing Conversation items above](https://platform.openai.com/docs/api-reference/conversations/list-items#conversations_list_items-include)
     * for more information. */
-  @query(#{ explode: true })
+  @query(#{ name: "include[]", explode: true })
   include?: IncludeEnum[],
 
   @body
@@ -70,7 +70,7 @@ op getConversationItem(
   /** Additional fields to include in the response. See the `include`
     * parameter for [listing Conversation items above](https://platform.openai.com/docs/api-reference/conversations/list-items#conversations_list_items-include)
     * for more information. */
-  @query(#{ explode: true })
+  @query(#{ name: "include[]", explode: true })
   include?: IncludeEnum[],
 ): ItemResource;
 

--- a/specification/base/typespec/conversations/operations.tsp
+++ b/specification/base/typespec/conversations/operations.tsp
@@ -31,7 +31,7 @@ op createConversationItems(
   /** Additional fields to include in the response. See the `include`
     * parameter for [listing Conversation items above](https://platform.openai.com/docs/api-reference/conversations/list-items#conversations_list_items-include)
     * for more information. */
-  @query
+  @query(#{ explode: true })
   include?: IncludeEnum[],
 
   @body
@@ -70,7 +70,7 @@ op getConversationItem(
   /** Additional fields to include in the response. See the `include`
     * parameter for [listing Conversation items above](https://platform.openai.com/docs/api-reference/conversations/list-items#conversations_list_items-include)
     * for more information. */
-  @query
+  @query(#{ explode: true })
   include?: IncludeEnum[],
 ): ItemResource;
 

--- a/tests/Conversations/ConversationMockTests.cs
+++ b/tests/Conversations/ConversationMockTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.ClientModel.TestFramework.Mocks;
+using NUnit.Framework;
+using OpenAI.Conversations;
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Linq;
+
+namespace OpenAI.Tests.Conversations;
+
+#pragma warning disable OPENAI001
+
+[Category("Conversations")]
+[Category("Smoke")]
+public class ConversationMockTests
+{
+    private static readonly ApiKeyCredential s_fakeCredential = new("sk-not-a-real-key");
+    private static readonly IncludedConversationItemProperty[] s_includedProperties =
+    [
+        IncludedConversationItemProperty.MessageInputImageUri,
+        IncludedConversationItemProperty.WebSearchCallActionSources,
+    ];
+
+    [Test]
+    public void GetConversationItemsExplodesIncludeQuery()
+    {
+        (ConversationClient client, Func<Uri> getRequestUri) = CreateClient();
+
+        _ = client.GetConversationItems("conversation_123", include: s_includedProperties)
+            .GetRawPages()
+            .First();
+
+        AssertIncludeQuery(getRequestUri(), "/conversations/conversation_123/items");
+    }
+
+    [Test]
+    public void CreateConversationItemsExplodesIncludeQuery()
+    {
+        (ConversationClient client, Func<Uri> getRequestUri) = CreateClient();
+
+        _ = client.CreateConversationItems(
+            "conversation_123",
+            BinaryContent.Create(BinaryData.FromString("""{"items":[]}""")),
+            include: s_includedProperties);
+
+        AssertIncludeQuery(getRequestUri(), "/conversations/conversation_123/items");
+    }
+
+    [Test]
+    public void GetConversationItemExplodesIncludeQuery()
+    {
+        (ConversationClient client, Func<Uri> getRequestUri) = CreateClient();
+
+        _ = client.GetConversationItem(
+            "conversation_123",
+            "item_123",
+            include: s_includedProperties);
+
+        AssertIncludeQuery(getRequestUri(), "/conversations/conversation_123/items/item_123");
+    }
+
+    private static (ConversationClient Client, Func<Uri> GetRequestUri) CreateClient()
+    {
+        Uri requestUri = null;
+        MockPipelineResponse response = new(200);
+        OpenAIClientOptions options = new()
+        {
+            Endpoint = new Uri("https://example.invalid/v1"),
+            Transport = new MockPipelineTransport(message =>
+            {
+                requestUri = message.Request.Uri;
+                return response;
+            }),
+        };
+
+        return (new ConversationClient(s_fakeCredential, options), () => requestUri);
+    }
+
+    private static void AssertIncludeQuery(Uri requestUri, string path)
+    {
+        Assert.That(requestUri, Is.Not.Null);
+        Assert.That(
+            requestUri.AbsoluteUri,
+            Is.EqualTo(
+                $"https://example.invalid/v1{path}"
+                + "?include=message.input_image.image_url"
+                + "&include=web_search_call.action.sources"));
+    }
+}

--- a/tests/Conversations/ConversationMockTests.cs
+++ b/tests/Conversations/ConversationMockTests.cs
@@ -83,7 +83,7 @@ public class ConversationMockTests
             requestUri.AbsoluteUri,
             Is.EqualTo(
                 $"https://example.invalid/v1{path}"
-                + "?include=message.input_image.image_url"
-                + "&include=web_search_call.action.sources"));
+                + "?include[]=message.input_image.image_url"
+                + "&include[]=web_search_call.action.sources"));
     }
 }

--- a/tests/Conversations/ConversationTests.cs
+++ b/tests/Conversations/ConversationTests.cs
@@ -3,8 +3,10 @@ using NUnit.Framework;
 using OpenAI.Conversations;
 using OpenAI.Responses;
 using OpenAI.Tests.Utility;
+using System;
 using System.ClientModel;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +15,12 @@ namespace OpenAI.Tests.Conversations;
 [Category("Conversations")]
 public class ConversationTests : OpenAIRecordedTestBase
 {
+    private static readonly IncludedConversationItemProperty[] s_includedProperties =
+    [
+        IncludedConversationItemProperty.MessageInputImageUri,
+        IncludedConversationItemProperty.WebSearchCallActionSources,
+    ];
+
     public ConversationTests(bool isAsync) : base(isAsync)
     {
         TestTimeoutInSeconds = 30;
@@ -66,6 +74,64 @@ public class ConversationTests : OpenAIRecordedTestBase
 
             Assert.That(deletedConversation.Deleted, Is.True);
             Assert.That(deletedConversation.ConversationId, Is.EqualTo(conversation.Id));
+        }
+        finally
+        {
+            if (conversationId is not null)
+            {
+                await client.DeleteConversationAsync(conversationId);
+            }
+        }
+    }
+
+    [RecordedTest]
+    public async Task ConversationItemEndpointsAcceptIncludeQuery()
+    {
+        ConversationClient client = GetProxiedOpenAIClient<ConversationClient>();
+        string conversationId = null;
+
+        try
+        {
+            ConversationCreationOptions createOptions = new()
+            {
+                Items = { ResponseItem.CreateUserMessageItem("first item") },
+            };
+
+            ClientResult<ConversationResource> createResult = await client.CreateConversationAsync(createOptions);
+            conversationId = createResult.Value.Id;
+
+            BinaryContent createItemsContent = BinaryContent.Create(
+                BinaryData.FromString(
+                    """{"items":[{"type":"message","role":"user","content":[{"type":"input_text","text":"second item"}]}]}"""));
+            ClientResult createItemsResult = await client.CreateConversationItemsAsync(
+                conversationId,
+                createItemsContent,
+                include: s_includedProperties);
+            Assert.That(createItemsResult.GetRawResponse().Status, Is.EqualTo(200));
+
+            using JsonDocument createdItemsJson = JsonDocument.Parse(createItemsResult.GetRawResponse().Content);
+            string itemId = createdItemsJson.RootElement
+                .GetProperty("data")[0]
+                .GetProperty("id")
+                .GetString();
+            Assert.That(itemId, Is.Not.Null.And.Not.Empty);
+
+            ClientResult getItemResult = await client.GetConversationItemAsync(
+                conversationId,
+                itemId,
+                include: s_includedProperties);
+            Assert.That(getItemResult.GetRawResponse().Status, Is.EqualTo(200));
+
+            bool receivedPage = false;
+            await foreach (ClientResult page in client
+                .GetConversationItemsAsync(conversationId, include: s_includedProperties)
+                .GetRawPagesAsync())
+            {
+                Assert.That(page.GetRawResponse().Status, Is.EqualTo(200));
+                receivedPage = true;
+                break;
+            }
+            Assert.That(receivedPage, Is.True);
         }
         finally
         {

--- a/tests/SessionRecords/ConversationTests/ConversationItemEndpointsAcceptIncludeQuery.json
+++ b/tests/SessionRecords/ConversationTests/ConversationItemEndpointsAcceptIncludeQuery.json
@@ -1,0 +1,263 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "98",
+        "Content-Type": "application/json",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": {
+        "items": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "first item"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c318e78bb1b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "141",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Set-Cookie": "Sanitized",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "id": "conv_6a64d61271bc81978f6bf8089632a0790f2c9ddbc598f953",
+        "object": "conversation",
+        "created_at": 1784993298,
+        "metadata": {}
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d61271bc81978f6bf8089632a0790f2c9ddbc598f953/items?include[]=message.input_image.image_url&include[]=web_search_call.action.sources",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "99",
+        "Content-Type": "application/json",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": {
+        "items": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "second item"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c3194bcaa1b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "466",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "object": "list",
+        "data": [
+          {
+            "id": "msg_6a64d61300bc8197b2ee13bee46a49890f2c9ddbc598f953",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "second item"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "first_id": "msg_6a64d61300bc8197b2ee13bee46a49890f2c9ddbc598f953",
+        "has_more": false,
+        "last_id": "msg_6a64d61300bc8197b2ee13bee46a49890f2c9ddbc598f953"
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d61271bc81978f6bf8089632a0790f2c9ddbc598f953/items/msg_6a64d61300bc8197b2ee13bee46a49890f2c9ddbc598f953?include[]=message.input_image.image_url&include[]=web_search_call.action.sources",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c3198cf2f1b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "218",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "id": "msg_6a64d61300bc8197b2ee13bee46a49890f2c9ddbc598f953",
+        "type": "message",
+        "status": "completed",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "second item"
+          }
+        ],
+        "role": "user"
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d61271bc81978f6bf8089632a0790f2c9ddbc598f953/items?include[]=message.input_image.image_url&include[]=web_search_call.action.sources",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c319cc9b71b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "733",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "object": "list",
+        "data": [
+          {
+            "id": "msg_6a64d61300bc8197b2ee13bee46a49890f2c9ddbc598f953",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "second item"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "id": "msg_6a64d61272088197a24548f9c5f6af470f2c9ddbc598f953",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "first item"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "first_id": "msg_6a64d61300bc8197b2ee13bee46a49890f2c9ddbc598f953",
+        "has_more": false,
+        "last_id": "msg_6a64d61272088197a24548f9c5f6af470f2c9ddbc598f953"
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d61271bc81978f6bf8089632a0790f2c9ddbc598f953",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c319ffc891b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "122",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "id": "conv_6a64d61271bc81978f6bf8089632a0790f2c9ddbc598f953",
+        "object": "conversation.deleted",
+        "deleted": true
+      }
+    }
+  ],
+  "Variables": {
+    "OPENAI_API_KEY": "api-key"
+  }
+}

--- a/tests/SessionRecords/ConversationTests/ConversationItemEndpointsAcceptIncludeQueryAsync.json
+++ b/tests/SessionRecords/ConversationTests/ConversationItemEndpointsAcceptIncludeQueryAsync.json
@@ -1,0 +1,262 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "98",
+        "Content-Type": "application/json",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": {
+        "items": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "first item"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c31a449021b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "141",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "id": "conv_6a64d615402c81908f47384c7f3812780427dcabbcb7249d",
+        "object": "conversation",
+        "created_at": 1784993301,
+        "metadata": {}
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d615402c81908f47384c7f3812780427dcabbcb7249d/items?include[]=message.input_image.image_url&include[]=web_search_call.action.sources",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "99",
+        "Content-Type": "application/json",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": {
+        "items": [
+          {
+            "type": "message",
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "second item"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c31a5fa501b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "466",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "object": "list",
+        "data": [
+          {
+            "id": "msg_6a64d615efb48190a769393b2204a29b0427dcabbcb7249d",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "second item"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "first_id": "msg_6a64d615efb48190a769393b2204a29b0427dcabbcb7249d",
+        "has_more": false,
+        "last_id": "msg_6a64d615efb48190a769393b2204a29b0427dcabbcb7249d"
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d615402c81908f47384c7f3812780427dcabbcb7249d/items/msg_6a64d615efb48190a769393b2204a29b0427dcabbcb7249d?include[]=message.input_image.image_url&include[]=web_search_call.action.sources",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c31aa8d781b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "218",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "id": "msg_6a64d615efb48190a769393b2204a29b0427dcabbcb7249d",
+        "type": "message",
+        "status": "completed",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "second item"
+          }
+        ],
+        "role": "user"
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d615402c81908f47384c7f3812780427dcabbcb7249d/items?include[]=message.input_image.image_url&include[]=web_search_call.action.sources",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c31ad5f801b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "733",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "object": "list",
+        "data": [
+          {
+            "id": "msg_6a64d615efb48190a769393b2204a29b0427dcabbcb7249d",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "second item"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "id": "msg_6a64d615406c8190b538346b0c5db3b30427dcabbcb7249d",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "first item"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "first_id": "msg_6a64d615efb48190a769393b2204a29b0427dcabbcb7249d",
+        "has_more": false,
+        "last_id": "msg_6a64d615406c8190b538346b0c5db3b30427dcabbcb7249d"
+      }
+    },
+    {
+      "RequestUri": "https://api.openai.com/v1/conversations/conv_6a64d615402c81908f47384c7f3812780427dcabbcb7249d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "OpenAI/2.12.0 (.NET 10.0.10; Ubuntu 24.04.4 LTS)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": "CF-Ray",
+        "Alt-Svc": "h3=\":443\"",
+        "cf-cache-status": "DYNAMIC",
+        "CF-RAY": "a20c31aee8b51b9a-DUB",
+        "Connection": "keep-alive",
+        "Content-Length": "122",
+        "Content-Type": "application/json",
+        "Date": "Sanitized",
+        "openai-organization": "Sanitized",
+        "openai-processing-ms": "Sanitized",
+        "openai-project": "Sanitized",
+        "openai-version": "2020-10-01",
+        "Server": "cloudflare",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-openai-proxy-wasm": "v0.1",
+        "X-Request-ID": "Sanitized"
+      },
+      "ResponseBody": {
+        "id": "conv_6a64d615402c81908f47384c7f3812780427dcabbcb7249d",
+        "object": "conversation.deleted",
+        "deleted": true
+      }
+    }
+  ],
+  "Variables": {
+    "OPENAI_API_KEY": "api-key"
+  }
+}


### PR DESCRIPTION
Fixes #1254.

Conversation item endpoints currently serialize multiple `include` values as one comma-delimited query value. The API then sees a string instead of an array and returns a 400 response.

This updates the Conversations TypeSpec to use exploded query serialization for `include` on list, create, and retrieve operations, then regenerates the client. Regression tests verify that each endpoint sends one query parameter per included property.

Tests:
- `./scripts/Invoke-CodeGen.ps1 -Clean`
- `dotnet test ./tests/OpenAI.Tests.csproj --configuration Release`
- `dotnet test codegen/generator/test/ --configuration Release`
- `dotnet pack --configuration Release`