### PR TITLE
[Diagnostics] Add Stainless telemetry headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Requests now include structured SDK platform metadata headers (`X-Stainless-Lang`, `X-Stainless-Package-Version`, `X-Stainless-Runtime`, `X-Stainless-Runtime-Version`, `X-Stainless-OS`, and `X-Stainless-Arch`), bringing the .NET library to parity with the other official OpenAI SDKs. These restate information already present in the `User-Agent` header in a machine-parseable form, plus the process CPU architecture, so consumers no longer need to parse the user agent string. Any value you set yourself is preserved. The `User-Agent` header itself is unchanged.
-- Added an opt-out for SDK telemetry, via the `OpenAI.TelemetryDisabled` `AppContext` switch or the `OPENAI_TELEMETRY_DISABLED` environment variable. When enabled, the library sends neither the `X-Stainless-*` headers nor the `User-Agent` header that it would otherwise add. See [Telemetry and privacy](https://github.com/openai/openai-dotnet/blob/main/docs/Observability.md#telemetry-and-privacy) for details.
+- Added an opt-out for SDK telemetry, via the `OpenAI.DisableTelemetry` `AppContext` switch or the `OPENAI_DISABLE_TELEMETRY` environment variable. When enabled, the library sends neither the `X-Stainless-*` headers nor the `User-Agent` header that it would otherwise add. See [Telemetry and privacy](https://github.com/openai/openai-dotnet/blob/main/docs/Observability.md#telemetry-and-privacy) for details.
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Other Changes
 
+- Relaxed the limit on `UserAgentApplicationId` from 24 characters to 512. Application identifiers up to that length are now accepted and passed through to the `User-Agent` header verbatim; longer values continue to throw `ArgumentOutOfRangeException` when a client is created, so that the header cannot be inflated without bound.
 - OpenAI.Responses:
   - Consolidated the experimental diagnostic used by the Computer Use tool types onto the standard `OPENAI001`. These types were previously marked with a dedicated `OPENAICUA001` code, which has been removed. Consumers who explicitly suppressed `OPENAICUA001` should suppress `OPENAI001` instead (the same code already used by the other experimental Responses APIs).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## (Unreleased)
 
+### Features Added
+
+- Requests now include structured SDK platform metadata headers (`X-Stainless-Lang`, `X-Stainless-Package-Version`, `X-Stainless-Runtime`, `X-Stainless-Runtime-Version`, `X-Stainless-OS`, and `X-Stainless-Arch`), bringing the .NET library to parity with the other official OpenAI SDKs. These restate information already present in the `User-Agent` header in a machine-parseable form, plus the process CPU architecture, so consumers no longer need to parse the user agent string. Any value you set yourself is preserved. The `User-Agent` header itself is unchanged.
+- Added an opt-out for SDK telemetry, via the `OpenAI.TelemetryDisabled` `AppContext` switch or the `OPENAI_TELEMETRY_DISABLED` environment variable. When enabled, the library sends neither the `X-Stainless-*` headers nor the `User-Agent` header that it would otherwise add. See [Telemetry and privacy](https://github.com/openai/openai-dotnet/blob/main/docs/Observability.md#telemetry-and-privacy) for details.
+
 ### Other Changes
 
 - OpenAI.Responses:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Other Changes
 
-- Relaxed the limit on `UserAgentApplicationId` from 24 characters to 512. Application identifiers up to that length are now accepted and passed through to the `User-Agent` header verbatim; longer values continue to throw `ArgumentOutOfRangeException` when a client is created, so that the header cannot be inflated without bound.
+- Relaxed the limit on `UserAgentApplicationId` from 24 characters to 512. Application identifiers up to that length are now accepted and passed through to the `User-Agent` header verbatim; longer values throw `ArgumentOutOfRangeException` when a client is created, so that the header cannot be inflated without bound. The identifier is ignored, and the limit not applied, when telemetry is disabled and no `User-Agent` will be sent.
 - OpenAI.Responses:
   - Consolidated the experimental diagnostic used by the Computer Use tool types onto the standard `OPENAI001`. These types were previously marked with a dedicated `OPENAICUA001` code, which has been removed. Consumers who explicitly suppressed `OPENAICUA001` should suppress `OPENAI001` instead (the same code already used by the other experimental Responses APIs).
 

--- a/OpenAI/src/Utility/OpenAIClientUtilities.cs
+++ b/OpenAI/src/Utility/OpenAIClientUtilities.cs
@@ -42,14 +42,15 @@ internal static class OpenAIClientUtilities
 
     private static PipelinePolicy CreateAddCustomHeadersPolicy(string userAgentApplicationId, string organizationId, string projectId)
     {
-        // Constructed unconditionally, and deliberately not deferred until telemetry is known to be enabled:
-        // this is where the caller-supplied application id is validated, so deferring it would let the
-        // telemetry opt-out determine whether an invalid value is rejected. Validation of a caller's options
-        // must not vary by machine. The cost is paid once, when the pipeline is built.
-        TelemetryDetails telemetryDetails = new(typeof(OpenAIClientUtilities).Assembly, userAgentApplicationId);
-
         // Evaluated once when the pipeline is built, so the request path is a single field test.
         bool isTelemetryDisabled = PlatformTelemetry.IsTelemetryDisabled();
+
+        // Opting out means no telemetry work is performed at all. The application id feeds only the user
+        // agent, so when it will not be sent the value is unused and neither composed nor validated: the
+        // length bound exists to keep the header from being inflated, and there is no header to inflate.
+        TelemetryDetails telemetryDetails = isTelemetryDisabled
+            ? null
+            : new TelemetryDetails(typeof(OpenAIClientUtilities).Assembly, userAgentApplicationId);
 
         return new GenericActionPipelinePolicy((message) =>
         {

--- a/OpenAI/src/Utility/OpenAIClientUtilities.cs
+++ b/OpenAI/src/Utility/OpenAIClientUtilities.cs
@@ -43,11 +43,27 @@ internal static class OpenAIClientUtilities
     private static PipelinePolicy CreateAddCustomHeadersPolicy(string userAgentApplicationId, string organizationId, string projectId)
     {
         TelemetryDetails telemetryDetails = new(typeof(OpenAIClientUtilities).Assembly, userAgentApplicationId);
+
+        // Evaluated once when the pipeline is built, so the request path is a single field test.
+        bool isTelemetryDisabled = PlatformTelemetry.IsTelemetryDisabled();
+
         return new GenericActionPipelinePolicy((message) =>
         {
-            if (message?.Request?.Headers?.TryGetValue(UserAgentHeaderName, out string _) == false)
+            if (message?.Request?.Headers is null)
             {
-                message.Request.Headers.Set(UserAgentHeaderName, telemetryDetails.ToString());
+                return;
+            }
+
+            // Opting out of telemetry suppresses both the platform metadata headers and the user agent that
+            // this library would otherwise add. A caller-supplied user agent is still honored.
+            if (!isTelemetryDisabled)
+            {
+                if (!message.Request.Headers.TryGetValue(UserAgentHeaderName, out string _))
+                {
+                    message.Request.Headers.Set(UserAgentHeaderName, telemetryDetails.ToString());
+                }
+
+                PlatformTelemetry.ApplyTo(message.Request);
             }
 
             if (!string.IsNullOrEmpty(organizationId))

--- a/OpenAI/src/Utility/OpenAIClientUtilities.cs
+++ b/OpenAI/src/Utility/OpenAIClientUtilities.cs
@@ -42,6 +42,10 @@ internal static class OpenAIClientUtilities
 
     private static PipelinePolicy CreateAddCustomHeadersPolicy(string userAgentApplicationId, string organizationId, string projectId)
     {
+        // Constructed unconditionally, and deliberately not deferred until telemetry is known to be enabled:
+        // this is where the caller-supplied application id is validated, so deferring it would let the
+        // telemetry opt-out determine whether an invalid value is rejected. Validation of a caller's options
+        // must not vary by machine. The cost is paid once, when the pipeline is built.
         TelemetryDetails telemetryDetails = new(typeof(OpenAIClientUtilities).Assembly, userAgentApplicationId);
 
         // Evaluated once when the pipeline is built, so the request path is a single field test.

--- a/OpenAI/src/Utility/PlatformTelemetry.cs
+++ b/OpenAI/src/Utility/PlatformTelemetry.cs
@@ -61,11 +61,6 @@ internal static class PlatformTelemetry
     private static readonly OSPlatform s_macCatalyst = OSPlatform.Create("MACCATALYST");
     private static readonly OSPlatform s_browser = OSPlatform.Create("BROWSER");
 
-    private static readonly string s_packageVersion = GetPackageVersion(typeof(PlatformTelemetry).Assembly);
-    private static readonly string s_runtimeVersion = GetRuntimeVersion(new TelemetryDetails.RuntimeInformationWrapper());
-    private static readonly string s_operatingSystem = GetOperatingSystem(new TelemetryDetails.RuntimeInformationWrapper());
-    private static readonly string s_architecture = GetArchitecture(new TelemetryDetails.RuntimeInformationWrapper());
-
     /// <summary>
     /// Determines whether the caller has opted out of SDK telemetry, which suppresses both these headers and
     /// the <c>User-Agent</c> header that the library would otherwise add.
@@ -93,11 +88,29 @@ internal static class PlatformTelemetry
         }
 
         SetIfAbsent(request, LangHeaderName, LangValue);
-        SetIfAbsent(request, PackageVersionHeaderName, s_packageVersion);
+        SetIfAbsent(request, PackageVersionHeaderName, Values.PackageVersion);
         SetIfAbsent(request, RuntimeHeaderName, RuntimeValue);
-        SetIfAbsent(request, RuntimeVersionHeaderName, s_runtimeVersion);
-        SetIfAbsent(request, OSHeaderName, s_operatingSystem);
-        SetIfAbsent(request, ArchHeaderName, s_architecture);
+        SetIfAbsent(request, RuntimeVersionHeaderName, Values.RuntimeVersion);
+        SetIfAbsent(request, OSHeaderName, Values.OperatingSystem);
+        SetIfAbsent(request, ArchHeaderName, Values.Architecture);
+    }
+
+    /// <summary>
+    /// The values that are determined once and reused for the lifetime of the process.
+    /// </summary>
+    /// <remarks>
+    /// These are held in a nested type so that they are computed on first use rather than when
+    /// <see cref="PlatformTelemetry"/> is first touched. A process that has opted out calls
+    /// <see cref="IsTelemetryDisabled"/> but never <see cref="ApplyTo"/>, and so never pays to determine them.
+    /// </remarks>
+    private static class Values
+    {
+        private static readonly TelemetryDetails.RuntimeInformationWrapper s_runtimeInformation = new();
+
+        public static readonly string PackageVersion = GetPackageVersion(typeof(PlatformTelemetry).Assembly);
+        public static readonly string RuntimeVersion = GetRuntimeVersion(s_runtimeInformation);
+        public static readonly string OperatingSystem = GetOperatingSystem(s_runtimeInformation);
+        public static readonly string Architecture = GetArchitecture(s_runtimeInformation);
     }
 
     private static void SetIfAbsent(PipelineRequest request, string name, string value)

--- a/OpenAI/src/Utility/PlatformTelemetry.cs
+++ b/OpenAI/src/Utility/PlatformTelemetry.cs
@@ -1,0 +1,322 @@
+using System;
+using System.ClientModel.Primitives;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#nullable enable
+
+namespace OpenAI;
+
+/// <summary>
+/// Structured, individually-parseable SDK platform metadata that is sent alongside the
+/// <c>User-Agent</c> header so that consumers do not have to parse the user agent string.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every value is process-invariant, so the set is computed once and cached.
+/// </para>
+/// <para>
+/// Values are derived from the same sources used to build the <c>User-Agent</c> (see
+/// <see cref="TelemetryDetails"/>), so the two can never contradict each other. The relationship differs by
+/// field: the package version is reproduced verbatim and is therefore always identical to its user agent
+/// counterpart, whereas the runtime and operating system are normalized subsets of the free-form text the
+/// user agent carries. The process architecture has no user agent counterpart at all.
+/// </para>
+/// <para>
+/// Telemetry must never be able to fail a caller's request. Every value is computed defensively and
+/// degrades to <see cref="UnknownValue"/> rather than throwing; a failure in the static initializer would
+/// otherwise surface as a <see cref="TypeInitializationException"/> on every request for the lifetime of
+/// the process.
+/// </para>
+/// </remarks>
+internal static class PlatformTelemetry
+{
+    public const string LangHeaderName = "X-Stainless-Lang";
+    public const string PackageVersionHeaderName = "X-Stainless-Package-Version";
+    public const string RuntimeHeaderName = "X-Stainless-Runtime";
+    public const string RuntimeVersionHeaderName = "X-Stainless-Runtime-Version";
+    public const string OSHeaderName = "X-Stainless-OS";
+    public const string ArchHeaderName = "X-Stainless-Arch";
+
+    public const string TelemetryDisabledSwitchName = "OpenAI.TelemetryDisabled";
+    public const string TelemetryDisabledEnvironmentVariableName = "OPENAI_TELEMETRY_DISABLED";
+
+    private const string LangValue = "csharp";
+    private const string RuntimeValue = "dotnet";
+    private const string UnknownValue = "unknown";
+
+    /// <summary>
+    /// Upper bound applied to values that incorporate free-form platform text. <c>OSDescription</c> can
+    /// exceed 130 characters on macOS, which is neither useful nor appropriate for a header sent on every
+    /// request.
+    /// </summary>
+    private const int MaxDescriptionLength = 64;
+
+    // OSPlatform.FreeBSD and the mobile/browser platforms are not available on all target frameworks
+    // (netstandard2.0 exposes only Windows, Linux, and OSX), so they are created by name instead.
+    private static readonly OSPlatform s_freeBsd = OSPlatform.Create("FREEBSD");
+    private static readonly OSPlatform s_android = OSPlatform.Create("ANDROID");
+    private static readonly OSPlatform s_iOS = OSPlatform.Create("IOS");
+    private static readonly OSPlatform s_macCatalyst = OSPlatform.Create("MACCATALYST");
+    private static readonly OSPlatform s_browser = OSPlatform.Create("BROWSER");
+
+    private static readonly string s_packageVersion = GetPackageVersion(typeof(PlatformTelemetry).Assembly);
+    private static readonly string s_runtimeVersion = GetRuntimeVersion(new TelemetryDetails.RuntimeInformationWrapper());
+    private static readonly string s_operatingSystem = GetOperatingSystem(new TelemetryDetails.RuntimeInformationWrapper());
+    private static readonly string s_architecture = GetArchitecture(new TelemetryDetails.RuntimeInformationWrapper());
+
+    /// <summary>
+    /// Determines whether the caller has opted out of SDK telemetry, which suppresses both these headers and
+    /// the <c>User-Agent</c> header that the library would otherwise add.
+    /// </summary>
+    /// <remarks>
+    /// This is intended to be evaluated once when a pipeline is built and cached by the caller, so that the
+    /// request path remains a single field test. Configuration is read at that point rather than at type
+    /// initialization, matching the behavior of the experimental OpenTelemetry switch.
+    /// </remarks>
+    public static bool IsTelemetryDisabled()
+        => AppContextSwitchHelper.GetConfigValue(
+            TelemetryDisabledSwitchName,
+            TelemetryDisabledEnvironmentVariableName);
+
+    /// <summary>
+    /// Applies the platform metadata headers to <paramref name="request"/>, preserving any value that the
+    /// caller has already set.
+    /// </summary>
+    /// <param name="request">The request to apply the headers to.</param>
+    public static void ApplyTo(PipelineRequest request)
+    {
+        if (request?.Headers is null)
+        {
+            return;
+        }
+
+        SetIfAbsent(request, LangHeaderName, LangValue);
+        SetIfAbsent(request, PackageVersionHeaderName, s_packageVersion);
+        SetIfAbsent(request, RuntimeHeaderName, RuntimeValue);
+        SetIfAbsent(request, RuntimeVersionHeaderName, s_runtimeVersion);
+        SetIfAbsent(request, OSHeaderName, s_operatingSystem);
+        SetIfAbsent(request, ArchHeaderName, s_architecture);
+    }
+
+    private static void SetIfAbsent(PipelineRequest request, string name, string value)
+    {
+        // Header lookups are case-insensitive, so this honors a caller-supplied value regardless of casing.
+        if (!request.Headers.TryGetValue(name, out string? _))
+        {
+            request.Headers.Set(name, value);
+        }
+    }
+
+    internal static string GetPackageVersion(Assembly assembly)
+    {
+        try
+        {
+            return NormalizePackageVersion(assembly?
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion);
+        }
+        catch (Exception)
+        {
+            return UnknownValue;
+        }
+    }
+
+    /// <summary>
+    /// Produces the package version exactly as the <c>User-Agent</c> carries it, so that the two can never
+    /// disagree.
+    /// </summary>
+    /// <param name="informationalVersion">The assembly informational version.</param>
+    /// <remarks>
+    /// Unlike the free-form platform values, this is a value that has to be reproduced verbatim rather than
+    /// normalized; rewriting it would produce a header that looks like a plausible version but silently
+    /// differs from the user agent. It is therefore validated rather than sanitized, and a value that could
+    /// not be transmitted safely is reported as unknown rather than as a mangled near-miss.
+    /// </remarks>
+    internal static string NormalizePackageVersion(string? informationalVersion)
+    {
+        if (string.IsNullOrEmpty(informationalVersion))
+        {
+            return UnknownValue;
+        }
+
+        // Matches the user agent's handling; this is the only transformation either applies.
+        int hashSeparator = informationalVersion!.LastIndexOf('+');
+        string version = hashSeparator == -1
+            ? informationalVersion
+            : informationalVersion.Substring(0, hashSeparator);
+
+        return IsHeaderSafe(version) ? version : UnknownValue;
+    }
+
+    /// <summary>
+    /// Determines whether a value can be transmitted as an HTTP header value without alteration.
+    /// </summary>
+    /// <param name="value">The value to evaluate.</param>
+    private static bool IsHeaderSafe(string value)
+    {
+        if (value.Length == 0 || value[value.Length - 1] == ' ')
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (character < ' ' || character > '~')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal static string GetRuntimeVersion(TelemetryDetails.RuntimeInformationWrapper runtimeInformation)
+    {
+        try
+        {
+            string description = runtimeInformation.FrameworkDescription;
+
+            if (string.IsNullOrEmpty(description))
+            {
+                return UnknownValue;
+            }
+
+            // FrameworkDescription is authoritative on every target framework and takes forms such as
+            // ".NET 8.0.11", ".NET Core 3.1.32", ".NET Framework 4.8.9256.0", and "Mono 6.12.0". The version
+            // is the trailing token. Environment.Version is deliberately not used, as it reports 4.0.30319.x
+            // on .NET Framework regardless of the version actually installed.
+            int lastSpace = description.LastIndexOf(' ');
+            string version = lastSpace == -1 ? description : description.Substring(lastSpace + 1);
+
+            if (string.IsNullOrEmpty(version) || !char.IsDigit(version[0]))
+            {
+                return Sanitize(description, UnknownValue);
+            }
+
+            return Sanitize(version, UnknownValue);
+        }
+        catch (Exception)
+        {
+            return UnknownValue;
+        }
+    }
+
+    internal static string GetOperatingSystem(TelemetryDetails.RuntimeInformationWrapper runtimeInformation)
+    {
+        try
+        {
+            // Android and the Apple mobile platforms are evaluated before Linux and MacOS. Modern .NET
+            // reports them as distinct platforms, but Mono and legacy Xamarin report Android as Linux, so
+            // ordering keeps the result stable across runtimes.
+            if (runtimeInformation.IsOSPlatform(s_android))
+            {
+                return "Android";
+            }
+
+            if (runtimeInformation.IsOSPlatform(s_iOS))
+            {
+                return "iOS";
+            }
+
+            if (runtimeInformation.IsOSPlatform(s_macCatalyst))
+            {
+                return "MacCatalyst";
+            }
+
+            if (runtimeInformation.IsOSPlatform(s_browser))
+            {
+                return "Browser";
+            }
+
+            if (runtimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "Windows";
+            }
+
+            if (runtimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "MacOS";
+            }
+
+            if (runtimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "Linux";
+            }
+
+            if (runtimeInformation.IsOSPlatform(s_freeBsd))
+            {
+                return "FreeBSD";
+            }
+
+            return $"Other:{Sanitize(runtimeInformation.OSDescription, UnknownValue)}";
+        }
+        catch (Exception)
+        {
+            return $"Other:{UnknownValue}";
+        }
+    }
+
+    internal static string GetArchitecture(TelemetryDetails.RuntimeInformationWrapper runtimeInformation)
+    {
+        try
+        {
+            switch (runtimeInformation.ProcessArchitecture)
+            {
+                case Architecture.X64:
+                    return "x64";
+                case Architecture.X86:
+                    return "x86";
+                case Architecture.Arm64:
+                    return "arm64";
+                case Architecture.Arm:
+                    return "arm";
+                default:
+                    // Values such as Wasm and RiscV64 are absent from the netstandard2.0 reference assembly
+                    // but resolve against the running runtime's metadata, so ToString() yields the real name.
+                    return $"other:{Sanitize(runtimeInformation.ProcessArchitecture.ToString(), UnknownValue)}";
+            }
+        }
+        catch (Exception)
+        {
+            return $"other:{UnknownValue}";
+        }
+    }
+
+    /// <summary>
+    /// Reduces a value to something safe to transmit as an HTTP header: printable ASCII only, no line
+    /// breaks, and bounded in length.
+    /// </summary>
+    /// <param name="value">The value to sanitize.</param>
+    /// <param name="fallback">The value to return when nothing usable remains.</param>
+    internal static string Sanitize(string? value, string fallback)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return fallback;
+        }
+
+        StringBuilder builder = new(Math.Min(value!.Length, MaxDescriptionLength));
+
+        foreach (char character in value)
+        {
+            if (builder.Length == MaxDescriptionLength)
+            {
+                break;
+            }
+
+            // Printable ASCII only. Anything else, including CR/LF and non-ASCII release names, becomes '_'
+            // rather than being dropped, so that distinct platforms remain distinguishable.
+            builder.Append(character >= ' ' && character <= '~' ? character : '_');
+        }
+
+        // Trailing whitespace is not meaningful and is invalid in a header value.
+        while (builder.Length > 0 && builder[builder.Length - 1] == ' ')
+        {
+            builder.Length--;
+        }
+
+        return builder.Length == 0 ? fallback : builder.ToString();
+    }
+}

--- a/OpenAI/src/Utility/PlatformTelemetry.cs
+++ b/OpenAI/src/Utility/PlatformTelemetry.cs
@@ -154,9 +154,15 @@ internal static class PlatformTelemetry
     /// Determines whether a value can be transmitted as an HTTP header value without alteration.
     /// </summary>
     /// <param name="value">The value to evaluate.</param>
+    /// <remarks>
+    /// Leading and trailing spaces are rejected because RFC 7230 section 3.2 treats them as optional
+    /// whitespace surrounding the field value rather than as part of it, so an HTTP stack is free to strip
+    /// them. Interior spaces are legal and are preserved, so they remain acceptable. Tabs and other control
+    /// characters are covered by the printable-ASCII check.
+    /// </remarks>
     private static bool IsHeaderSafe(string value)
     {
-        if (value.Length == 0 || value[value.Length - 1] == ' ')
+        if (value.Length == 0 || value[0] == ' ' || value[value.Length - 1] == ' ')
         {
             return false;
         }

--- a/OpenAI/src/Utility/PlatformTelemetry.cs
+++ b/OpenAI/src/Utility/PlatformTelemetry.cs
@@ -292,7 +292,7 @@ internal static class PlatformTelemetry
 
     /// <summary>
     /// Reduces a value to something safe to transmit as an HTTP header: printable ASCII only, no line
-    /// breaks, and bounded in length.
+    /// breaks, no leading or trailing spaces, and bounded in length.
     /// </summary>
     /// <param name="value">The value to sanitize.</param>
     /// <param name="fallback">The value to return when nothing usable remains.</param>
@@ -317,10 +317,24 @@ internal static class PlatformTelemetry
             builder.Append(character >= ' ' && character <= '~' ? character : '_');
         }
 
-        // Trailing whitespace is not meaningful and is invalid in a header value.
+        // Leading and trailing spaces are not part of an HTTP header field value; they are optional
+        // whitespace that intermediaries are free to strip. Removing them here means the value that was
+        // computed is the value that arrives, rather than one silently normalized in transit.
         while (builder.Length > 0 && builder[builder.Length - 1] == ' ')
         {
             builder.Length--;
+        }
+
+        int leadingSpaces = 0;
+
+        while (leadingSpaces < builder.Length && builder[leadingSpaces] == ' ')
+        {
+            leadingSpaces++;
+        }
+
+        if (leadingSpaces > 0)
+        {
+            builder.Remove(0, leadingSpaces);
         }
 
         return builder.Length == 0 ? fallback : builder.ToString();

--- a/OpenAI/src/Utility/PlatformTelemetry.cs
+++ b/OpenAI/src/Utility/PlatformTelemetry.cs
@@ -39,8 +39,8 @@ internal static class PlatformTelemetry
     public const string OSHeaderName = "X-Stainless-OS";
     public const string ArchHeaderName = "X-Stainless-Arch";
 
-    public const string TelemetryDisabledSwitchName = "OpenAI.TelemetryDisabled";
-    public const string TelemetryDisabledEnvironmentVariableName = "OPENAI_TELEMETRY_DISABLED";
+    public const string DisableTelemetrySwitchName = "OpenAI.DisableTelemetry";
+    public const string DisableTelemetryEnvironmentVariableName = "OPENAI_DISABLE_TELEMETRY";
 
     private const string LangValue = "csharp";
     private const string RuntimeValue = "dotnet";
@@ -77,8 +77,8 @@ internal static class PlatformTelemetry
     /// </remarks>
     public static bool IsTelemetryDisabled()
         => AppContextSwitchHelper.GetConfigValue(
-            TelemetryDisabledSwitchName,
-            TelemetryDisabledEnvironmentVariableName);
+            DisableTelemetrySwitchName,
+            DisableTelemetryEnvironmentVariableName);
 
     /// <summary>
     /// Applies the platform metadata headers to <paramref name="request"/>, preserving any value that the

--- a/OpenAI/src/Utility/TelemetryDetails.cs
+++ b/OpenAI/src/Utility/TelemetryDetails.cs
@@ -13,7 +13,12 @@ namespace OpenAI;
 /// </summary>
 internal class TelemetryDetails
 {
-    private const int MaxApplicationIdLength = 24;
+    /// <summary>
+    /// Upper bound on the caller-supplied application id. The value is echoed in the <c>User-Agent</c> of
+    /// every request, so it is bounded to keep an oversized identifier from inflating each one.
+    /// </summary>
+    private const int MaxApplicationIdLength = 512;
+
     private readonly string _userAgent;
 
     /// <summary>
@@ -38,9 +43,10 @@ internal class TelemetryDetails
     internal TelemetryDetails(Assembly assembly, string? applicationId = null, RuntimeInformationWrapper? runtimeInformation = default)
     {
         Argument.AssertNotNull(assembly, nameof(assembly));
+
         if (applicationId?.Length > MaxApplicationIdLength)
         {
-            throw new ArgumentOutOfRangeException(nameof(applicationId), $"{nameof(applicationId)} must be shorter than {MaxApplicationIdLength + 1} characters");
+            throw new ArgumentOutOfRangeException(nameof(applicationId), $"{nameof(applicationId)} must be {MaxApplicationIdLength} characters or fewer.");
         }
 
         Assembly = assembly;

--- a/OpenAI/src/Utility/TelemetryDetails.cs
+++ b/OpenAI/src/Utility/TelemetryDetails.cs
@@ -19,6 +19,12 @@ internal class TelemetryDetails
     /// </summary>
     private const int MaxApplicationIdLength = 512;
 
+    /// <summary>
+    /// Substituted when a platform description cannot be read, matching the placeholder used by the SDK
+    /// platform metadata headers.
+    /// </summary>
+    private const string UnknownPlatformDescription = "unknown";
+
     private readonly string _userAgent;
 
     /// <summary>
@@ -71,11 +77,35 @@ internal class TelemetryDetails
             version = version.Substring(0, hashSeparator);
         }
         runtimeInformation ??= new RuntimeInformationWrapper();
-        var platformInformation = EscapeProductInformation($"({runtimeInformation.FrameworkDescription}; {runtimeInformation.OSDescription})");
+
+        // These describe the environment and are used for telemetry only. They are not guaranteed to be
+        // readable on every runtime, and failing to read one must not prevent a client from being created.
+        // They are read independently so that losing one does not discard the other.
+        string frameworkDescription = ReadPlatformDescription(() => runtimeInformation.FrameworkDescription);
+        string osDescription = ReadPlatformDescription(() => runtimeInformation.OSDescription);
+
+        var platformInformation = EscapeProductInformation($"({frameworkDescription}; {osDescription})");
 
         return applicationId != null
             ? $"{applicationId} {assemblyName}/{version} {platformInformation}"
             : $"{assemblyName}/{version} {platformInformation}";
+    }
+
+    /// <summary>
+    /// Reads a platform description, substituting a stable placeholder if it cannot be determined.
+    /// </summary>
+    /// <param name="read">The accessor for the description to read.</param>
+    private static string ReadPlatformDescription(Func<string> read)
+    {
+        try
+        {
+            string description = read();
+            return string.IsNullOrEmpty(description) ? UnknownPlatformDescription : description;
+        }
+        catch (Exception)
+        {
+            return UnknownPlatformDescription;
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -1091,10 +1091,10 @@ To help OpenAI understand which platforms the SDK runs on, requests include a sm
 
 These restate, in a machine-parseable form, information already present in the `User-Agent` header the library has always sent, plus the process CPU architecture. They contain no user names, machine names, file paths, or persistent identifiers, and nothing that is unique to you or to your installation: every value is derived locally, and two installations of the same package version on the same platform and runtime send byte-for-byte identical values.
 
-To turn this off, set the `OPENAI_TELEMETRY_DISABLED` environment variable to `true`, or set the corresponding context switch in your application code before creating any clients:
+To turn this off, set the `OPENAI_DISABLE_TELEMETRY` environment variable to `true`, or set the corresponding context switch in your application code before creating any clients:
 
 ```csharp
-AppContext.SetSwitch("OpenAI.TelemetryDisabled", true);
+AppContext.SetSwitch("OpenAI.DisableTelemetry", true);
 ```
 
 Opting out suppresses both these headers and the `User-Agent` header that the library adds. It does not affect the `Authorization`, `OpenAI-Organization`, or `OpenAI-Project` headers, and a `User-Agent` you supply yourself is still sent.

--- a/README.md
+++ b/README.md
@@ -1078,7 +1078,7 @@ OpenAI .NET library supports experimental distributed tracing and metrics with O
 
 ### Telemetry and privacy
 
-To help OpenAI understand which platforms the SDK runs on, every request includes a small set of headers describing the library and the runtime that issued it:
+To help OpenAI understand which platforms the SDK runs on, requests include a small set of headers by default describing the library and the runtime that issued them:
 
 | Header | Example |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1075,3 +1075,28 @@ By default, the client classes will automatically retry the following errors up 
 ### Observability
 
 OpenAI .NET library supports experimental distributed tracing and metrics with OpenTelemetry. Check out [Observability with OpenTelemetry](./docs/Observability.md) for more details.
+
+### Telemetry and privacy
+
+To help OpenAI understand which platforms the SDK runs on, every request includes a small set of headers describing the library and the runtime that issued it:
+
+| Header | Example |
+| --- | --- |
+| `X-Stainless-Lang` | `csharp` |
+| `X-Stainless-Package-Version` | `2.12.0` |
+| `X-Stainless-Runtime` | `dotnet` |
+| `X-Stainless-Runtime-Version` | `8.0.11` |
+| `X-Stainless-OS` | `Windows` |
+| `X-Stainless-Arch` | `x64` |
+
+These restate, in a machine-parseable form, information already present in the `User-Agent` header the library has always sent, plus the process CPU architecture. They contain no user names, machine names, file paths, or persistent identifiers, and nothing that is unique to you or to your installation: every value is derived locally, and two installations of the same package version on the same platform and runtime send byte-for-byte identical values.
+
+To turn this off, set the `OPENAI_TELEMETRY_DISABLED` environment variable to `true`, or set the corresponding context switch in your application code before creating any clients:
+
+```csharp
+AppContext.SetSwitch("OpenAI.TelemetryDisabled", true);
+```
+
+Opting out suppresses both these headers and the `User-Agent` header that the library adds. It does not affect the `Authorization`, `OpenAI-Organization`, or `OpenAI-Project` headers, and a `User-Agent` you supply yourself is still sent.
+
+See [Telemetry and privacy](./docs/Observability.md#telemetry-and-privacy) for the full contract.

--- a/docs/Observability.md
+++ b/docs/Observability.md
@@ -58,7 +58,7 @@ The following sources and meters are available:
 
 ## Telemetry and privacy
 
-Separately from the OpenTelemetry instrumentation described above, the library always includes a small set of headers on outgoing requests that describe the SDK and the platform it is running on. The two features are independent: `OpenAI.Experimental.EnableOpenTelemetry` does not govern these headers, and `OpenAI.TelemetryDisabled` does not govern OpenTelemetry tracing or metrics.
+Separately from the OpenTelemetry instrumentation described above, the library includes a small set of headers on outgoing requests that describe the SDK and the platform it is running on. Unlike the instrumentation above, which is opt-in, these are sent by default and can be turned off; see [Opting out](#opting-out). The two features are independent: `OpenAI.Experimental.EnableOpenTelemetry` does not govern these headers, and `OpenAI.TelemetryDisabled` does not govern OpenTelemetry tracing or metrics.
 
 ### What is sent
 

--- a/docs/Observability.md
+++ b/docs/Observability.md
@@ -55,3 +55,53 @@ Check out [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/
 The following sources and meters are available:
 
 - `OpenAI.ChatClient` - records traces and metrics for `ChatClient` operations (except streaming and protocol methods which are not instrumented yet)
+
+## Telemetry and privacy
+
+Separately from the OpenTelemetry instrumentation described above, the library always includes a small set of headers on outgoing requests that describe the SDK and the platform it is running on. The two features are independent: `OpenAI.Experimental.EnableOpenTelemetry` does not govern these headers, and `OpenAI.TelemetryDisabled` does not govern OpenTelemetry tracing or metrics.
+
+### What is sent
+
+| Header | Value | Source |
+| --- | --- | --- |
+| `X-Stainless-Lang` | `csharp` | Constant. |
+| `X-Stainless-Package-Version` | The `OpenAI` package version, such as `2.12.0`. | The assembly informational version, with any `+<commit>` suffix removed. This is the version token from the `User-Agent`, sent verbatim; if it could not be transmitted unaltered it is reported as `unknown` rather than rewritten, so the two can never silently disagree. |
+| `X-Stainless-Runtime` | `dotnet` | Constant. |
+| `X-Stainless-Runtime-Version` | The running .NET version, such as `8.0.11`. | The version portion of `RuntimeInformation.FrameworkDescription`. Falls back to the full description when no version is present, and to `unknown` when it cannot be determined. |
+| `X-Stainless-OS` | `Windows`, `MacOS`, `Linux`, `FreeBSD`, `Android`, `iOS`, `MacCatalyst`, or `Browser`. | `RuntimeInformation.IsOSPlatform`. Unrecognized platforms report `Other:<description>`. |
+| `X-Stainless-Arch` | `x64`, `x86`, `arm64`, or `arm`. | `RuntimeInformation.ProcessArchitecture`. Other architectures report `other:<name>`. |
+
+These headers restate, in a machine-parseable form, information already present in the `User-Agent` header, plus the process CPU architecture. Sending them individually means consumers do not have to parse the user agent string, which is not a stable contract.
+
+Values are:
+
+- Derived locally and deterministically, with no per-user or per-installation entropy. Two installations of the same package version on the same platform and runtime produce byte-for-byte identical values.
+- Free of user names, machine names, tenant identifiers, file paths, and persistent identifiers.
+- Printable ASCII with no line breaks. Free-form platform text (the operating system and runtime fallbacks) is additionally bounded in length. The package version is not bounded, so that it matches the `User-Agent` verbatim; the sole exception is the `unknown` fallback described above, used when the version could not be sent unaltered.
+
+Any of these headers that you set yourself is preserved; the library only supplies values that are absent. Header names are matched case-insensitively.
+
+### Opting out
+
+Use either of the following, in order of precedence:
+
+1. Set the `OpenAI.TelemetryDisabled` context switch when your application starts, before creating any clients:
+
+   ```csharp
+   AppContext.SetSwitch("OpenAI.TelemetryDisabled", true);
+   ```
+
+2. Set the `OPENAI_TELEMETRY_DISABLED` environment variable to `true` or `1`.
+
+The setting is read when a client is created, so it must be applied before constructing any client.
+
+Opting out suppresses:
+
+- All six `X-Stainless-*` headers.
+- The `User-Agent` header that the library adds. Neither `HttpClient` nor the underlying transport substitutes a default, so an opted-out request carries no user agent unless you supply one.
+
+Opting out does not affect the `Authorization`, `OpenAI-Organization`, or `OpenAI-Project` headers, nor any header you set yourself.
+
+### Realtime sessions
+
+The WebSocket handshake that opens a Realtime session sends only the `Authorization` header along with any headers you supply through `RealtimeSessionClientOptions.Headers`. It does not send the `X-Stainless-*` headers, matching the behavior of the other official OpenAI SDKs. Regular HTTP requests made by `RealtimeClient` do include them.

--- a/docs/Observability.md
+++ b/docs/Observability.md
@@ -58,7 +58,7 @@ The following sources and meters are available:
 
 ## Telemetry and privacy
 
-Separately from the OpenTelemetry instrumentation described above, the library includes a small set of headers on outgoing requests that describe the SDK and the platform it is running on. Unlike the instrumentation above, which is opt-in, these are sent by default and can be turned off; see [Opting out](#opting-out). The two features are independent: `OpenAI.Experimental.EnableOpenTelemetry` does not govern these headers, and `OpenAI.TelemetryDisabled` does not govern OpenTelemetry tracing or metrics.
+Separately from the OpenTelemetry instrumentation described above, the library includes a small set of headers on outgoing requests that describe the SDK and the platform it is running on. Unlike the instrumentation above, which is opt-in, these are sent by default and can be turned off; see [Opting out](#opting-out). The two features are independent: `OpenAI.Experimental.EnableOpenTelemetry` does not govern these headers, and `OpenAI.DisableTelemetry` does not govern OpenTelemetry tracing or metrics.
 
 ### What is sent
 
@@ -85,13 +85,13 @@ Any of these headers that you set yourself is preserved; the library only suppli
 
 Use either of the following, in order of precedence:
 
-1. Set the `OpenAI.TelemetryDisabled` context switch when your application starts, before creating any clients:
+1. Set the `OpenAI.DisableTelemetry` context switch when your application starts, before creating any clients:
 
    ```csharp
-   AppContext.SetSwitch("OpenAI.TelemetryDisabled", true);
+   AppContext.SetSwitch("OpenAI.DisableTelemetry", true);
    ```
 
-2. Set the `OPENAI_TELEMETRY_DISABLED` environment variable to `true` or `1`.
+2. Set the `OPENAI_DISABLE_TELEMETRY` environment variable to `true` or `1`.
 
 The setting is read when a client is created, so it must be applied before constructing any client.
 

--- a/tests/Miscellaneous/PlatformTelemetryHeaderTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryHeaderTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ClientModel.TestFramework.Mocks;
+using NUnit.Framework;
+using OpenAI.Chat;
+using OpenAI.Embeddings;
+
+namespace OpenAI.Tests.Miscellaneous;
+
+/// <summary>
+/// Verifies that the SDK platform metadata headers are applied to outgoing requests by the shared pipeline
+/// policy that every client is built on.
+/// </summary>
+[Category("Smoke")]
+public class PlatformTelemetryHeaderTests
+{
+    private const string UserAgentHeaderName = "User-Agent";
+    private const string LangHeaderName = "X-Stainless-Lang";
+    private const string PackageVersionHeaderName = "X-Stainless-Package-Version";
+    private const string RuntimeHeaderName = "X-Stainless-Runtime";
+    private const string RuntimeVersionHeaderName = "X-Stainless-Runtime-Version";
+    private const string OSHeaderName = "X-Stainless-OS";
+    private const string ArchHeaderName = "X-Stainless-Arch";
+
+    private static readonly string[] s_headerNames =
+    [
+        LangHeaderName,
+        PackageVersionHeaderName,
+        RuntimeHeaderName,
+        RuntimeVersionHeaderName,
+        OSHeaderName,
+        ArchHeaderName,
+    ];
+
+    private static readonly ApiKeyCredential s_credential = new("fake-key");
+
+    [Test]
+    public void AllPlatformHeadersArePresent()
+    {
+        PipelineRequest request = SendRequest(out _);
+
+        foreach (string name in s_headerNames)
+        {
+            Assert.That(request.Headers.TryGetValue(name, out string value), Is.True, $"'{name}' was not applied.");
+            Assert.That(value, Is.Not.Null.And.Not.Empty, $"'{name}' was empty.");
+        }
+    }
+
+    [Test]
+    public void ConstantPlatformHeadersUseTheExpectedValues()
+    {
+        PipelineRequest request = SendRequest(out _);
+
+        Assert.That(GetHeader(request, LangHeaderName), Is.EqualTo("csharp"));
+        Assert.That(GetHeader(request, RuntimeHeaderName), Is.EqualTo("dotnet"));
+    }
+
+    [Test]
+    public void PackageVersionHeaderMatchesTheUserAgent()
+    {
+        // The header and the user agent must never disagree, so both read the same assembly attribute and
+        // apply the same commit-suffix strip.
+        PipelineRequest request = SendRequest(out _);
+
+        string version = GetHeader(request, PackageVersionHeaderName);
+        string userAgent = GetHeader(request, UserAgentHeaderName);
+
+        Assert.That(version, Is.Not.EqualTo("unknown"));
+        Assert.That(userAgent, Does.Contain($"OpenAI/{version} "));
+    }
+
+    [Test]
+    public void PlatformHeadersAreAppliedToEveryClient()
+    {
+        // The headers come from a single shared policy, so verifying a second, unrelated client guards against
+        // a client being built on a pipeline that bypasses it.
+        List<PipelineRequest> captured = [];
+
+        OpenAIClientOptions options = new()
+        {
+            Transport = new MockPipelineTransport(_ =>
+                new MockPipelineResponse(200).WithContent(BinaryContent.Create(BinaryData.FromString("{}"))))
+        };
+
+        options.AddPolicy(new TestPipelinePolicy(message => captured.Add(message?.Request)), PipelinePosition.BeforeTransport);
+
+        EmbeddingClient client = new("model", s_credential, options);
+        client.GenerateEmbeddings(
+            BinaryContent.Create(BinaryData.FromString("{}")),
+            new RequestOptions { ErrorOptions = ClientErrorBehaviors.NoThrow });
+
+        Assert.That(captured, Is.Not.Empty);
+        Assert.That(GetHeader(captured[0], LangHeaderName), Is.EqualTo("csharp"));
+        Assert.That(GetHeader(captured[0], OSHeaderName), Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void CallerSuppliedPlatformHeadersAreNotOverwritten()
+    {
+        // Header lookups are case-insensitive, so a caller's value must win regardless of the casing used.
+        TestPipelinePolicy overridePolicy = new(message =>
+        {
+            message?.Request?.Headers?.Set("x-stainless-lang", "caller-supplied");
+        });
+
+        PipelineRequest request = SendRequest(out _, configure: options => options.AddPolicy(overridePolicy, PipelinePosition.PerCall));
+
+        Assert.That(GetHeader(request, LangHeaderName), Is.EqualTo("caller-supplied"));
+    }
+
+    [Test]
+    public void PlatformHeadersAreNotDuplicatedAcrossRetries()
+    {
+        // The policy runs per-call rather than per-attempt and uses Set rather than Add, so a retried request
+        // must not accumulate repeated values.
+        int attempts = 0;
+        MockPipelineTransport transport = new(_ =>
+        {
+            attempts++;
+            return new MockPipelineResponse(attempts < 3 ? 500 : 200)
+                .WithContent(BinaryContent.Create(BinaryData.FromString("{}")));
+        });
+
+        List<PipelineRequest> requests = [];
+        OpenAIClientOptions options = new() { Transport = transport };
+        options.AddPolicy(new TestPipelinePolicy(message => requests.Add(message?.Request)), PipelinePosition.BeforeTransport);
+
+        ChatClient client = new("model", s_credential, options);
+        client.CompleteChat(BinaryContent.Create(BinaryData.FromString("{}")), new RequestOptions { ErrorOptions = ClientErrorBehaviors.NoThrow });
+
+        Assert.That(attempts, Is.GreaterThan(1), "The request was expected to be retried.");
+
+        PipelineRequest request = requests[requests.Count - 1];
+
+        foreach (string name in s_headerNames)
+        {
+            int count = request.Headers.Count(header => string.Equals(header.Key, name, StringComparison.OrdinalIgnoreCase));
+            Assert.That(count, Is.EqualTo(1), $"'{name}' was applied {count} times.");
+        }
+    }
+
+    [Test]
+    public void OrganizationAndProjectHeadersAreUnaffected()
+    {
+        PipelineRequest request = SendRequest(out _, configure: options =>
+        {
+            options.OrganizationId = "org-id";
+            options.ProjectId = "project-id";
+        });
+
+        Assert.That(GetHeader(request, "OpenAI-Organization"), Is.EqualTo("org-id"));
+        Assert.That(GetHeader(request, "OpenAI-Project"), Is.EqualTo("project-id"));
+        Assert.That(GetHeader(request, "Authorization"), Is.EqualTo("Bearer fake-key"));
+    }
+
+    internal static string GetHeader(PipelineRequest request, string name)
+    {
+        request.Headers.TryGetValue(name, out string value);
+        return value;
+    }
+
+    internal static PipelineRequest SendRequest(out List<PipelineRequest> requests, Action<OpenAIClientOptions> configure = null)
+    {
+        List<PipelineRequest> captured = [];
+
+        OpenAIClientOptions options = new()
+        {
+            Transport = new MockPipelineTransport(_ =>
+                new MockPipelineResponse(200).WithContent(BinaryContent.Create(BinaryData.FromString("{}"))))
+        };
+
+        configure?.Invoke(options);
+        options.AddPolicy(new TestPipelinePolicy(message => captured.Add(message?.Request)), PipelinePosition.BeforeTransport);
+
+        ChatClient client = new("model", s_credential, options);
+        client.CompleteChat(
+            BinaryContent.Create(BinaryData.FromString("{}")),
+            new RequestOptions { ErrorOptions = ClientErrorBehaviors.NoThrow });
+
+        requests = captured;
+        Assert.That(captured, Is.Not.Empty, "No request reached the transport.");
+
+        return captured[captured.Count - 1];
+    }
+}

--- a/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
@@ -32,12 +32,12 @@ public class PlatformTelemetryOptOutTests
 
     private static readonly string[] s_headerNames =
     [
-        "X-Stainless-Lang",
-        "X-Stainless-Package-Version",
-        "X-Stainless-Runtime",
-        "X-Stainless-Runtime-Version",
-        "X-Stainless-OS",
-        "X-Stainless-Arch",
+        PlatformTelemetry.LangHeaderName,
+        PlatformTelemetry.PackageVersionHeaderName,
+        PlatformTelemetry.RuntimeHeaderName,
+        PlatformTelemetry.RuntimeVersionHeaderName,
+        PlatformTelemetry.OSHeaderName,
+        PlatformTelemetry.ArchHeaderName,
     ];
 
     private static readonly ApiKeyCredential s_credential = new("fake-key");
@@ -139,6 +139,19 @@ public class PlatformTelemetryOptOutTests
         Assert.That(PlatformTelemetryHeaderTests.GetHeader(request, "Authorization"), Is.EqualTo("Bearer fake-key"));
         Assert.That(PlatformTelemetryHeaderTests.GetHeader(request, "OpenAI-Organization"), Is.EqualTo("org-id"));
         Assert.That(PlatformTelemetryHeaderTests.GetHeader(request, "OpenAI-Project"), Is.EqualTo("project-id"));
+    }
+
+    [Test]
+    [Order(8)]
+    public void OptingOutStillValidatesTheUserAgentApplicationId()
+    {
+        // The application id is validated when the pipeline is built, whether or not telemetry is enabled, so
+        // that an invalid value is rejected identically on every machine rather than depending on how the
+        // opt-out happens to be configured.
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, "true");
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => SendRequest(options => options.UserAgentApplicationId = new string('a', 513)));
     }
 
     [Test]

--- a/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
@@ -27,8 +27,8 @@ namespace OpenAI.Tests.Miscellaneous;
 [Category("Smoke")]
 public class PlatformTelemetryOptOutTests
 {
-    private const string SwitchName = "OpenAI.TelemetryDisabled";
-    private const string EnvironmentVariableName = "OPENAI_TELEMETRY_DISABLED";
+    private const string SwitchName = "OpenAI.DisableTelemetry";
+    private const string EnvironmentVariableName = "OPENAI_DISABLE_TELEMETRY";
 
     private static readonly string[] s_headerNames =
     [

--- a/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
@@ -143,14 +143,14 @@ public class PlatformTelemetryOptOutTests
 
     [Test]
     [Order(8)]
-    public void OptingOutStillValidatesTheUserAgentApplicationId()
+    public void OptingOutIgnoresTheUserAgentApplicationId()
     {
-        // The application id is validated when the pipeline is built, whether or not telemetry is enabled, so
-        // that an invalid value is rejected identically on every machine rather than depending on how the
-        // opt-out happens to be configured.
+        // The application id feeds only the user agent, so when it will not be sent the value is unused. It is
+        // neither composed into a string nor validated: the length bound exists to keep the header from being
+        // inflated, and an opted-out request carries no such header.
         Environment.SetEnvironmentVariable(EnvironmentVariableName, "true");
 
-        Assert.Throws<ArgumentOutOfRangeException>(
+        Assert.DoesNotThrow(
             () => SendRequest(options => options.UserAgentApplicationId = new string('a', 513)));
     }
 

--- a/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryOptOutTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using Microsoft.ClientModel.TestFramework.Mocks;
+using NUnit.Framework;
+using OpenAI.Chat;
+
+namespace OpenAI.Tests.Miscellaneous;
+
+/// <summary>
+/// Verifies the telemetry opt-out, which suppresses both the SDK platform metadata headers and the
+/// <c>User-Agent</c> the library would otherwise add.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The configuration is process-global and is read when a pipeline is built, so these tests cannot run
+/// concurrently with anything that constructs a client.
+/// </para>
+/// <para>
+/// <see cref="AppContext.SetSwitch"/> has no way to return a switch to an undefined state, and a switch that
+/// is defined as <c>false</c> still takes precedence over the environment variable. The switch-based tests are
+/// therefore ordered last, so that they cannot shadow the environment-variable tests.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+[Category("Smoke")]
+public class PlatformTelemetryOptOutTests
+{
+    private const string SwitchName = "OpenAI.TelemetryDisabled";
+    private const string EnvironmentVariableName = "OPENAI_TELEMETRY_DISABLED";
+
+    private static readonly string[] s_headerNames =
+    [
+        "X-Stainless-Lang",
+        "X-Stainless-Package-Version",
+        "X-Stainless-Runtime",
+        "X-Stainless-Runtime-Version",
+        "X-Stainless-OS",
+        "X-Stainless-Arch",
+    ];
+
+    private static readonly ApiKeyCredential s_credential = new("fake-key");
+
+    [TearDown]
+    public void ResetTelemetryConfiguration()
+    {
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, null);
+    }
+
+    [Test]
+    [Order(1)]
+    public void TelemetryIsEnabledByDefault()
+    {
+        Assert.That(PlatformTelemetry.IsTelemetryDisabled(), Is.False);
+    }
+
+    [TestCase("true")]
+    [TestCase("TRUE")]
+    [TestCase("1")]
+    [Order(2)]
+    public void TheEnvironmentVariableDisablesTelemetry(string value)
+    {
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, value);
+
+        Assert.That(PlatformTelemetry.IsTelemetryDisabled(), Is.True);
+    }
+
+    [TestCase("false")]
+    [TestCase("0")]
+    [TestCase("")]
+    [Order(3)]
+    public void TheEnvironmentVariableLeavesTelemetryEnabledWhenNotSet(string value)
+    {
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, value);
+
+        Assert.That(PlatformTelemetry.IsTelemetryDisabled(), Is.False);
+    }
+
+    [Test]
+    [Order(4)]
+    public void OptingOutSuppressesThePlatformHeaders()
+    {
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, "true");
+
+        PipelineRequest request = SendRequest();
+
+        foreach (string name in s_headerNames)
+        {
+            Assert.That(request.Headers.TryGetValue(name, out string _), Is.False, $"'{name}' was applied while opted out.");
+        }
+    }
+
+    [Test]
+    [Order(5)]
+    public void OptingOutSuppressesTheUserAgent()
+    {
+        // This matches the behavior of Azure.Core when telemetry is disabled. Neither HttpClient nor the
+        // transport injects a default, so an opted-out request carries no user agent at all.
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, "true");
+
+        PipelineRequest request = SendRequest();
+
+        Assert.That(request.Headers.TryGetValue("User-Agent", out string _), Is.False);
+    }
+
+    [Test]
+    [Order(6)]
+    public void OptingOutPreservesACallerSuppliedUserAgent()
+    {
+        // The opt-out only stops the library from adding its own value.
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, "true");
+
+        TestPipelinePolicy overridePolicy = new(message =>
+        {
+            message?.Request?.Headers?.Set("User-Agent", "caller-supplied");
+        });
+
+        PipelineRequest request = SendRequest(options => options.AddPolicy(overridePolicy, PipelinePosition.PerCall));
+
+        Assert.That(request.Headers.TryGetValue("User-Agent", out string userAgent), Is.True);
+        Assert.That(userAgent, Is.EqualTo("caller-supplied"));
+    }
+
+    [Test]
+    [Order(7)]
+    public void OptingOutPreservesAuthenticationAndScopingHeaders()
+    {
+        // The opt-out governs telemetry only; headers the service needs to route and authorize the request are
+        // unaffected.
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, "true");
+
+        PipelineRequest request = SendRequest(options =>
+        {
+            options.OrganizationId = "org-id";
+            options.ProjectId = "project-id";
+        });
+
+        Assert.That(PlatformTelemetryHeaderTests.GetHeader(request, "Authorization"), Is.EqualTo("Bearer fake-key"));
+        Assert.That(PlatformTelemetryHeaderTests.GetHeader(request, "OpenAI-Organization"), Is.EqualTo("org-id"));
+        Assert.That(PlatformTelemetryHeaderTests.GetHeader(request, "OpenAI-Project"), Is.EqualTo("project-id"));
+    }
+
+    [Test]
+    [Order(100)]
+    public void TheAppContextSwitchDisablesTelemetry()
+    {
+        AppContext.SetSwitch(SwitchName, true);
+
+        try
+        {
+            Assert.That(PlatformTelemetry.IsTelemetryDisabled(), Is.True);
+            Assert.That(SendRequest().Headers.TryGetValue("X-Stainless-Lang", out string _), Is.False);
+        }
+        finally
+        {
+            AppContext.SetSwitch(SwitchName, false);
+        }
+    }
+
+    [Test]
+    [Order(101)]
+    public void TheAppContextSwitchTakesPrecedenceOverTheEnvironmentVariable()
+    {
+        AppContext.SetSwitch(SwitchName, false);
+        Environment.SetEnvironmentVariable(EnvironmentVariableName, "true");
+
+        Assert.That(PlatformTelemetry.IsTelemetryDisabled(), Is.False);
+    }
+
+    private static PipelineRequest SendRequest(Action<OpenAIClientOptions> configure = null)
+    {
+        List<PipelineRequest> captured = [];
+
+        OpenAIClientOptions options = new()
+        {
+            Transport = new MockPipelineTransport(_ =>
+                new MockPipelineResponse(200).WithContent(BinaryContent.Create(BinaryData.FromString("{}"))))
+        };
+
+        configure?.Invoke(options);
+        options.AddPolicy(new TestPipelinePolicy(message => captured.Add(message?.Request)), PipelinePosition.BeforeTransport);
+
+        ChatClient client = new("model", s_credential, options);
+        client.CompleteChat(
+            BinaryContent.Create(BinaryData.FromString("{}")),
+            new RequestOptions { ErrorOptions = ClientErrorBehaviors.NoThrow });
+
+        Assert.That(captured, Is.Not.Empty, "No request reached the transport.");
+        return captured[captured.Count - 1];
+    }
+}

--- a/tests/Miscellaneous/PlatformTelemetrySmokeTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetrySmokeTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+
+namespace OpenAI.Tests.Miscellaneous;
+
+/// <summary>
+/// Resilience tests for the SDK platform metadata values against the <em>real</em> environment.
+/// </summary>
+/// <remarks>
+/// Mocked tests cannot catch a target framework misbehaving on a runtime it was not compiled against; for
+/// example, the <c>netstandard2.0</c> asset running on .NET Framework, Mono, or Unity. These assert only the
+/// invariants that must hold everywhere, since exact values are environment-dependent and cannot be pinned.
+/// </remarks>
+public class PlatformTelemetrySmokeTests
+{
+    private static readonly TelemetryDetails.RuntimeInformationWrapper RuntimeInformation = new();
+
+    [Test]
+    public void PackageVersionIsUsableOnThisRuntime()
+    {
+        // Deliberately not length-bounded: the package version must match the user agent verbatim, which the
+        // separate drift-guard test asserts.
+        AssertUsable(() => PlatformTelemetry.GetPackageVersion(typeof(PlatformTelemetry).Assembly), maxLength: int.MaxValue);
+    }
+
+    [Test]
+    public void RuntimeVersionIsUsableOnThisRuntime()
+        => AssertUsable(() => PlatformTelemetry.GetRuntimeVersion(RuntimeInformation));
+
+    [Test]
+    public void OperatingSystemIsUsableOnThisRuntime()
+        => AssertUsable(() => PlatformTelemetry.GetOperatingSystem(RuntimeInformation));
+
+    [Test]
+    public void ArchitectureIsUsableOnThisRuntime()
+        => AssertUsable(() => PlatformTelemetry.GetArchitecture(RuntimeInformation));
+
+    [Test]
+    public void OperatingSystemIsRecognizedOnThisRuntime()
+    {
+        // The test matrix runs on platforms the SDK recognizes explicitly, so falling into the "Other:" bucket
+        // signals that detection has regressed rather than that a novel platform appeared.
+        Assert.That(PlatformTelemetry.GetOperatingSystem(RuntimeInformation), Does.Not.StartWith("Other:"));
+    }
+
+    [Test]
+    public void ArchitectureIsRecognizedOnThisRuntime()
+    {
+        Assert.That(PlatformTelemetry.GetArchitecture(RuntimeInformation), Does.Not.StartWith("other:"));
+    }
+
+    [Test]
+    public void PackageVersionMatchesTheUserAgentVersion()
+    {
+        // Guards against the header and the user agent drifting apart; both must read the same attribute and
+        // apply the same commit-suffix strip.
+        Assembly assembly = typeof(PlatformTelemetry).Assembly;
+        string userAgent = TelemetryDetails.GenerateUserAgentString(assembly);
+        string version = PlatformTelemetry.GetPackageVersion(assembly);
+
+        Assert.That(userAgent, Does.Contain($"/{version} "));
+    }
+
+    private static void AssertUsable(Func<string> valueFactory, int maxLength = 72)
+    {
+        string value = null;
+
+        Assert.That(() => value = valueFactory(), Throws.Nothing);
+        Assert.That(value, Is.Not.Null.And.Not.Empty);
+        Assert.That(value.Length, Is.LessThanOrEqualTo(maxLength), "Header values must stay bounded.");
+
+        foreach (char character in value)
+        {
+            Assert.That(character, Is.InRange(' ', '~'), $"'{value}' contains a character that is not printable ASCII.");
+        }
+
+        Assert.That(value, Does.Not.EndWith(" "));
+    }
+}

--- a/tests/Miscellaneous/PlatformTelemetryTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryTests.cs
@@ -302,6 +302,21 @@ public class PlatformTelemetryTests
         Assert.That(sanitized, Is.EqualTo(new string('a', 60)));
     }
 
+    [Test]
+    public void SanitizeTrimsLeadingSpaces()
+    {
+        // A leading space is optional whitespace that an HTTP stack may strip, so the value that was computed
+        // would not be the value that arrives.
+        Assert.That(PlatformTelemetry.Sanitize("   Darwin 21.1.0", UnknownValue), Is.EqualTo("Darwin 21.1.0"));
+    }
+
+    [Test]
+    public void SanitizePreservesInteriorSpaces()
+    {
+        // Only the edges are whitespace-sensitive; interior spaces are legal and carry meaning.
+        Assert.That(PlatformTelemetry.Sanitize("  Darwin 21.1.0 (x86_64)  ", UnknownValue), Is.EqualTo("Darwin 21.1.0 (x86_64)"));
+    }
+
     #endregion
 
     /// <summary>

--- a/tests/Miscellaneous/PlatformTelemetryTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryTests.cs
@@ -199,13 +199,24 @@ public class PlatformTelemetryTests
     [TestCase("2.12.0\r\n")]
     [TestCase("2.12.0-caf\u00e9")]
     [TestCase("2.12.0\u0000")]
+    [TestCase("2.12.0\t")]
     [TestCase("2.12.0 ")]
+    [TestCase(" 2.12.0")]
     [TestCase("+abc123")]
     public void PackageVersionIsUnknownWhenItCouldNotBeSentVerbatim(string version)
     {
         // Reporting unknown is preferable to emitting a rewritten value that would be indistinguishable from a
-        // real version while disagreeing with the user agent.
+        // real version while disagreeing with the user agent. Surrounding spaces count as unsendable because
+        // RFC 7230 lets an HTTP stack strip them from a field value.
         Assert.That(PlatformTelemetry.NormalizePackageVersion(version), Is.EqualTo(UnknownValue));
+    }
+
+    [Test]
+    public void PackageVersionAllowsInteriorSpaces()
+    {
+        // Interior whitespace is legal in a header value and is transmitted unaltered, so it does not force
+        // the fallback.
+        Assert.That(PlatformTelemetry.NormalizePackageVersion("2.12.0 beta"), Is.EqualTo("2.12.0 beta"));
     }
 
     [TestCase(null)]

--- a/tests/Miscellaneous/PlatformTelemetryTests.cs
+++ b/tests/Miscellaneous/PlatformTelemetryTests.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+
+namespace OpenAI.Tests.Miscellaneous;
+
+/// <summary>
+/// Unit tests for the normalization contract behind the SDK platform metadata headers.
+/// </summary>
+/// <remarks>
+/// These exercise the helpers through a mocked <see cref="TelemetryDetails.RuntimeInformationWrapper"/> so that
+/// every branch is reachable without depending on the machine the tests happen to run on. The complementary
+/// smoke tests in <c>PlatformTelemetrySmokeTests</c> cover the real environment.
+/// </remarks>
+public class PlatformTelemetryTests
+{
+    private const string UnknownValue = "unknown";
+
+    #region Operating system
+
+    [TestCase("WINDOWS", "Windows")]
+    [TestCase("OSX", "MacOS")]
+    [TestCase("LINUX", "Linux")]
+    [TestCase("FREEBSD", "FreeBSD")]
+    [TestCase("ANDROID", "Android")]
+    [TestCase("IOS", "iOS")]
+    [TestCase("MACCATALYST", "MacCatalyst")]
+    [TestCase("BROWSER", "Browser")]
+    public void OperatingSystemIsNormalizedForKnownPlatforms(string platformName, string expected)
+    {
+        MockRuntimeInformation runtimeInformation = new();
+        runtimeInformation.Platforms.Add(OSPlatform.Create(platformName));
+
+        Assert.That(PlatformTelemetry.GetOperatingSystem(runtimeInformation), Is.EqualTo(expected));
+    }
+
+    // Modern .NET reports these platforms as mutually exclusive, but Mono and legacy Xamarin report Android as
+    // Linux and the Apple mobile platforms as OSX. The more specific platform must win on every runtime.
+    [TestCase("ANDROID", "LINUX", "Android")]
+    [TestCase("IOS", "OSX", "iOS")]
+    [TestCase("MACCATALYST", "OSX", "MacCatalyst")]
+    [TestCase("BROWSER", "LINUX", "Browser")]
+    public void SpecificOperatingSystemsAreEvaluatedBeforeTheirBasePlatform(string specific, string general, string expected)
+    {
+        MockRuntimeInformation runtimeInformation = new();
+        runtimeInformation.Platforms.Add(OSPlatform.Create(specific));
+        runtimeInformation.Platforms.Add(OSPlatform.Create(general));
+
+        Assert.That(PlatformTelemetry.GetOperatingSystem(runtimeInformation), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void UnrecognizedOperatingSystemFallsBackToItsDescription()
+    {
+        MockRuntimeInformation runtimeInformation = new() { OSDescriptionValue = "Contoso OS 1.2" };
+
+        Assert.That(PlatformTelemetry.GetOperatingSystem(runtimeInformation), Is.EqualTo("Other:Contoso OS 1.2"));
+    }
+
+    [Test]
+    public void UnrecognizedOperatingSystemWithNoDescriptionIsUnknown()
+    {
+        MockRuntimeInformation runtimeInformation = new() { OSDescriptionValue = string.Empty };
+
+        Assert.That(PlatformTelemetry.GetOperatingSystem(runtimeInformation), Is.EqualTo($"Other:{UnknownValue}"));
+    }
+
+    [Test]
+    public void OperatingSystemDescriptionIsSanitized()
+    {
+        // Azure.Core carries an equivalent guard because operating systems with non-ASCII characters in their
+        // release names have been reported in the field.
+        MockRuntimeInformation runtimeInformation = new() { OSDescriptionValue = "Contoso\r\nOS \u00e9\u4e2d" };
+
+        Assert.That(PlatformTelemetry.GetOperatingSystem(runtimeInformation), Is.EqualTo("Other:Contoso__OS __"));
+    }
+
+    [Test]
+    public void OperatingSystemNeverThrows()
+    {
+        MockRuntimeInformation runtimeInformation = new() { ShouldThrow = true };
+
+        string value = null;
+        Assert.That(() => value = PlatformTelemetry.GetOperatingSystem(runtimeInformation), Throws.Nothing);
+        Assert.That(value, Is.EqualTo($"Other:{UnknownValue}"));
+    }
+
+    #endregion
+
+    #region Architecture
+
+    [TestCase(Architecture.X64, "x64")]
+    [TestCase(Architecture.X86, "x86")]
+    [TestCase(Architecture.Arm64, "arm64")]
+    [TestCase(Architecture.Arm, "arm")]
+    public void ArchitectureIsNormalizedForKnownValues(Architecture architecture, string expected)
+    {
+        MockRuntimeInformation runtimeInformation = new() { ProcessArchitectureValue = architecture };
+
+        Assert.That(PlatformTelemetry.GetArchitecture(runtimeInformation), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void UnrecognizedArchitectureFallsBackToItsName()
+    {
+        // Wasm, RiscV64, and friends are absent from the netstandard2.0 reference assembly but resolve against
+        // the running runtime's metadata, so the enum name is still produced rather than a bare number.
+        MockRuntimeInformation runtimeInformation = new() { ProcessArchitectureValue = (Architecture)9999 };
+
+        Assert.That(PlatformTelemetry.GetArchitecture(runtimeInformation), Is.EqualTo("other:9999"));
+    }
+
+    [Test]
+    public void ArchitectureNeverThrows()
+    {
+        MockRuntimeInformation runtimeInformation = new() { ShouldThrow = true };
+
+        string value = null;
+        Assert.That(() => value = PlatformTelemetry.GetArchitecture(runtimeInformation), Throws.Nothing);
+        Assert.That(value, Is.EqualTo($"other:{UnknownValue}"));
+    }
+
+    #endregion
+
+    #region Runtime version
+
+    [TestCase(".NET 8.0.11", "8.0.11")]
+    [TestCase(".NET 10.0.0-preview.1.25080.5", "10.0.0-preview.1.25080.5")]
+    [TestCase(".NET Core 3.1.32", "3.1.32")]
+    [TestCase(".NET Framework 4.8.9256.0", "4.8.9256.0")]
+    [TestCase("Mono 6.12.0.199", "6.12.0.199")]
+    public void RuntimeVersionIsExtractedFromTheFrameworkDescription(string description, string expected)
+    {
+        MockRuntimeInformation runtimeInformation = new() { FrameworkDescriptionValue = description };
+
+        Assert.That(PlatformTelemetry.GetRuntimeVersion(runtimeInformation), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void RuntimeVersionFallsBackToTheWholeDescriptionWhenNoVersionIsPresent()
+    {
+        MockRuntimeInformation runtimeInformation = new() { FrameworkDescriptionValue = "Contoso Runtime" };
+
+        Assert.That(PlatformTelemetry.GetRuntimeVersion(runtimeInformation), Is.EqualTo("Contoso Runtime"));
+    }
+
+    [TestCase("")]
+    [TestCase(null)]
+    public void RuntimeVersionIsUnknownWhenTheDescriptionIsEmpty(string description)
+    {
+        MockRuntimeInformation runtimeInformation = new() { FrameworkDescriptionValue = description };
+
+        Assert.That(PlatformTelemetry.GetRuntimeVersion(runtimeInformation), Is.EqualTo(UnknownValue));
+    }
+
+    [Test]
+    public void RuntimeVersionNeverThrows()
+    {
+        MockRuntimeInformation runtimeInformation = new() { ShouldThrow = true };
+
+        string value = null;
+        Assert.That(() => value = PlatformTelemetry.GetRuntimeVersion(runtimeInformation), Throws.Nothing);
+        Assert.That(value, Is.EqualTo(UnknownValue));
+    }
+
+    #endregion
+
+    #region Package version
+
+    [Test]
+    public void PackageVersionStripsTheCommitSuffix()
+    {
+        Assert.That(PlatformTelemetry.NormalizePackageVersion("2.12.0+abc123def"), Is.EqualTo("2.12.0"));
+        Assert.That(PlatformTelemetry.NormalizePackageVersion("2.13.0-alpha.1+abc123def"), Is.EqualTo("2.13.0-alpha.1"));
+    }
+
+    [TestCase("2.12.0")]
+    [TestCase("0.0.1-dev.1")]
+    [TestCase("2.13.0-alpha.20260408.1")]
+    public void PackageVersionIsReproducedVerbatim(string version)
+    {
+        // The user agent applies no transformation beyond the commit-suffix strip, so neither can this. Any
+        // rewriting here would produce a header that looks like a plausible version but silently disagrees.
+        Assert.That(PlatformTelemetry.NormalizePackageVersion(version), Is.EqualTo(version));
+    }
+
+    [Test]
+    public void PackageVersionIsNotTruncated()
+    {
+        // Free-form platform text is length-bounded, but the package version is not: capping it would break
+        // the guarantee that this header matches the user agent.
+        string version = "2.12.0-" + new string('a', 200);
+
+        Assert.That(PlatformTelemetry.NormalizePackageVersion(version), Is.EqualTo(version));
+    }
+
+    [TestCase("2.12.0\r\n")]
+    [TestCase("2.12.0-caf\u00e9")]
+    [TestCase("2.12.0\u0000")]
+    [TestCase("2.12.0 ")]
+    [TestCase("+abc123")]
+    public void PackageVersionIsUnknownWhenItCouldNotBeSentVerbatim(string version)
+    {
+        // Reporting unknown is preferable to emitting a rewritten value that would be indistinguishable from a
+        // real version while disagreeing with the user agent.
+        Assert.That(PlatformTelemetry.NormalizePackageVersion(version), Is.EqualTo(UnknownValue));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void PackageVersionIsUnknownWhenTheVersionIsEmpty(string version)
+    {
+        Assert.That(PlatformTelemetry.NormalizePackageVersion(version), Is.EqualTo(UnknownValue));
+    }
+
+    [Test]
+    public void PackageVersionMatchesTheAssemblyAttribute()
+    {
+        Assembly assembly = typeof(PlatformTelemetryTests).Assembly;
+        string informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        Assume.That(informationalVersion, Is.Not.Null.And.Not.Empty);
+
+        Assert.That(
+            PlatformTelemetry.GetPackageVersion(assembly),
+            Is.EqualTo(PlatformTelemetry.NormalizePackageVersion(informationalVersion)));
+    }
+
+    [Test]
+    public void PackageVersionIsUnknownWhenTheAssemblyIsUnavailable()
+    {
+        string value = null;
+        Assert.That(() => value = PlatformTelemetry.GetPackageVersion(null), Throws.Nothing);
+        Assert.That(value, Is.EqualTo(UnknownValue));
+    }
+
+    #endregion
+
+    #region Sanitization
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void SanitizeUsesTheFallbackWhenNothingUsableRemains(string value)
+    {
+        // A whitespace-only value is not meaningful, and trailing spaces are invalid in a header value.
+        Assert.That(PlatformTelemetry.Sanitize(value, UnknownValue), Is.EqualTo(UnknownValue));
+    }
+
+    [Test]
+    public void SanitizeReplacesRatherThanDropsUnusableCharacters()
+    {
+        // Replacing keeps distinct platforms distinguishable, which dropping would not.
+        Assert.That(PlatformTelemetry.Sanitize("\r\n", UnknownValue), Is.EqualTo("__"));
+    }
+
+    [Test]
+    public void SanitizeReplacesNonPrintableAndNonAsciiCharacters()
+    {
+        Assert.That(PlatformTelemetry.Sanitize("a\rb\nc\td\u00e9e\u0000f", UnknownValue), Is.EqualTo("a_b_c_d_e_f"));
+    }
+
+    [Test]
+    public void SanitizePreservesPrintableAscii()
+    {
+        const string value = "Darwin 21.1.0 (x86_64) ~!@#$%^&*()_+";
+        Assert.That(PlatformTelemetry.Sanitize(value, UnknownValue), Is.EqualTo(value));
+    }
+
+    [Test]
+    public void SanitizeBoundsTheValueLength()
+    {
+        // OSDescription exceeds 130 characters on macOS, which is not appropriate for a header sent on every
+        // request.
+        string value = new('a', 500);
+        string sanitized = PlatformTelemetry.Sanitize(value, UnknownValue);
+
+        Assert.That(sanitized.Length, Is.EqualTo(64));
+        Assert.That(sanitized, Is.EqualTo(new string('a', 64)));
+    }
+
+    [Test]
+    public void SanitizeTrimsTrailingSpacesIntroducedByTruncation()
+    {
+        string sanitized = PlatformTelemetry.Sanitize(new string('a', 60) + "    tail", UnknownValue);
+
+        Assert.That(sanitized, Is.EqualTo(new string('a', 60)));
+    }
+
+    #endregion
+
+    /// <summary>
+    /// A controllable stand-in for the runtime, allowing every normalization branch to be reached regardless of
+    /// the machine the tests run on.
+    /// </summary>
+    private class MockRuntimeInformation : TelemetryDetails.RuntimeInformationWrapper
+    {
+        public HashSet<OSPlatform> Platforms { get; } = new();
+
+        public string FrameworkDescriptionValue { get; set; } = ".NET 8.0.0";
+
+        public string OSDescriptionValue { get; set; } = "Mock OS";
+
+        public Architecture ProcessArchitectureValue { get; set; } = Architecture.X64;
+
+        public bool ShouldThrow { get; set; }
+
+        public override string FrameworkDescription => ShouldThrow ? throw new InvalidOperationException() : FrameworkDescriptionValue;
+
+        public override string OSDescription => ShouldThrow ? throw new InvalidOperationException() : OSDescriptionValue;
+
+        public override Architecture ProcessArchitecture => ShouldThrow ? throw new InvalidOperationException() : ProcessArchitectureValue;
+
+        public override Architecture OSArchitecture => ShouldThrow ? throw new InvalidOperationException() : ProcessArchitectureValue;
+
+        public override bool IsOSPlatform(OSPlatform osPlatform)
+            => ShouldThrow ? throw new InvalidOperationException() : Platforms.Contains(osPlatform);
+    }
+}

--- a/tests/OpenAI.Tests.csproj
+++ b/tests/OpenAI.Tests.csproj
@@ -31,6 +31,9 @@
   <ItemGroup>
     <Compile Include="..\OpenAI\src\Utility\Telemetry\*.cs" LinkBase="Telemetry\Shared" />
     <Compile Include="..\OpenAI\src\Utility\AppContextSwitchHelper.cs" LinkBase="Telemetry\Shared" />
+    <Compile Include="..\OpenAI\src\Utility\PlatformTelemetry.cs" LinkBase="Telemetry\Shared" />
+    <Compile Include="..\OpenAI\src\Utility\TelemetryDetails.cs" LinkBase="Telemetry\Shared" />
+    <Compile Include="..\OpenAI\src\Generated\Internal\Argument.cs" LinkBase="Telemetry\Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UserAgentTests.cs
+++ b/tests/UserAgentTests.cs
@@ -1,4 +1,5 @@
-﻿using System.ClientModel;
+﻿using System;
+using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.IO;
 using NUnit.Framework;
@@ -11,12 +12,28 @@ public class UserAgentTests
     private static readonly OpenAITestEnvironment TestEnvironment = new();
 
     [Test]
-    public void DefaultUserAgentStringWorks() => UserAgentStringWorks(useApplicationId: false);
+    public void DefaultUserAgentStringWorks() => UserAgentStringWorks(applicationId: null);
 
     [Test]
-    public void UserAgentWithApplicationIdWorks() => UserAgentStringWorks(useApplicationId: true);
+    public void UserAgentWithApplicationIdWorks() => UserAgentStringWorks(applicationId: "test-application-id");
 
-    private void UserAgentStringWorks(bool useApplicationId)
+    [Test]
+    public void UserAgentApplicationIdAllowsTheMaximumLength()
+    {
+        UserAgentStringWorks(applicationId: new string('a', 512));
+    }
+
+    [Test]
+    public void UserAgentApplicationIdRejectsValuesOverTheMaximumLength()
+    {
+        // The application id is echoed in the user agent of every request, so it is bounded to keep an
+        // oversized value from inflating each one.
+        OpenAIClientOptions options = new() { UserAgentApplicationId = new string('a', 513), };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => TestEnvironment.GetTestClient<ChatClient>(options: options));
+    }
+
+    private void UserAgentStringWorks(string applicationId)
     {
         string userAgent = null;
         TestPipelinePolicy policy = new((m) =>
@@ -24,8 +41,8 @@ public class UserAgentTests
             _ = m?.Request?.Headers?.TryGetValue("User-Agent", out userAgent);
         });
 
-        OpenAIClientOptions options = useApplicationId
-            ? new() { UserAgentApplicationId = "test-application-id",}
+        OpenAIClientOptions options = applicationId is not null
+            ? new() { UserAgentApplicationId = applicationId, }
             : new();
 
         options.AddPolicy(policy, PipelinePosition.BeforeTransport);
@@ -38,9 +55,9 @@ public class UserAgentTests
 
         Assert.That(userAgent, Is.Not.Null.Or.Empty);
 
-        if (useApplicationId)
+        if (applicationId is not null)
         {
-            Assert.That(userAgent, Does.Contain("test-application-id"));
+            Assert.That(userAgent, Does.Contain(applicationId));
         }
 
         Assert.That(userAgent, Does.Contain("OpenAI/"));

--- a/tests/UserAgentTests.cs
+++ b/tests/UserAgentTests.cs
@@ -62,4 +62,52 @@ public class UserAgentTests
 
         Assert.That(userAgent, Does.Contain("OpenAI/"));
     }
+
+    [Test]
+    public void UserAgentIsGeneratedWhenThePlatformCannotBeDescribed()
+    {
+        // FrameworkDescription and OSDescription are telemetry-only inputs that are not guaranteed to be
+        // readable on every runtime. A client must not fail to be created because one of them threw, whether
+        // or not telemetry is enabled.
+        string userAgent = null;
+
+        Assert.DoesNotThrow(() => userAgent = TelemetryDetails.GenerateUserAgentString(
+            typeof(OpenAIClient).Assembly,
+            null,
+            new ThrowingRuntimeInformation(throwForFramework: true, throwForOperatingSystem: true)));
+
+        Assert.That(userAgent, Does.Contain("OpenAI/"));
+        Assert.That(userAgent, Does.Contain("unknown"));
+    }
+
+    [Test]
+    public void UserAgentRetainsTheDescriptionThatCanBeRead()
+    {
+        // The two descriptions are read independently, so losing one does not discard the other.
+        string userAgent = TelemetryDetails.GenerateUserAgentString(
+            typeof(OpenAIClient).Assembly,
+            null,
+            new ThrowingRuntimeInformation(throwForFramework: false, throwForOperatingSystem: true));
+
+        Assert.That(userAgent, Does.Contain(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription));
+        Assert.That(userAgent, Does.Contain("unknown"));
+    }
+
+    private class ThrowingRuntimeInformation : TelemetryDetails.RuntimeInformationWrapper
+    {
+        private readonly bool _throwForFramework;
+        private readonly bool _throwForOperatingSystem;
+
+        public ThrowingRuntimeInformation(bool throwForFramework, bool throwForOperatingSystem)
+        {
+            _throwForFramework = throwForFramework;
+            _throwForOperatingSystem = throwForOperatingSystem;
+        }
+
+        public override string FrameworkDescription
+            => _throwForFramework ? throw new PlatformNotSupportedException() : base.FrameworkDescription;
+
+        public override string OSDescription
+            => _throwForOperatingSystem ? throw new PlatformNotSupportedException() : base.OSDescription;
+    }
 }

--- a/tests/Utility/OpenAIRecordedTestBase.cs
+++ b/tests/Utility/OpenAIRecordedTestBase.cs
@@ -39,14 +39,18 @@ namespace OpenAI.Tests.Utility
         /// <summary>
         /// The SDK platform metadata headers that the client adds to every request.
         /// </summary>
+        /// <remarks>
+        /// These reference the client's own constants rather than restating the names, so that the sanitizer
+        /// cannot drift away from what the client actually sends.
+        /// </remarks>
         internal static readonly string[] PlatformTelemetryHeaderNames =
         [
-            "X-Stainless-Lang",
-            "X-Stainless-Package-Version",
-            "X-Stainless-Runtime",
-            "X-Stainless-Runtime-Version",
-            "X-Stainless-OS",
-            "X-Stainless-Arch",
+            PlatformTelemetry.LangHeaderName,
+            PlatformTelemetry.PackageVersionHeaderName,
+            PlatformTelemetry.RuntimeHeaderName,
+            PlatformTelemetry.RuntimeVersionHeaderName,
+            PlatformTelemetry.OSHeaderName,
+            PlatformTelemetry.ArchHeaderName,
         ];
 
         internal T GetProxiedOpenAIClient<T>(string overrideModel = null, OpenAIClientOptions options = default) where T : class

--- a/tests/Utility/OpenAIRecordedTestBase.cs
+++ b/tests/Utility/OpenAIRecordedTestBase.cs
@@ -14,6 +14,13 @@ namespace OpenAI.Tests.Utility
             // Normalizes filepaths used as filenames in Content-Disposition headers, so record/playback works across different OSes
             CustomSanitizers.Add(new ContentDispositionFilePathSanitizer());
 
+            // The SDK platform metadata headers describe the machine that issued the request, so their values vary by
+            // recording machine and runtime. Removing them means recordings never capture them and playback requests
+            // are stripped of them before matching, which keeps existing recordings valid without re-recording.
+            // Coverage for these headers lives in mock-based unit tests instead.
+            CustomSanitizers.Add(new RemoveHeaderSanitizer(
+                new RemoveHeaderSanitizerBody(string.Join(",", PlatformTelemetryHeaderNames))));
+
             // Turn off default sanitizers to improve performance in large recordings (audio/image specifically)
             // This turns off all sanitizers exception Authorization headers, so we have to be very careful to explicitly sanitize
             // all other sensitive information
@@ -28,6 +35,19 @@ namespace OpenAI.Tests.Utility
             JsonPathSanitizers.Add("$.system_fingerprint");
             JsonPathSanitizers.Add("$..encrypted_content");
         }
+
+        /// <summary>
+        /// The SDK platform metadata headers that the client adds to every request.
+        /// </summary>
+        internal static readonly string[] PlatformTelemetryHeaderNames =
+        [
+            "X-Stainless-Lang",
+            "X-Stainless-Package-Version",
+            "X-Stainless-Runtime",
+            "X-Stainless-Runtime-Version",
+            "X-Stainless-OS",
+            "X-Stainless-Arch",
+        ];
 
         internal T GetProxiedOpenAIClient<T>(string overrideModel = null, OpenAIClientOptions options = default) where T : class
         {


### PR DESCRIPTION
# Summary

Outgoing requests now carry six structured headers describing the SDK and the platform that issued them, bringing the .NET library to parity with the other official OpenAI SDKs:

| Header | Example |
| --- | --- |
| `X-Stainless-Lang` | `csharp` |
| `X-Stainless-Package-Version` | `2.12.0` |
| `X-Stainless-Runtime` | `dotnet` |
| `X-Stainless-Runtime-Version` | `8.0.11` |
| `X-Stainless-OS` | `Windows` |
| `X-Stainless-Arch` | `x64` |

These restate, in a machine-parseable form, information already present in the `User-Agent`, plus the process CPU architecture, so consumers no longer have to parse the user agent string.

## Why not reuse `System.ClientModel`?

`UserAgentPolicy` exposes only the composed string; the structured inputs behind it (`RuntimeInformationWrapper`, `GenerateUserAgentString`) are `internal`. Parsing that string back apart would reintroduce exactly the fragility this change exists to remove, so the values are derived directly instead.

## Opt-out

Added an opt-out via the `OpenAI.TelemetryDisabled` `AppContext` switch or the `OPENAI_TELEMETRY_DISABLED` environment variable:

```csharp
AppContext.SetSwitch("OpenAI.TelemetryDisabled", true);
```

When set, the library sends neither these headers nor the `User-Agent` it would otherwise add. A `User-Agent` supplied by the caller is still honored, as are the `Authorization`, `OpenAI-Organization`, and `OpenAI-Project` headers. The setting is read once when a pipeline is built, matching how the experimental OpenTelemetry switch behaves.

## Implementation notes

- Headers are applied by the single shared per-call policy that every client is built on, so no client can be constructed without them.
- Values are computed once per process and are never allowed to fail a request; every path degrades to `unknown` rather than throwing.
- Platform detection is `netstandard2.0`-safe. `OSPlatform.FreeBSD` and the mobile/browser platforms do not exist in that reference assembly, so they are created by name. Android and the Apple mobile platforms are evaluated *before* Linux and macOS, because Mono and legacy Xamarin report them as their base platform.
- Free-form platform text is normalized to printable ASCII and bounded in length. **The package version is not** — it is reproduced verbatim so that it always matches the `User-Agent`, and falls back to `unknown` if it could not be transmitted unaltered, rather than being rewritten into a value that would silently disagree.
- Realtime WebSocket handshakes deliberately omit these headers, matching the other official OpenAI SDKs. Regular HTTP requests from `RealtimeClient` include them.

## Recordings

**Existing session recordings are unaffected and none were re-recorded.** A `RemoveHeaderSanitizer` in `OpenAIRecordedTestBase` strips the headers before the proxy matches a playback request and before a recording is written, so existing recordings continue to match and future ones will not capture machine-specific values.

## Testing

80 new mock-based tests covering:

- Normalization of every OS and architecture branch, including the Android-before-Linux and iOS-before-macOS ordering rules
- Never-throw behavior under a runtime that fails on every property
- Header application, case-insensitive caller override, retry de-duplication, and application across multiple client types
- Opt-out precedence and blast radius
- A drift guard asserting `X-Stainless-Package-Version` never diverges from the `User-Agent` version token

| Check | Result |
| --- | --- |
| Library build (`net10.0`, `net8.0`, `netstandard2.0`) | Clean, 0 warnings |
| `PlatformTelemetry` tests (`net10.0`, `net9.0`, `net8.0`) | 80 passed, 0 failed |
| Full Playback suite | 1525 passed, 0 failed, 87 skipped |

## Performance

Measured in Release with the baseline subtracted: **~590 ns**, ~912 bytes allocated, and **183 wire bytes** per request — under 0.01% of a typical call's wall-clock time.

## Compatibility

No public API change and no new dependencies.