### PR TITLE
Add mutual TLS transport example

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,9 +991,11 @@ Console.WriteLine(response.Value.GetOutputText());
 
 ### Using mutual TLS
 
-The API mTLS beta combines your API key with a client certificate. For how request authentication works, certificate requirements, activation, and supported API operations, see the [OpenAI Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program). To manage uploaded certificates programmatically, see the [Certificates API reference](https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/certificates/).
+The API mTLS beta combines your API key with a client certificate. For how request authentication works, certificate requirements, activation, and supported API operations, see the [OpenAI Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program). To upload and activate the issuing CA programmatically, see the [Certificates API reference](https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/certificates/).
 
-Configure the client certificate chain on a `SocketsHttpHandler`, then provide its `HttpClient` to the SDK through `HttpClientPipelineTransport`. The PFX/PKCS#12 file must contain exactly one certificate with a private key—the leaf client certificate—along with any intermediate certificates required to build its chain. This example uses `X509CertificateLoader`, available in .NET 9 and later.
+Upload and activate the CA certificate that signs the client leaf; keep the leaf certificate and its private key in the PFX used by the application. Certificate-chain support is available by request and must be enabled for your organization. Without it, the leaf must be signed directly by the uploaded CA. When chain support is enabled, the PFX/PKCS#12 file must contain exactly one certificate with a private key—the leaf—and every intermediate certificate needed to build a chain to the uploaded CA.
+
+Configure that bundle on a `SocketsHttpHandler`, then provide its `HttpClient` to the SDK through `HttpClientPipelineTransport`. This example uses `X509CertificateLoader`, available in .NET 9 and later.
 
 Choose the base URL that matches your data residency:
 
@@ -1034,7 +1036,11 @@ try
     };
     handler.SslOptions.ClientCertificateContext = certificateContext;
 
-    using HttpClient httpClient = new(handler);
+    using HttpClient httpClient = new(handler)
+    {
+        // Let the SDK pipeline enforce OpenAIClientOptions.NetworkTimeout.
+        Timeout = System.Threading.Timeout.InfiniteTimeSpan,
+    };
     OpenAIClientOptions options = new()
     {
         Endpoint = new Uri("https://mtls.api.openai.com/v1"),

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It is generated from our [OpenAPI specification](https://github.com/openai/opena
 - [How to use assistants with streaming and vision](#how-to-use-assistants-with-streaming-and-vision)
 - [How to work with Azure OpenAI](#how-to-work-with-azure-openai)
 - [Advanced scenarios](#advanced-scenarios)
+  - [Using mutual TLS](#using-mutual-tls)
   - [Using protocol methods](#using-protocol-methods)
   - [Mock a client for testing](#mock-a-client-for-testing)
   - [Automatically retrying errors](#automatically-retrying-errors)
@@ -987,6 +988,79 @@ Console.WriteLine(response.Value.GetOutputText());
 - Drop‑in model switching: Swap "gpt-5-mini" or any other model as long as the Azure model deployment has the same name as the model.
 
 ## Advanced scenarios
+
+### Using mutual TLS
+
+The API mTLS beta combines your API key with a client certificate. For how request authentication works, certificate requirements, activation, and supported API operations, see the [OpenAI Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program). To manage uploaded certificates programmatically, see the [Certificates API reference](https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/certificates/).
+
+Configure the client certificate chain on a `SocketsHttpHandler`, then provide its `HttpClient` to the SDK through `HttpClientPipelineTransport`. The PFX/PKCS#12 file must contain exactly one certificate with a private key—the leaf client certificate—along with any intermediate certificates required to build its chain. This example uses `X509CertificateLoader`, available in .NET 9 and later.
+
+Choose the base URL that matches your data residency:
+
+| Scope | Base URL |
+| --- | --- |
+| Global | `https://mtls.api.openai.com/v1` |
+| EU Data Residency | `https://mtls-eu.api.openai.com/v1` |
+
+```C# Snippet:ReadMe_MutualTls
+string pfxPath = Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PATH")
+    ?? throw new InvalidOperationException("OPENAI_CLIENT_PFX_PATH is required.");
+string apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")
+    ?? throw new InvalidOperationException("OPENAI_API_KEY is required.");
+
+X509Certificate2Collection certificates =
+    X509CertificateLoader.LoadPkcs12CollectionFromFile(
+        pfxPath,
+        Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PASSWORD"));
+
+try
+{
+    X509Certificate2 clientCertificate =
+        certificates.Single(certificate => certificate.HasPrivateKey);
+    X509Certificate2Collection intermediateCertificates = new(
+        certificates
+            .Where(certificate => !certificate.HasPrivateKey)
+            .ToArray());
+    SslStreamCertificateContext certificateContext =
+        SslStreamCertificateContext.Create(
+            clientCertificate,
+            intermediateCertificates,
+            offline: true);
+
+    SocketsHttpHandler handler = new()
+    {
+        // Do not automatically follow a redirect with a certificate-bearing handler.
+        AllowAutoRedirect = false,
+    };
+    handler.SslOptions.ClientCertificateContext = certificateContext;
+
+    using HttpClient httpClient = new(handler);
+    OpenAIClientOptions options = new()
+    {
+        Endpoint = new Uri("https://mtls.api.openai.com/v1"),
+        Transport = new HttpClientPipelineTransport(httpClient),
+    };
+
+    OpenAIClient client = new(
+        new ApiKeyCredential(apiKey),
+        options);
+
+    ChatCompletion completion = await client
+        .GetChatClient("gpt-4o-mini")
+        .CompleteChatAsync("Reply with exactly: mTLS request succeeded.");
+}
+finally
+{
+    foreach (X509Certificate2 certificate in certificates)
+    {
+        certificate.Dispose();
+    }
+}
+```
+
+Keep the `HttpClient` alive for as long as the OpenAI client uses it, and create a new handler, transport, and client when rotating the certificate so new TLS connections use the replacement credentials. This transport recipe applies to HTTP clients created from `OpenAIClient`; it does not configure Realtime WebSocket connections.
+
+See the [complete mTLS example](examples/MutualTls/README.md) for setup and a runnable end-to-end request.
 
 ### Using protocol methods
 

--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ try
         SslStreamCertificateContext.Create(
             clientCertificate,
             intermediateCertificates,
+            // Build the local chain without revocation network lookups.
             offline: true);
 
     SocketsHttpHandler handler = new()

--- a/examples/MutualTls/Example01_MutualTlsAsync.cs
+++ b/examples/MutualTls/Example01_MutualTlsAsync.cs
@@ -1,0 +1,101 @@
+// Demonstrates API-key + HTTP mTLS with OpenAI by configuring .NET's native
+// SocketsHttpHandler and passing its HttpClient through the SDK's existing
+// transport seam. Keeping certificate handling in the HTTP transport preserves
+// native .NET support for certificate stores, proxies, and credential rotation.
+
+using NUnit.Framework;
+using OpenAI.Chat;
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace OpenAI.Examples;
+
+public partial class MutualTlsExamples
+{
+    [Test]
+    [Explicit("Requires an API key and a client certificate enrolled in the OpenAI mTLS beta.")]
+    public async Task Example01_MutualTlsAsync()
+    {
+        string apiKey = GetRequiredEnvironmentVariable("OPENAI_API_KEY");
+        string pfxPath = GetRequiredEnvironmentVariable("OPENAI_CLIENT_PFX_PATH");
+        Uri endpoint = GetEndpoint();
+
+        X509Certificate2Collection certificates =
+            X509CertificateLoader.LoadPkcs12CollectionFromFile(
+                pfxPath,
+                Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PASSWORD"));
+
+        try
+        {
+            X509Certificate2 clientCertificate =
+                certificates.Single(certificate => certificate.HasPrivateKey);
+            X509Certificate2Collection intermediateCertificates = new(
+                certificates
+                    .Where(certificate => !certificate.HasPrivateKey)
+                    .ToArray());
+            SslStreamCertificateContext certificateContext =
+                SslStreamCertificateContext.Create(
+                    clientCertificate,
+                    intermediateCertificates,
+                    offline: true);
+
+            SocketsHttpHandler handler = new()
+            {
+                AllowAutoRedirect = false,
+            };
+            handler.SslOptions.ClientCertificateContext = certificateContext;
+
+            using HttpClient httpClient = new(handler);
+            OpenAIClientOptions options = new()
+            {
+                Endpoint = endpoint,
+                Transport = new HttpClientPipelineTransport(httpClient),
+            };
+
+            OpenAIClient client = new(new ApiKeyCredential(apiKey), options);
+            ChatCompletion completion = await client
+                .GetChatClient("gpt-4o-mini")
+                .CompleteChatAsync("Reply with exactly: mTLS request succeeded.");
+
+            Console.WriteLine(completion.Content[0].Text);
+        }
+        finally
+        {
+            foreach (X509Certificate2 certificate in certificates)
+            {
+                certificate.Dispose();
+            }
+        }
+    }
+
+    private static string GetRequiredEnvironmentVariable(string name)
+    {
+        string value = Environment.GetEnvironmentVariable(name);
+        return !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new InvalidOperationException($"{name} is required.");
+    }
+
+    private static Uri GetEndpoint()
+    {
+        // Choose the global endpoint or set OPENAI_BASE_URL to the EU endpoint:
+        // https://mtls-eu.api.openai.com/v1
+        string value = Environment.GetEnvironmentVariable("OPENAI_BASE_URL")
+            ?? "https://mtls.api.openai.com/v1";
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out Uri endpoint)
+            || endpoint.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new InvalidOperationException(
+                "OPENAI_BASE_URL must be an absolute HTTPS URI.");
+        }
+
+        return endpoint;
+    }
+}

--- a/examples/MutualTls/Example01_MutualTlsAsync.cs
+++ b/examples/MutualTls/Example01_MutualTlsAsync.cs
@@ -46,6 +46,7 @@ public partial class MutualTlsExamples
                 SslStreamCertificateContext.Create(
                     clientCertificate,
                     intermediateCertificates,
+                    // Build the local chain without revocation network lookups.
                     offline: true);
 
             SocketsHttpHandler handler = new()
@@ -126,26 +127,5 @@ public partial class MutualTlsExamples
             || endpoint.IdnHost.Equals(
                 "mtls-eu.api.openai.com",
                 StringComparison.OrdinalIgnoreCase));
-    }
-
-    [TestCase(GlobalEndpoint)]
-    [TestCase(EuropeanUnionEndpoint)]
-    [TestCase("https://mtls.api.openai.com:443/v1")]
-    [TestCase("https://mtls.api.openai.com/v1/")]
-    public void GetEndpointAcceptsSupportedMtlsBaseUrls(string value)
-    {
-        Assert.That(GetEndpoint(value), Is.Not.Null);
-    }
-
-    [TestCase("http://mtls.api.openai.com/v1")]
-    [TestCase("https://mtls.api.openai.com:444/v1")]
-    [TestCase("https://mtls.api.openai.com@attacker.example/v1")]
-    [TestCase("https://mtls.api.openai.com.attacker.example/v1")]
-    [TestCase("https://mtls.api.openai.com/v1/other")]
-    [TestCase("https://mtls.api.openai.com/v1?query=value")]
-    [TestCase("https://mtls.api.openai.com/v1#fragment")]
-    public void GetEndpointRejectsUntrustedDestinations(string value)
-    {
-        Assert.Throws<InvalidOperationException>(() => GetEndpoint(value));
     }
 }

--- a/examples/MutualTls/Example01_MutualTlsAsync.cs
+++ b/examples/MutualTls/Example01_MutualTlsAsync.cs
@@ -18,6 +18,9 @@ namespace OpenAI.Examples;
 
 public partial class MutualTlsExamples
 {
+    private const string GlobalEndpoint = "https://mtls.api.openai.com/v1";
+    private const string EuropeanUnionEndpoint = "https://mtls-eu.api.openai.com/v1";
+
     [Test]
     [Explicit("Requires an API key and a client certificate enrolled in the OpenAI mTLS beta.")]
     public async Task Example01_MutualTlsAsync()
@@ -51,7 +54,11 @@ public partial class MutualTlsExamples
             };
             handler.SslOptions.ClientCertificateContext = certificateContext;
 
-            using HttpClient httpClient = new(handler);
+            using HttpClient httpClient = new(handler)
+            {
+                // The SDK pipeline owns request timeouts through NetworkTimeout.
+                Timeout = System.Threading.Timeout.InfiniteTimeSpan,
+            };
             OpenAIClientOptions options = new()
             {
                 Endpoint = endpoint,
@@ -84,18 +91,61 @@ public partial class MutualTlsExamples
 
     private static Uri GetEndpoint()
     {
-        // Choose the global endpoint or set OPENAI_BASE_URL to the EU endpoint:
-        // https://mtls-eu.api.openai.com/v1
         string value = Environment.GetEnvironmentVariable("OPENAI_BASE_URL")
-            ?? "https://mtls.api.openai.com/v1";
+            ?? GlobalEndpoint;
+        return GetEndpoint(value);
+    }
 
+    private static Uri GetEndpoint(string value)
+    {
         if (!Uri.TryCreate(value, UriKind.Absolute, out Uri endpoint)
-            || endpoint.Scheme != Uri.UriSchemeHttps)
+            || !IsSupportedEndpoint(endpoint))
         {
             throw new InvalidOperationException(
-                "OPENAI_BASE_URL must be an absolute HTTPS URI.");
+                $"OPENAI_BASE_URL must be {GlobalEndpoint} or "
+                + $"{EuropeanUnionEndpoint}.");
         }
 
         return endpoint;
+    }
+
+    private static bool IsSupportedEndpoint(Uri endpoint)
+    {
+        return endpoint.Scheme == Uri.UriSchemeHttps
+        && endpoint is
+        {
+            IsDefaultPort: true,
+            UserInfo.Length: 0,
+            Query.Length: 0,
+            Fragment.Length: 0,
+        }
+        && endpoint.AbsolutePath.TrimEnd('/') == "/v1"
+        && (endpoint.IdnHost.Equals(
+                "mtls.api.openai.com",
+                StringComparison.OrdinalIgnoreCase)
+            || endpoint.IdnHost.Equals(
+                "mtls-eu.api.openai.com",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestCase(GlobalEndpoint)]
+    [TestCase(EuropeanUnionEndpoint)]
+    [TestCase("https://mtls.api.openai.com:443/v1")]
+    [TestCase("https://mtls.api.openai.com/v1/")]
+    public void GetEndpointAcceptsSupportedMtlsBaseUrls(string value)
+    {
+        Assert.That(GetEndpoint(value), Is.Not.Null);
+    }
+
+    [TestCase("http://mtls.api.openai.com/v1")]
+    [TestCase("https://mtls.api.openai.com:444/v1")]
+    [TestCase("https://mtls.api.openai.com@attacker.example/v1")]
+    [TestCase("https://mtls.api.openai.com.attacker.example/v1")]
+    [TestCase("https://mtls.api.openai.com/v1/other")]
+    [TestCase("https://mtls.api.openai.com/v1?query=value")]
+    [TestCase("https://mtls.api.openai.com/v1#fragment")]
+    public void GetEndpointRejectsUntrustedDestinations(string value)
+    {
+        Assert.Throws<InvalidOperationException>(() => GetEndpoint(value));
     }
 }

--- a/examples/MutualTls/MutualTlsExamplesTests.cs
+++ b/examples/MutualTls/MutualTlsExamplesTests.cs
@@ -1,0 +1,30 @@
+// Keeps endpoint security-policy tests separate from the runnable mTLS example.
+
+using NUnit.Framework;
+using System;
+
+namespace OpenAI.Examples;
+
+public partial class MutualTlsExamples
+{
+    [TestCase(GlobalEndpoint)]
+    [TestCase(EuropeanUnionEndpoint)]
+    [TestCase("https://mtls.api.openai.com:443/v1")]
+    [TestCase("https://mtls.api.openai.com/v1/")]
+    public void GetEndpointAcceptsSupportedMtlsBaseUrls(string value)
+    {
+        Assert.That(GetEndpoint(value), Is.Not.Null);
+    }
+
+    [TestCase("http://mtls.api.openai.com/v1")]
+    [TestCase("https://mtls.api.openai.com:444/v1")]
+    [TestCase("https://mtls.api.openai.com@attacker.example/v1")]
+    [TestCase("https://mtls.api.openai.com.attacker.example/v1")]
+    [TestCase("https://mtls.api.openai.com/v1/other")]
+    [TestCase("https://mtls.api.openai.com/v1?query=value")]
+    [TestCase("https://mtls.api.openai.com/v1#fragment")]
+    public void GetEndpointRejectsUntrustedDestinations(string value)
+    {
+        Assert.Throws<InvalidOperationException>(() => GetEndpoint(value));
+    }
+}

--- a/examples/MutualTls/README.md
+++ b/examples/MutualTls/README.md
@@ -1,0 +1,73 @@
+# API-key + HTTP mTLS example
+
+This example configures mTLS on .NET's native `SocketsHttpHandler` and passes the resulting `HttpClient` to the OpenAI SDK through `HttpClientPipelineTransport`. Keeping certificate handling in the HTTP transport preserves .NET's native certificate, proxy, and rotation capabilities without adding an SDK-specific mTLS option.
+
+Before running it, follow the [OpenAI Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program) instructions to understand request authentication and enroll, upload, and activate a client certificate for your organization or project. To manage uploaded certificates programmatically, see the [Certificates API reference](https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/certificates/).
+
+## Certificate bundle
+
+Set `OPENAI_CLIENT_PFX_PATH` to a PFX/PKCS#12 bundle containing:
+
+1. Exactly one certificate with a private key: the leaf client certificate.
+2. Every required intermediate certificate.
+
+Do not include the root CA certificate; TLS peers establish trust from their own root stores. Do not rely on `X509Certificate2.CreateFromPemFile` for a certificate-chain PEM: it loads only the first certificate. A PFX bundle keeps the leaf, private key, and intermediates together for `SslStreamCertificateContext`, which ensures the TLS handshake can present the complete chain.
+
+## Endpoint
+
+Set `OPENAI_BASE_URL` to the base URL that matches your data residency:
+
+| Scope | Base URL |
+| --- | --- |
+| Global (default) | `https://mtls.api.openai.com/v1` |
+| EU Data Residency | `https://mtls-eu.api.openai.com/v1` |
+
+`OPENAI_BASE_URL` must be an absolute HTTPS URI.
+
+## Run the example
+
+From PowerShell at the repository root, set the environment variables for the
+current process and run the explicit example test:
+
+```powershell
+$env:OPENAI_API_KEY = "sk-..."
+$env:OPENAI_CLIENT_PFX_PATH = "C:\path\to\client-chain.pfx"
+$env:OPENAI_CLIENT_PFX_PASSWORD = "optional-password"
+
+dotnet test .\examples\OpenAI.Examples.csproj `
+  --framework net10.0 `
+  -- NUnit.Where="test == 'OpenAI.Examples.MutualTlsExamples.Example01_MutualTlsAsync'"
+```
+
+The example calls the supported Chat Completions endpoint and prints its text
+response. For EU Data Residency, set:
+
+```powershell
+$env:OPENAI_BASE_URL = "https://mtls-eu.api.openai.com/v1"
+```
+
+The handler disables automatic redirects so the certificate-bearing transport does not follow a redirect to another host. Keep the `HttpClient` alive for the lifetime of the SDK client. When rotating the certificate, create a new handler, transport, and SDK client; an existing pooled TLS connection will not renegotiate with replacement credentials.
+
+## End-to-end testing
+
+The automated mTLS tests create a private root, intermediate, server, and client
+certificate for each test. They start a loopback TLS server that requires a
+trusted client certificate, send a request through the real
+`SocketsHttpHandler`, `HttpClientPipelineTransport`, and OpenAI Chat client, and
+verify the TLS chain, API key, HTTP request, and deserialized SDK response. They
+also verify that missing or untrusted client credentials fail closed and that
+the certificate-bearing handler does not follow redirects.
+
+Run these deterministic tests from PowerShell:
+
+```powershell
+dotnet test .\tests\OpenAI.Tests.csproj `
+  --filter "TestCategory=MutualTls"
+```
+
+The explicit example test above is the live end-to-end check against OpenAI. It
+requires an API key and a client certificate whose CA has been uploaded and
+activated for the same organization or project, so it is not suitable for
+credential-free pull request CI.
+
+This example covers API-key + HTTP mTLS only. It does not configure Realtime WebSocket connections or X.509 workload identity federation.

--- a/examples/MutualTls/README.md
+++ b/examples/MutualTls/README.md
@@ -2,11 +2,11 @@
 
 This example configures mTLS on .NET's native `SocketsHttpHandler` and passes the resulting `HttpClient` to the OpenAI SDK through `HttpClientPipelineTransport`. Keeping certificate handling in the HTTP transport preserves .NET's native certificate, proxy, and rotation capabilities without adding an SDK-specific mTLS option.
 
-Before running it, follow the [OpenAI Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program) instructions to understand request authentication and enroll, upload, and activate a client certificate for your organization or project. To manage uploaded certificates programmatically, see the [Certificates API reference](https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/certificates/).
+Before running it, follow the [OpenAI Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program) instructions to understand request authentication and enroll. Upload and activate the CA certificate that issues your client certificate; keep the leaf client certificate and its private key in the PFX used by this example. To manage uploaded CA certificates programmatically, see the [Certificates API reference](https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/certificates/).
 
 ## Certificate bundle
 
-Set `OPENAI_CLIENT_PFX_PATH` to a PFX/PKCS#12 bundle containing:
+Certificate-chain support is available by request and must be enabled for your organization. Without it, the leaf client certificate must be signed directly by the uploaded CA. When chain support is enabled, set `OPENAI_CLIENT_PFX_PATH` to a PFX/PKCS#12 bundle containing:
 
 1. Exactly one certificate with a private key: the leaf client certificate.
 2. Every required intermediate certificate.
@@ -22,7 +22,7 @@ Set `OPENAI_BASE_URL` to the base URL that matches your data residency:
 | Global (default) | `https://mtls.api.openai.com/v1` |
 | EU Data Residency | `https://mtls-eu.api.openai.com/v1` |
 
-`OPENAI_BASE_URL` must be an absolute HTTPS URI.
+For safety, the example accepts only these two HTTPS origins and the `/v1` base path. It rejects custom hosts, non-default ports, credentials, query strings, and fragments so the API key and client certificate cannot be sent to an unintended server.
 
 ## Run the example
 

--- a/tests/MutualTls/CertificateFixture.cs
+++ b/tests/MutualTls/CertificateFixture.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Formats.Asn1;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace OpenAI.Tests.MutualTls;
+
+internal sealed class CertificateFixture : IDisposable
+{
+    private const string AuthorityKeyIdentifierOid = "2.5.29.35";
+    private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+    private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+
+    public X509Certificate2 RootCertificate { get; }
+    public X509Certificate2 IntermediateCertificate { get; }
+    public X509Certificate2 ClientCertificate { get; }
+    public X509Certificate2 ServerCertificate { get; }
+
+    private CertificateFixture(
+        X509Certificate2 rootCertificate,
+        X509Certificate2 intermediateCertificate,
+        X509Certificate2 clientCertificate,
+        X509Certificate2 serverCertificate)
+    {
+        RootCertificate = rootCertificate;
+        IntermediateCertificate = intermediateCertificate;
+        ClientCertificate = clientCertificate;
+        ServerCertificate = serverCertificate;
+    }
+
+    public static CertificateFixture Create()
+    {
+        DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+        DateTimeOffset notAfter = DateTimeOffset.UtcNow.AddDays(7);
+        string certificateSetId = Guid.NewGuid().ToString("N");
+
+        using RSA rootKey = RSA.Create(2048);
+        CertificateRequest rootRequest = CreateCertificateRequest(
+            $"CN=OpenAI mTLS Test Root {certificateSetId}",
+            rootKey);
+        rootRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(
+                certificateAuthority: true,
+                hasPathLengthConstraint: true,
+                pathLengthConstraint: 1,
+                critical: true));
+        rootRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                critical: true));
+        X509SubjectKeyIdentifierExtension rootSubjectKeyIdentifier =
+            AddSubjectKeyIdentifier(rootRequest);
+        AddAuthorityKeyIdentifier(rootRequest, rootSubjectKeyIdentifier);
+        X509Certificate2 rootCertificate =
+            rootRequest.CreateSelfSigned(notBefore, notAfter);
+
+        using RSA intermediateKey = RSA.Create(2048);
+        CertificateRequest intermediateRequest = CreateCertificateRequest(
+            $"CN=OpenAI mTLS Test Intermediate {certificateSetId}",
+            intermediateKey);
+        intermediateRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(
+                certificateAuthority: true,
+                hasPathLengthConstraint: true,
+                pathLengthConstraint: 0,
+                critical: true));
+        intermediateRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                critical: true));
+        X509SubjectKeyIdentifierExtension intermediateSubjectKeyIdentifier =
+            AddSubjectKeyIdentifier(intermediateRequest);
+        AddAuthorityKeyIdentifier(
+            intermediateRequest,
+            rootSubjectKeyIdentifier);
+        X509Certificate2 intermediateCertificate =
+            intermediateRequest.Create(
+                rootCertificate,
+                notBefore,
+                notAfter,
+                CreateSerialNumber());
+
+        using RSA clientKey = RSA.Create(2048);
+        CertificateRequest clientRequest = CreateCertificateRequest(
+            $"CN=OpenAI mTLS Test Client {certificateSetId}",
+            clientKey);
+        SubjectAlternativeNameBuilder clientSubjectAlternativeNames = new();
+        clientSubjectAlternativeNames.AddDnsName(
+            $"client-{certificateSetId}.openai.test");
+        AddEndEntityExtensions(
+            clientRequest,
+            ClientAuthenticationOid,
+            intermediateSubjectKeyIdentifier,
+            clientSubjectAlternativeNames.Build());
+        using X509Certificate2 clientPublicCertificate =
+            clientRequest.Create(
+                intermediateCertificate.SubjectName,
+                X509SignatureGenerator.CreateForRSA(
+                    intermediateKey,
+                    RSASignaturePadding.Pkcs1),
+                notBefore,
+                notAfter,
+                CreateSerialNumber());
+        X509Certificate2 clientCertificate =
+            clientPublicCertificate.CopyWithPrivateKey(clientKey);
+
+        using RSA serverKey = RSA.Create(2048);
+        CertificateRequest serverRequest = CreateCertificateRequest(
+            "CN=127.0.0.1",
+            serverKey);
+        SubjectAlternativeNameBuilder subjectAlternativeNames = new();
+        subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
+        subjectAlternativeNames.AddDnsName("localhost");
+        AddEndEntityExtensions(
+            serverRequest,
+            ServerAuthenticationOid,
+            rootSubjectKeyIdentifier,
+            subjectAlternativeNames.Build());
+        using X509Certificate2 serverPublicCertificate =
+            serverRequest.Create(
+                rootCertificate,
+                notBefore,
+                notAfter,
+                CreateSerialNumber());
+        X509Certificate2 serverCertificate =
+            serverPublicCertificate.CopyWithPrivateKey(serverKey);
+
+        return new CertificateFixture(
+            rootCertificate,
+            intermediateCertificate,
+            clientCertificate,
+            serverCertificate);
+    }
+
+    public byte[] ExportClientBundle(string password)
+    {
+        X509Certificate2Collection certificates =
+            new(
+                new X509Certificate2[]
+                {
+                    ClientCertificate,
+                    IntermediateCertificate,
+                });
+        return certificates.Export(X509ContentType.Pkcs12, password);
+    }
+
+    public void Dispose()
+    {
+        ServerCertificate.Dispose();
+        ClientCertificate.Dispose();
+        IntermediateCertificate.Dispose();
+        RootCertificate.Dispose();
+    }
+
+    private static CertificateRequest CreateCertificateRequest(
+        string subjectName,
+        RSA key)
+    {
+        return new CertificateRequest(
+            new X500DistinguishedName(subjectName),
+            key,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+    }
+
+    private static X509SubjectKeyIdentifierExtension AddSubjectKeyIdentifier(
+        CertificateRequest request)
+    {
+        X509SubjectKeyIdentifierExtension extension =
+            new(request.PublicKey, critical: false);
+        request.CertificateExtensions.Add(extension);
+        return extension;
+    }
+
+    private static void AddAuthorityKeyIdentifier(
+        CertificateRequest request,
+        X509SubjectKeyIdentifierExtension issuerSubjectKeyIdentifier)
+    {
+        byte[] keyIdentifier =
+            Convert.FromHexString(
+                issuerSubjectKeyIdentifier.SubjectKeyIdentifier);
+        AsnWriter writer = new(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteOctetString(
+            keyIdentifier,
+            new Asn1Tag(TagClass.ContextSpecific, 0));
+        writer.PopSequence();
+        request.CertificateExtensions.Add(
+            new X509Extension(
+                AuthorityKeyIdentifierOid,
+                writer.Encode(),
+                critical: false));
+    }
+
+    private static void AddEndEntityExtensions(
+        CertificateRequest request,
+        string enhancedKeyUsageOid,
+        X509SubjectKeyIdentifierExtension issuerSubjectKeyIdentifier,
+        X509Extension subjectAlternativeName)
+    {
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(
+                certificateAuthority: false,
+                hasPathLengthConstraint: false,
+                pathLengthConstraint: 0,
+                critical: true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature
+                    | X509KeyUsageFlags.KeyEncipherment,
+                critical: true));
+        OidCollection enhancedKeyUsages = new();
+        enhancedKeyUsages.Add(new Oid(enhancedKeyUsageOid));
+        request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(enhancedKeyUsages, critical: true));
+        AddSubjectKeyIdentifier(request);
+        AddAuthorityKeyIdentifier(request, issuerSubjectKeyIdentifier);
+        request.CertificateExtensions.Add(subjectAlternativeName);
+    }
+
+    private static byte[] CreateSerialNumber()
+    {
+        byte[] serialNumber = RandomNumberGenerator.GetBytes(16);
+        serialNumber[0] &= 0x7F;
+        serialNumber[^1] |= 0x01;
+        return serialNumber;
+    }
+}

--- a/tests/MutualTls/MutualTlsEndpointTests.cs
+++ b/tests/MutualTls/MutualTlsEndpointTests.cs
@@ -1,10 +1,13 @@
-// Keeps endpoint security-policy tests separate from the runnable mTLS example.
+#if NET9_0_OR_GREATER
+// Compiles with the linked runnable sample so its private endpoint policy can
+// be tested without adding test hooks to the example.
 
 using NUnit.Framework;
 using System;
 
 namespace OpenAI.Examples;
 
+[Category("MutualTls")]
 public partial class MutualTlsExamples
 {
     [TestCase(GlobalEndpoint)]
@@ -28,3 +31,4 @@ public partial class MutualTlsExamples
         Assert.Throws<InvalidOperationException>(() => GetEndpoint(value));
     }
 }
+#endif

--- a/tests/MutualTls/MutualTlsExamplesTests.cs
+++ b/tests/MutualTls/MutualTlsExamplesTests.cs
@@ -1,0 +1,840 @@
+using NUnit.Framework;
+using OpenAI.Chat;
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Tests.MutualTls;
+
+[NonParallelizable]
+[Category("MutualTls")]
+public class MutualTlsExamplesTests
+{
+    private const string ApiKey = "test-api-key";
+    private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+    private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+    private const string PfxPassword = "test-password";
+
+    // Loading a PFX private key affects the temporary key store on macOS, so run it last.
+    [Test]
+    [Order(6)]
+    public async Task FullChainCompletesSdkRequestEndToEnd()
+    {
+        using CertificateFixture certificates = CertificateFixture.Create();
+        await using MutualTlsServer server = MutualTlsServer.Start(
+            certificates.ServerCertificate,
+            certificates.RootCertificate);
+        using DisposableCertificateCollection imported =
+            DisposableCertificateCollection.Load(
+                certificates.ExportClientBundle(),
+                PfxPassword);
+        using HttpClient httpClient = CreateHttpClient(
+            imported.Certificates,
+            certificates.ServerCertificate);
+
+        ChatClient client = CreateChatClient(server.Endpoint, httpClient);
+        ChatCompletion completion;
+        try
+        {
+            completion = await client.CompleteChatAsync(
+                "Reply with exactly: mTLS request succeeded.");
+        }
+        catch (Exception clientException)
+        {
+            await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Fail(
+                $"Client request failed: {clientException}\n"
+                + $"Server failure: {server.Failure}\n"
+                + "Presented chain: "
+                + string.Join(", ", server.PresentedClientChainThumbprints));
+            throw;
+        }
+        await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+        using JsonDocument requestBody = JsonDocument.Parse(server.Request.Body);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(imported.Certificates, Has.Count.EqualTo(2));
+            Assert.That(
+                imported.Certificates.Count(certificate => certificate.HasPrivateKey),
+                Is.EqualTo(1));
+            Assert.That(completion.Content[0].Text, Is.EqualTo("mTLS request succeeded."));
+            Assert.That(server.Request.Method, Is.EqualTo("POST"));
+            Assert.That(server.Request.Path, Is.EqualTo("/v1/chat/completions"));
+            Assert.That(
+                requestBody.RootElement.GetProperty("model").GetString(),
+                Is.EqualTo("gpt-4o-mini"));
+            Assert.That(
+                requestBody.RootElement
+                    .GetProperty("messages")[0]
+                    .GetProperty("content")
+                    .GetString(),
+                Is.EqualTo("Reply with exactly: mTLS request succeeded."));
+            Assert.That(
+                server.Request.Headers["Authorization"],
+                Is.EqualTo($"Bearer {ApiKey}"));
+            Assert.That(server.ClientCertificateWasTrusted, Is.True);
+            Assert.That(
+                server.PresentedClientChainThumbprints,
+                Does.Contain(certificates.IntermediateCertificate.Thumbprint));
+        });
+    }
+
+    [Test]
+    [Order(2)]
+    public async Task MissingIntermediateFailsClosed()
+    {
+        using CertificateFixture certificates = CertificateFixture.Create();
+        await using MutualTlsServer server = MutualTlsServer.Start(
+            certificates.ServerCertificate,
+            certificates.RootCertificate);
+        using HttpClient httpClient = CreateHttpClient(
+            new X509Certificate2Collection(certificates.ClientCertificate),
+            certificates.ServerCertificate);
+
+        ChatClient client = CreateChatClient(server.Endpoint, httpClient);
+
+        Exception exception =
+            Assert.CatchAsync(
+                async () => await client.CompleteChatAsync("Hello"));
+        await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                exception,
+                Is.InstanceOf<ClientResultException>()
+                    .Or.InstanceOf<OperationCanceledException>());
+            Assert.That(server.Request, Is.Null);
+            Assert.That(server.ClientCertificateWasTrusted, Is.False);
+            Assert.That(
+                server.PresentedClientChainThumbprints,
+                Does.Not.Contain(certificates.IntermediateCertificate.Thumbprint));
+            Assert.That(server.Failure, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    [Order(1)]
+    public async Task MissingClientCertificateFailsClosed()
+    {
+        using CertificateFixture certificates = CertificateFixture.Create();
+        await using MutualTlsServer server = MutualTlsServer.Start(
+            certificates.ServerCertificate,
+            certificates.RootCertificate);
+        using HttpClient httpClient = CreateHttpClient(
+            new X509Certificate2Collection(),
+            certificates.ServerCertificate);
+
+        ChatClient client = CreateChatClient(server.Endpoint, httpClient);
+
+        Exception exception =
+            Assert.CatchAsync(
+                async () => await client.CompleteChatAsync("Hello"));
+        await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                exception,
+                Is.InstanceOf<ClientResultException>()
+                    .Or.InstanceOf<OperationCanceledException>());
+            Assert.That(server.Request, Is.Null);
+            Assert.That(server.ClientCertificateWasTrusted, Is.False);
+            Assert.That(server.Failure, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    [Order(5)]
+    public async Task CertificateBearingHandlerDoesNotFollowRedirects()
+    {
+        using CertificateFixture certificates = CertificateFixture.Create();
+        await using MutualTlsServer redirectTarget = MutualTlsServer.Start(
+            certificates.ServerCertificate,
+            certificates.RootCertificate);
+        await using MutualTlsServer redirectSource = MutualTlsServer.Start(
+            certificates.ServerCertificate,
+            certificates.RootCertificate,
+            redirectLocation: new Uri(redirectTarget.Endpoint, "chat/completions"));
+        using HttpClient httpClient = CreateHttpClient(
+            new X509Certificate2Collection(
+                new X509Certificate2[]
+                {
+                    certificates.ClientCertificate,
+                    certificates.IntermediateCertificate,
+                }),
+            certificates.ServerCertificate);
+
+        ChatClient client = CreateChatClient(redirectSource.Endpoint, httpClient);
+
+        ClientResultException exception =
+            Assert.ThrowsAsync<ClientResultException>(
+                async () => await client.CompleteChatAsync("Hello"));
+        await redirectSource.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Status, Is.EqualTo((int)HttpStatusCode.TemporaryRedirect));
+            Assert.That(redirectSource.Request, Is.Not.Null);
+            Assert.That(redirectTarget.ConnectionCount, Is.Zero);
+        });
+    }
+
+    [Test]
+    [Order(3)]
+    public async Task UntrustedClientCertificateFailsClosed()
+    {
+        using CertificateFixture trustedCertificates = CertificateFixture.Create();
+        using CertificateFixture untrustedCertificates = CertificateFixture.Create();
+        await using MutualTlsServer server = MutualTlsServer.Start(
+            trustedCertificates.ServerCertificate,
+            trustedCertificates.RootCertificate);
+        using HttpClient httpClient = CreateHttpClient(
+            new X509Certificate2Collection(
+                new X509Certificate2[]
+                {
+                    untrustedCertificates.ClientCertificate,
+                    untrustedCertificates.IntermediateCertificate,
+                }),
+            trustedCertificates.ServerCertificate);
+
+        ChatClient client = CreateChatClient(server.Endpoint, httpClient);
+
+        Exception exception =
+            Assert.CatchAsync(
+                async () => await client.CompleteChatAsync("Hello"));
+        await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                exception,
+                Is.InstanceOf<ClientResultException>()
+                    .Or.InstanceOf<OperationCanceledException>());
+            Assert.That(server.Request, Is.Null);
+            Assert.That(server.ClientCertificateWasTrusted, Is.False);
+            Assert.That(server.Failure, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    [Order(4)]
+    public async Task InvalidApiKeyIsRejectedAfterSuccessfulTlsAuthentication()
+    {
+        const string invalidApiKey = "invalid-api-key";
+        using CertificateFixture certificates = CertificateFixture.Create();
+        await using MutualTlsServer server = MutualTlsServer.Start(
+            certificates.ServerCertificate,
+            certificates.RootCertificate,
+            requiredApiKey: ApiKey);
+        using HttpClient httpClient = CreateHttpClient(
+            new X509Certificate2Collection(
+                new X509Certificate2[]
+                {
+                    certificates.ClientCertificate,
+                    certificates.IntermediateCertificate,
+                }),
+            certificates.ServerCertificate);
+
+        ChatClient client =
+            CreateChatClient(server.Endpoint, httpClient, invalidApiKey);
+
+        ClientResultException exception =
+            Assert.ThrowsAsync<ClientResultException>(
+                async () => await client.CompleteChatAsync("Hello"));
+        await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Status, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+            Assert.That(server.ClientCertificateWasTrusted, Is.True);
+            Assert.That(server.Request, Is.Not.Null);
+            Assert.That(
+                server.Request.Headers["Authorization"],
+                Is.EqualTo($"Bearer {invalidApiKey}"));
+        });
+    }
+
+    private static HttpClient CreateHttpClient(
+        X509Certificate2Collection clientCertificates,
+        X509Certificate2 serverCertificate)
+    {
+        SocketsHttpHandler handler = new()
+        {
+            AllowAutoRedirect = false,
+        };
+        handler.SslOptions.RemoteCertificateValidationCallback =
+            (_, certificate, _, _) =>
+                certificate?.GetCertHashString(HashAlgorithmName.SHA256)
+                    == serverCertificate.GetCertHashString(HashAlgorithmName.SHA256);
+        if (clientCertificates.Count > 0)
+        {
+            X509Certificate2 clientCertificate =
+                clientCertificates.Single(certificate => certificate.HasPrivateKey);
+            X509Certificate2Collection intermediateCertificates = new(
+                clientCertificates
+                    .Where(certificate => !certificate.HasPrivateKey)
+                    .ToArray());
+            handler.SslOptions.ClientCertificateContext =
+                SslStreamCertificateContext.Create(
+                    clientCertificate,
+                    intermediateCertificates,
+                    offline: true);
+        }
+
+        return new HttpClient(handler);
+    }
+
+    private static ChatClient CreateChatClient(
+        Uri endpoint,
+        HttpClient httpClient,
+        string apiKey = ApiKey)
+    {
+        OpenAIClientOptions options = new()
+        {
+            Endpoint = endpoint,
+            NetworkTimeout = TimeSpan.FromSeconds(5),
+            RetryPolicy = new ClientRetryPolicy(maxRetries: 0),
+            Transport = new HttpClientPipelineTransport(httpClient),
+        };
+
+        OpenAIClient client = new(new ApiKeyCredential(apiKey), options);
+        return client.GetChatClient("gpt-4o-mini");
+    }
+
+    private sealed class DisposableCertificateCollection : IDisposable
+    {
+        public X509Certificate2Collection Certificates { get; }
+
+        private DisposableCertificateCollection(X509Certificate2Collection certificates)
+        {
+            Certificates = certificates;
+        }
+
+        public static DisposableCertificateCollection Load(byte[] pfx, string password)
+        {
+#if NET9_0_OR_GREATER
+            X509Certificate2Collection certificates =
+                X509CertificateLoader.LoadPkcs12Collection(
+                    pfx,
+                    password,
+                    X509KeyStorageFlags.DefaultKeySet);
+#else
+            X509Certificate2Collection certificates = new();
+#pragma warning disable SYSLIB0057
+            certificates.Import(
+                pfx,
+                password,
+                X509KeyStorageFlags.DefaultKeySet);
+#pragma warning restore SYSLIB0057
+#endif
+            return new DisposableCertificateCollection(certificates);
+        }
+
+        public void Dispose()
+        {
+            foreach (X509Certificate2 certificate in Certificates)
+            {
+                certificate.Dispose();
+            }
+        }
+    }
+
+    private sealed class CertificateFixture : IDisposable
+    {
+        public X509Certificate2 RootCertificate { get; }
+        public X509Certificate2 IntermediateCertificate { get; }
+        public X509Certificate2 ClientCertificate { get; }
+        public X509Certificate2 ServerCertificate { get; }
+
+        private CertificateFixture(
+            X509Certificate2 rootCertificate,
+            X509Certificate2 intermediateCertificate,
+            X509Certificate2 clientCertificate,
+            X509Certificate2 serverCertificate)
+        {
+            RootCertificate = rootCertificate;
+            IntermediateCertificate = intermediateCertificate;
+            ClientCertificate = clientCertificate;
+            ServerCertificate = serverCertificate;
+        }
+
+        public static CertificateFixture Create()
+        {
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+            DateTimeOffset notAfter = DateTimeOffset.UtcNow.AddHours(1);
+            string certificateSetId = Guid.NewGuid().ToString("N");
+
+            using RSA rootKey = RSA.Create(2048);
+            CertificateRequest rootRequest = CreateCertificateRequest(
+                $"CN=OpenAI mTLS Test Root {certificateSetId}",
+                rootKey);
+            rootRequest.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: true,
+                    hasPathLengthConstraint: true,
+                    pathLengthConstraint: 1,
+                    critical: true));
+            rootRequest.CertificateExtensions.Add(
+                new X509KeyUsageExtension(
+                    X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                    critical: true));
+            AddSubjectKeyIdentifier(rootRequest);
+            X509Certificate2 rootCertificate =
+                rootRequest.CreateSelfSigned(notBefore, notAfter);
+
+            using RSA intermediateKey = RSA.Create(2048);
+            CertificateRequest intermediateRequest = CreateCertificateRequest(
+                $"CN=OpenAI mTLS Test Intermediate {certificateSetId}",
+                intermediateKey);
+            intermediateRequest.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: true,
+                    hasPathLengthConstraint: true,
+                    pathLengthConstraint: 0,
+                    critical: true));
+            intermediateRequest.CertificateExtensions.Add(
+                new X509KeyUsageExtension(
+                    X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                    critical: true));
+            AddSubjectKeyIdentifier(intermediateRequest);
+            using X509Certificate2 intermediatePublicCertificate =
+                intermediateRequest.Create(
+                    rootCertificate,
+                    notBefore,
+                    notAfter,
+                    CreateSerialNumber());
+            X509Certificate2 intermediateCertificateWithPrivateKey =
+                intermediatePublicCertificate.CopyWithPrivateKey(intermediateKey);
+
+            using RSA clientKey = RSA.Create(2048);
+            CertificateRequest clientRequest = CreateCertificateRequest(
+                $"CN=OpenAI mTLS Test Client {certificateSetId}",
+                clientKey);
+            AddEndEntityExtensions(clientRequest, ClientAuthenticationOid);
+            using X509Certificate2 clientPublicCertificate =
+                clientRequest.Create(
+                    intermediateCertificateWithPrivateKey,
+                    notBefore,
+                    notAfter,
+                    CreateSerialNumber());
+            X509Certificate2 clientCertificate =
+                clientPublicCertificate.CopyWithPrivateKey(clientKey);
+            X509Certificate2 intermediateCertificate =
+                LoadPublicCertificate(
+                    intermediateCertificateWithPrivateKey.RawData);
+            intermediateCertificateWithPrivateKey.Dispose();
+
+            using RSA serverKey = RSA.Create(2048);
+            CertificateRequest serverRequest = CreateCertificateRequest(
+                "CN=127.0.0.1",
+                serverKey);
+            AddEndEntityExtensions(serverRequest, ServerAuthenticationOid);
+            SubjectAlternativeNameBuilder subjectAlternativeNames = new();
+            subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
+            subjectAlternativeNames.AddDnsName("localhost");
+            serverRequest.CertificateExtensions.Add(subjectAlternativeNames.Build());
+            using X509Certificate2 serverPublicCertificate =
+                serverRequest.Create(
+                    rootCertificate,
+                    notBefore,
+                    notAfter,
+                    CreateSerialNumber());
+            X509Certificate2 serverCertificate =
+                serverPublicCertificate.CopyWithPrivateKey(serverKey);
+
+            return new CertificateFixture(
+                rootCertificate,
+                intermediateCertificate,
+                clientCertificate,
+                serverCertificate);
+        }
+
+        public byte[] ExportClientBundle()
+        {
+            X509Certificate2Collection certificates =
+                new(
+                    new X509Certificate2[]
+                    {
+                        ClientCertificate,
+                        IntermediateCertificate,
+                    });
+            return certificates.Export(X509ContentType.Pkcs12, PfxPassword);
+        }
+
+        public void Dispose()
+        {
+            ServerCertificate.Dispose();
+            ClientCertificate.Dispose();
+            IntermediateCertificate.Dispose();
+            RootCertificate.Dispose();
+        }
+
+        private static CertificateRequest CreateCertificateRequest(
+            string subjectName,
+            RSA key)
+        {
+            return new CertificateRequest(
+                new X500DistinguishedName(subjectName),
+                key,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+        }
+
+        private static void AddSubjectKeyIdentifier(CertificateRequest request)
+        {
+            request.CertificateExtensions.Add(
+                new X509SubjectKeyIdentifierExtension(request.PublicKey, critical: false));
+        }
+
+        private static void AddEndEntityExtensions(
+            CertificateRequest request,
+            string enhancedKeyUsageOid)
+        {
+            request.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: false,
+                    hasPathLengthConstraint: false,
+                    pathLengthConstraint: 0,
+                    critical: true));
+            request.CertificateExtensions.Add(
+                new X509KeyUsageExtension(
+                    X509KeyUsageFlags.DigitalSignature,
+                    critical: true));
+            OidCollection enhancedKeyUsages = new();
+            enhancedKeyUsages.Add(new Oid(enhancedKeyUsageOid));
+            request.CertificateExtensions.Add(
+                new X509EnhancedKeyUsageExtension(enhancedKeyUsages, critical: true));
+            AddSubjectKeyIdentifier(request);
+        }
+
+        private static byte[] CreateSerialNumber()
+        {
+            byte[] serialNumber = RandomNumberGenerator.GetBytes(16);
+            serialNumber[0] &= 0x7F;
+            serialNumber[^1] |= 0x01;
+            return serialNumber;
+        }
+
+        private static X509Certificate2 LoadPublicCertificate(byte[] rawData)
+        {
+#if NET9_0_OR_GREATER
+            return X509CertificateLoader.LoadCertificate(rawData);
+#else
+#pragma warning disable SYSLIB0057
+            return new X509Certificate2(rawData);
+#pragma warning restore SYSLIB0057
+#endif
+        }
+    }
+
+    private sealed class MutualTlsServer : IAsyncDisposable
+    {
+        private const string SuccessBody = """
+            {
+              "id": "chatcmpl-test",
+              "object": "chat.completion",
+              "created": 1704096000,
+              "model": "gpt-4o-mini",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "mTLS request succeeded.",
+                    "refusal": null,
+                    "annotations": []
+                  },
+                  "logprobs": null,
+                  "finish_reason": "stop"
+                }
+              ],
+              "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 5,
+                "total_tokens": 14
+              }
+            }
+            """;
+
+        private readonly CancellationTokenSource _cancellationSource = new();
+        private readonly Uri _redirectLocation;
+        private readonly string _requiredApiKey;
+        private readonly X509Certificate2 _serverCertificate;
+        private readonly TcpListener _listener;
+        private readonly X509Certificate2 _trustedClientRoot;
+        private readonly Task _serveTask;
+        private int _connectionCount;
+
+        public Task Completion => _serveTask;
+        public int ConnectionCount => Volatile.Read(ref _connectionCount);
+        public bool ClientCertificateWasTrusted { get; private set; }
+        public Uri Endpoint { get; }
+        public Exception Failure { get; private set; }
+        public IReadOnlyList<string> PresentedClientChainThumbprints { get; private set; } =
+            Array.Empty<string>();
+        public ReceivedRequest Request { get; private set; }
+
+        private MutualTlsServer(
+            X509Certificate2 serverCertificate,
+            X509Certificate2 trustedClientRoot,
+            Uri redirectLocation,
+            string requiredApiKey)
+        {
+            _serverCertificate = serverCertificate;
+            _trustedClientRoot = trustedClientRoot;
+            _redirectLocation = redirectLocation;
+            _requiredApiKey = requiredApiKey;
+            _listener = new TcpListener(IPAddress.Loopback, port: 0);
+            _listener.Start();
+            int port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            Endpoint = new Uri($"https://127.0.0.1:{port}/v1/");
+            _serveTask = ServeOnceAsync();
+        }
+
+        public static MutualTlsServer Start(
+            X509Certificate2 serverCertificate,
+            X509Certificate2 trustedClientRoot,
+            Uri redirectLocation = null,
+            string requiredApiKey = null)
+        {
+            return new MutualTlsServer(
+                serverCertificate,
+                trustedClientRoot,
+                redirectLocation,
+                requiredApiKey);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cancellationSource.Cancel();
+            _listener.Stop();
+
+            try
+            {
+                await _serveTask.ConfigureAwait(false);
+            }
+            catch (Exception) when (_cancellationSource.IsCancellationRequested)
+            {
+            }
+
+            _cancellationSource.Dispose();
+        }
+
+        private async Task ServeOnceAsync()
+        {
+            try
+            {
+                using TcpClient client =
+                    await _listener.AcceptTcpClientAsync(_cancellationSource.Token)
+                        .ConfigureAwait(false);
+                Interlocked.Increment(ref _connectionCount);
+
+                using SslStream sslStream = new(
+                    client.GetStream(),
+                    leaveInnerStreamOpen: false,
+                    ValidateClientCertificate);
+                SslServerAuthenticationOptions authenticationOptions = new()
+                {
+                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                    ClientCertificateRequired = true,
+                    EnabledSslProtocols = SslProtocols.Tls12,
+                    ServerCertificate = _serverCertificate,
+                };
+                await sslStream.AuthenticateAsServerAsync(
+                        authenticationOptions,
+                        _cancellationSource.Token)
+                    .ConfigureAwait(false);
+
+                Request = await ReadRequestAsync(
+                        sslStream,
+                        _cancellationSource.Token)
+                    .ConfigureAwait(false);
+                bool isAuthorized = _requiredApiKey is null
+                    || Request.Headers.TryGetValue(
+                        "Authorization",
+                        out string authorization)
+                    && authorization == $"Bearer {_requiredApiKey}";
+                await WriteResponseAsync(
+                        sslStream,
+                        _redirectLocation,
+                        isAuthorized,
+                        _cancellationSource.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+                when (!_cancellationSource.IsCancellationRequested)
+            {
+                Failure = exception;
+            }
+        }
+
+        private bool ValidateClientCertificate(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (certificate is not X509Certificate2 clientCertificate || chain is null)
+            {
+                return false;
+            }
+
+            chain.ChainPolicy.ApplicationPolicy.Add(new Oid(ClientAuthenticationOid));
+            chain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+
+            ClientCertificateWasTrusted = chain.Build(clientCertificate);
+            PresentedClientChainThumbprints = chain.ChainElements
+                .Cast<X509ChainElement>()
+                .Select(element => element.Certificate.Thumbprint)
+                .ToArray();
+            return ClientCertificateWasTrusted;
+        }
+
+        private static async Task<ReceivedRequest> ReadRequestAsync(
+            Stream stream,
+            CancellationToken cancellationToken)
+        {
+            using StreamReader reader = new(
+                stream,
+                Encoding.ASCII,
+                detectEncodingFromByteOrderMarks: false,
+                bufferSize: 1024,
+                leaveOpen: true);
+            string requestLine = await reader.ReadLineAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (string.IsNullOrEmpty(requestLine))
+            {
+                throw new InvalidDataException("Expected an HTTP request line.");
+            }
+
+            string[] requestParts = requestLine.Split(' ');
+            if (requestParts.Length != 3)
+            {
+                throw new InvalidDataException(
+                    $"Unexpected HTTP request line: {requestLine}");
+            }
+
+            Dictionary<string, string> headers =
+                new(StringComparer.OrdinalIgnoreCase);
+            while (await reader.ReadLineAsync(cancellationToken)
+                .ConfigureAwait(false) is { Length: > 0 } headerLine)
+            {
+                int separatorIndex = headerLine.IndexOf(':');
+                if (separatorIndex <= 0)
+                {
+                    throw new InvalidDataException(
+                        $"Unexpected HTTP header: {headerLine}");
+                }
+
+                headers[headerLine[..separatorIndex]] =
+                    headerLine[(separatorIndex + 1)..].Trim();
+            }
+
+            if (!headers.TryGetValue("Content-Length", out string contentLengthValue)
+                || !int.TryParse(contentLengthValue, out int contentLength)
+                || contentLength < 0)
+            {
+                throw new InvalidDataException(
+                    "Expected a valid Content-Length header.");
+            }
+
+            char[] bodyBuffer = new char[contentLength];
+            int bodyLength = 0;
+            while (bodyLength < contentLength)
+            {
+                int read = await reader.ReadAsync(
+                        bodyBuffer.AsMemory(bodyLength, contentLength - bodyLength),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                {
+                    throw new EndOfStreamException(
+                        "HTTP request body ended before Content-Length bytes were read.");
+                }
+
+                bodyLength += read;
+            }
+
+            return new ReceivedRequest(
+                requestParts[0],
+                requestParts[1],
+                headers,
+                new string(bodyBuffer));
+        }
+
+        private static async Task WriteResponseAsync(
+            Stream stream,
+            Uri redirectLocation,
+            bool isAuthorized,
+            CancellationToken cancellationToken)
+        {
+            string statusLine;
+            string body;
+            string locationHeader;
+            if (!isAuthorized)
+            {
+                statusLine = "HTTP/1.1 401 Unauthorized";
+                body = """
+                    {
+                      "error": {
+                        "message": "Invalid API key",
+                        "type": "invalid_request_error"
+                      }
+                    }
+                    """;
+                locationHeader = string.Empty;
+            }
+            else if (redirectLocation is null)
+            {
+                statusLine = "HTTP/1.1 200 OK";
+                body = SuccessBody;
+                locationHeader = string.Empty;
+            }
+            else
+            {
+                statusLine = "HTTP/1.1 307 Temporary Redirect";
+                body = "{}";
+                locationHeader = $"Location: {redirectLocation}\r\n";
+            }
+
+            byte[] bodyBytes = Encoding.UTF8.GetBytes(body);
+            string responseHeaders =
+                $"{statusLine}\r\n"
+                + "Content-Type: application/json\r\n"
+                + $"Content-Length: {bodyBytes.Length}\r\n"
+                + locationHeader
+                + "Connection: close\r\n"
+                + "\r\n";
+            byte[] headerBytes = Encoding.ASCII.GetBytes(responseHeaders);
+
+            await stream.WriteAsync(headerBytes, cancellationToken)
+                .ConfigureAwait(false);
+            await stream.WriteAsync(bodyBytes, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private sealed record ReceivedRequest(
+        string Method,
+        string Path,
+        IReadOnlyDictionary<string, string> Headers,
+        string Body);
+}

--- a/tests/MutualTls/MutualTlsExamplesTests.cs
+++ b/tests/MutualTls/MutualTlsExamplesTests.cs
@@ -284,9 +284,11 @@ public class MutualTlsExamplesTests
                 }),
             certificates.ServerCertificate);
 
+        using StringContent requestContent =
+            new(requestBody, Encoding.UTF8);
         using HttpResponseMessage response = await httpClient.PostAsync(
             new Uri(server.Endpoint, "unicode"),
-            new StringContent(requestBody, Encoding.UTF8));
+            requestContent);
         await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.Multiple(() =>

--- a/tests/MutualTls/MutualTlsExamplesTests.cs
+++ b/tests/MutualTls/MutualTlsExamplesTests.cs
@@ -3,14 +3,10 @@ using OpenAI.Chat;
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
-using System.Net.Sockets;
-using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -25,13 +21,12 @@ namespace OpenAI.Tests.MutualTls;
 public class MutualTlsExamplesTests
 {
     private const string ApiKey = "test-api-key";
-    private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
-    private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
     private const string PfxPassword = "test-password";
 
+#if NET9_0_OR_GREATER
     // Loading a PFX private key affects the temporary key store on macOS, so run it last.
     [Test]
-    [Order(6)]
+    [Order(7)]
     public async Task FullChainCompletesSdkRequestEndToEnd()
     {
         using CertificateFixture certificates = CertificateFixture.Create();
@@ -40,7 +35,7 @@ public class MutualTlsExamplesTests
             certificates.RootCertificate);
         using DisposableCertificateCollection imported =
             DisposableCertificateCollection.Load(
-                certificates.ExportClientBundle(),
+                certificates.ExportClientBundle(PfxPassword),
                 PfxPassword);
         using HttpClient httpClient = CreateHttpClient(
             imported.Certificates,
@@ -87,12 +82,13 @@ public class MutualTlsExamplesTests
             Assert.That(
                 server.Request.Headers["Authorization"],
                 Is.EqualTo($"Bearer {ApiKey}"));
-            Assert.That(server.ClientCertificateWasTrusted, Is.True);
+            Assert.That(server.ClientCertificateWasAccepted, Is.True);
             Assert.That(
                 server.PresentedClientChainThumbprints,
                 Does.Contain(certificates.IntermediateCertificate.Thumbprint));
         });
     }
+#endif
 
     [Test]
     [Order(2)]
@@ -120,7 +116,7 @@ public class MutualTlsExamplesTests
                 Is.InstanceOf<ClientResultException>()
                     .Or.InstanceOf<OperationCanceledException>());
             Assert.That(server.Request, Is.Null);
-            Assert.That(server.ClientCertificateWasTrusted, Is.False);
+            Assert.That(server.ClientCertificateWasAccepted, Is.False);
             Assert.That(
                 server.PresentedClientChainThumbprints,
                 Does.Not.Contain(certificates.IntermediateCertificate.Thumbprint));
@@ -154,7 +150,7 @@ public class MutualTlsExamplesTests
                 Is.InstanceOf<ClientResultException>()
                     .Or.InstanceOf<OperationCanceledException>());
             Assert.That(server.Request, Is.Null);
-            Assert.That(server.ClientCertificateWasTrusted, Is.False);
+            Assert.That(server.ClientCertificateWasAccepted, Is.False);
             Assert.That(server.Failure, Is.Not.Null);
         });
     }
@@ -227,7 +223,7 @@ public class MutualTlsExamplesTests
                 Is.InstanceOf<ClientResultException>()
                     .Or.InstanceOf<OperationCanceledException>());
             Assert.That(server.Request, Is.Null);
-            Assert.That(server.ClientCertificateWasTrusted, Is.False);
+            Assert.That(server.ClientCertificateWasAccepted, Is.False);
             Assert.That(server.Failure, Is.Not.Null);
         });
     }
@@ -262,11 +258,41 @@ public class MutualTlsExamplesTests
         Assert.Multiple(() =>
         {
             Assert.That(exception.Status, Is.EqualTo((int)HttpStatusCode.Unauthorized));
-            Assert.That(server.ClientCertificateWasTrusted, Is.True);
+            Assert.That(server.ClientCertificateWasAccepted, Is.True);
             Assert.That(server.Request, Is.Not.Null);
             Assert.That(
                 server.Request.Headers["Authorization"],
                 Is.EqualTo($"Bearer {invalidApiKey}"));
+        });
+    }
+
+    [Test]
+    [Order(6)]
+    public async Task RequestBodyIsReadUsingContentLengthBytes()
+    {
+        const string requestBody = "Zażółć gęślą jaźń ☕";
+        using CertificateFixture certificates = CertificateFixture.Create();
+        await using MutualTlsServer server = MutualTlsServer.Start(
+            certificates.ServerCertificate,
+            certificates.RootCertificate);
+        using HttpClient httpClient = CreateHttpClient(
+            new X509Certificate2Collection(
+                new X509Certificate2[]
+                {
+                    certificates.ClientCertificate,
+                    certificates.IntermediateCertificate,
+                }),
+            certificates.ServerCertificate);
+
+        using HttpResponseMessage response = await httpClient.PostAsync(
+            new Uri(server.Endpoint, "unicode"),
+            new StringContent(requestBody, Encoding.UTF8));
+        await server.Completion.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(server.Request.Body, Is.EqualTo(requestBody));
         });
     }
 
@@ -297,7 +323,10 @@ public class MutualTlsExamplesTests
                     offline: true);
         }
 
-        return new HttpClient(handler);
+        return new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
     }
 
     private static ChatClient CreateChatClient(
@@ -317,6 +346,7 @@ public class MutualTlsExamplesTests
         return client.GetChatClient("gpt-4o-mini");
     }
 
+#if NET9_0_OR_GREATER
     private sealed class DisposableCertificateCollection : IDisposable
     {
         public X509Certificate2Collection Certificates { get; }
@@ -328,21 +358,11 @@ public class MutualTlsExamplesTests
 
         public static DisposableCertificateCollection Load(byte[] pfx, string password)
         {
-#if NET9_0_OR_GREATER
             X509Certificate2Collection certificates =
                 X509CertificateLoader.LoadPkcs12Collection(
                     pfx,
                     password,
                     X509KeyStorageFlags.DefaultKeySet);
-#else
-            X509Certificate2Collection certificates = new();
-#pragma warning disable SYSLIB0057
-            certificates.Import(
-                pfx,
-                password,
-                X509KeyStorageFlags.DefaultKeySet);
-#pragma warning restore SYSLIB0057
-#endif
             return new DisposableCertificateCollection(certificates);
         }
 
@@ -354,487 +374,5 @@ public class MutualTlsExamplesTests
             }
         }
     }
-
-    private sealed class CertificateFixture : IDisposable
-    {
-        public X509Certificate2 RootCertificate { get; }
-        public X509Certificate2 IntermediateCertificate { get; }
-        public X509Certificate2 ClientCertificate { get; }
-        public X509Certificate2 ServerCertificate { get; }
-
-        private CertificateFixture(
-            X509Certificate2 rootCertificate,
-            X509Certificate2 intermediateCertificate,
-            X509Certificate2 clientCertificate,
-            X509Certificate2 serverCertificate)
-        {
-            RootCertificate = rootCertificate;
-            IntermediateCertificate = intermediateCertificate;
-            ClientCertificate = clientCertificate;
-            ServerCertificate = serverCertificate;
-        }
-
-        public static CertificateFixture Create()
-        {
-            DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
-            DateTimeOffset notAfter = DateTimeOffset.UtcNow.AddHours(1);
-            string certificateSetId = Guid.NewGuid().ToString("N");
-
-            using RSA rootKey = RSA.Create(2048);
-            CertificateRequest rootRequest = CreateCertificateRequest(
-                $"CN=OpenAI mTLS Test Root {certificateSetId}",
-                rootKey);
-            rootRequest.CertificateExtensions.Add(
-                new X509BasicConstraintsExtension(
-                    certificateAuthority: true,
-                    hasPathLengthConstraint: true,
-                    pathLengthConstraint: 1,
-                    critical: true));
-            rootRequest.CertificateExtensions.Add(
-                new X509KeyUsageExtension(
-                    X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
-                    critical: true));
-            AddSubjectKeyIdentifier(rootRequest);
-            X509Certificate2 rootCertificate =
-                rootRequest.CreateSelfSigned(notBefore, notAfter);
-
-            using RSA intermediateKey = RSA.Create(2048);
-            CertificateRequest intermediateRequest = CreateCertificateRequest(
-                $"CN=OpenAI mTLS Test Intermediate {certificateSetId}",
-                intermediateKey);
-            intermediateRequest.CertificateExtensions.Add(
-                new X509BasicConstraintsExtension(
-                    certificateAuthority: true,
-                    hasPathLengthConstraint: true,
-                    pathLengthConstraint: 0,
-                    critical: true));
-            intermediateRequest.CertificateExtensions.Add(
-                new X509KeyUsageExtension(
-                    X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
-                    critical: true));
-            AddSubjectKeyIdentifier(intermediateRequest);
-            using X509Certificate2 intermediatePublicCertificate =
-                intermediateRequest.Create(
-                    rootCertificate,
-                    notBefore,
-                    notAfter,
-                    CreateSerialNumber());
-            X509Certificate2 intermediateCertificateWithPrivateKey =
-                intermediatePublicCertificate.CopyWithPrivateKey(intermediateKey);
-
-            using RSA clientKey = RSA.Create(2048);
-            CertificateRequest clientRequest = CreateCertificateRequest(
-                $"CN=OpenAI mTLS Test Client {certificateSetId}",
-                clientKey);
-            AddEndEntityExtensions(clientRequest, ClientAuthenticationOid);
-            using X509Certificate2 clientPublicCertificate =
-                clientRequest.Create(
-                    intermediateCertificateWithPrivateKey,
-                    notBefore,
-                    notAfter,
-                    CreateSerialNumber());
-            X509Certificate2 clientCertificate =
-                clientPublicCertificate.CopyWithPrivateKey(clientKey);
-            X509Certificate2 intermediateCertificate =
-                LoadPublicCertificate(
-                    intermediateCertificateWithPrivateKey.RawData);
-            intermediateCertificateWithPrivateKey.Dispose();
-
-            using RSA serverKey = RSA.Create(2048);
-            CertificateRequest serverRequest = CreateCertificateRequest(
-                "CN=127.0.0.1",
-                serverKey);
-            AddEndEntityExtensions(serverRequest, ServerAuthenticationOid);
-            SubjectAlternativeNameBuilder subjectAlternativeNames = new();
-            subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
-            subjectAlternativeNames.AddDnsName("localhost");
-            serverRequest.CertificateExtensions.Add(subjectAlternativeNames.Build());
-            using X509Certificate2 serverPublicCertificate =
-                serverRequest.Create(
-                    rootCertificate,
-                    notBefore,
-                    notAfter,
-                    CreateSerialNumber());
-            X509Certificate2 serverCertificate =
-                serverPublicCertificate.CopyWithPrivateKey(serverKey);
-
-            return new CertificateFixture(
-                rootCertificate,
-                intermediateCertificate,
-                clientCertificate,
-                serverCertificate);
-        }
-
-        public byte[] ExportClientBundle()
-        {
-            X509Certificate2Collection certificates =
-                new(
-                    new X509Certificate2[]
-                    {
-                        ClientCertificate,
-                        IntermediateCertificate,
-                    });
-            return certificates.Export(X509ContentType.Pkcs12, PfxPassword);
-        }
-
-        public void Dispose()
-        {
-            ServerCertificate.Dispose();
-            ClientCertificate.Dispose();
-            IntermediateCertificate.Dispose();
-            RootCertificate.Dispose();
-        }
-
-        private static CertificateRequest CreateCertificateRequest(
-            string subjectName,
-            RSA key)
-        {
-            return new CertificateRequest(
-                new X500DistinguishedName(subjectName),
-                key,
-                HashAlgorithmName.SHA256,
-                RSASignaturePadding.Pkcs1);
-        }
-
-        private static void AddSubjectKeyIdentifier(CertificateRequest request)
-        {
-            request.CertificateExtensions.Add(
-                new X509SubjectKeyIdentifierExtension(request.PublicKey, critical: false));
-        }
-
-        private static void AddEndEntityExtensions(
-            CertificateRequest request,
-            string enhancedKeyUsageOid)
-        {
-            request.CertificateExtensions.Add(
-                new X509BasicConstraintsExtension(
-                    certificateAuthority: false,
-                    hasPathLengthConstraint: false,
-                    pathLengthConstraint: 0,
-                    critical: true));
-            request.CertificateExtensions.Add(
-                new X509KeyUsageExtension(
-                    X509KeyUsageFlags.DigitalSignature,
-                    critical: true));
-            OidCollection enhancedKeyUsages = new();
-            enhancedKeyUsages.Add(new Oid(enhancedKeyUsageOid));
-            request.CertificateExtensions.Add(
-                new X509EnhancedKeyUsageExtension(enhancedKeyUsages, critical: true));
-            AddSubjectKeyIdentifier(request);
-        }
-
-        private static byte[] CreateSerialNumber()
-        {
-            byte[] serialNumber = RandomNumberGenerator.GetBytes(16);
-            serialNumber[0] &= 0x7F;
-            serialNumber[^1] |= 0x01;
-            return serialNumber;
-        }
-
-        private static X509Certificate2 LoadPublicCertificate(byte[] rawData)
-        {
-#if NET9_0_OR_GREATER
-            return X509CertificateLoader.LoadCertificate(rawData);
-#else
-#pragma warning disable SYSLIB0057
-            return new X509Certificate2(rawData);
-#pragma warning restore SYSLIB0057
 #endif
-        }
-    }
-
-    private sealed class MutualTlsServer : IAsyncDisposable
-    {
-        private const string SuccessBody = """
-            {
-              "id": "chatcmpl-test",
-              "object": "chat.completion",
-              "created": 1704096000,
-              "model": "gpt-4o-mini",
-              "choices": [
-                {
-                  "index": 0,
-                  "message": {
-                    "role": "assistant",
-                    "content": "mTLS request succeeded.",
-                    "refusal": null,
-                    "annotations": []
-                  },
-                  "logprobs": null,
-                  "finish_reason": "stop"
-                }
-              ],
-              "usage": {
-                "prompt_tokens": 9,
-                "completion_tokens": 5,
-                "total_tokens": 14
-              }
-            }
-            """;
-
-        private readonly CancellationTokenSource _cancellationSource = new();
-        private readonly Uri _redirectLocation;
-        private readonly string _requiredApiKey;
-        private readonly X509Certificate2 _serverCertificate;
-        private readonly TcpListener _listener;
-        private readonly X509Certificate2 _trustedClientRoot;
-        private readonly Task _serveTask;
-        private int _connectionCount;
-
-        public Task Completion => _serveTask;
-        public int ConnectionCount => Volatile.Read(ref _connectionCount);
-        public bool ClientCertificateWasTrusted { get; private set; }
-        public Uri Endpoint { get; }
-        public Exception Failure { get; private set; }
-        public IReadOnlyList<string> PresentedClientChainThumbprints { get; private set; } =
-            Array.Empty<string>();
-        public ReceivedRequest Request { get; private set; }
-
-        private MutualTlsServer(
-            X509Certificate2 serverCertificate,
-            X509Certificate2 trustedClientRoot,
-            Uri redirectLocation,
-            string requiredApiKey)
-        {
-            _serverCertificate = serverCertificate;
-            _trustedClientRoot = trustedClientRoot;
-            _redirectLocation = redirectLocation;
-            _requiredApiKey = requiredApiKey;
-            _listener = new TcpListener(IPAddress.Loopback, port: 0);
-            _listener.Start();
-            int port = ((IPEndPoint)_listener.LocalEndpoint).Port;
-            Endpoint = new Uri($"https://127.0.0.1:{port}/v1/");
-            _serveTask = ServeOnceAsync();
-        }
-
-        public static MutualTlsServer Start(
-            X509Certificate2 serverCertificate,
-            X509Certificate2 trustedClientRoot,
-            Uri redirectLocation = null,
-            string requiredApiKey = null)
-        {
-            return new MutualTlsServer(
-                serverCertificate,
-                trustedClientRoot,
-                redirectLocation,
-                requiredApiKey);
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            _cancellationSource.Cancel();
-            _listener.Stop();
-
-            try
-            {
-                await _serveTask.ConfigureAwait(false);
-            }
-            catch (Exception) when (_cancellationSource.IsCancellationRequested)
-            {
-            }
-
-            _cancellationSource.Dispose();
-        }
-
-        private async Task ServeOnceAsync()
-        {
-            try
-            {
-                using TcpClient client =
-                    await _listener.AcceptTcpClientAsync(_cancellationSource.Token)
-                        .ConfigureAwait(false);
-                Interlocked.Increment(ref _connectionCount);
-
-                using SslStream sslStream = new(
-                    client.GetStream(),
-                    leaveInnerStreamOpen: false,
-                    ValidateClientCertificate);
-                SslServerAuthenticationOptions authenticationOptions = new()
-                {
-                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
-                    ClientCertificateRequired = true,
-                    EnabledSslProtocols = SslProtocols.Tls12,
-                    ServerCertificate = _serverCertificate,
-                };
-                await sslStream.AuthenticateAsServerAsync(
-                        authenticationOptions,
-                        _cancellationSource.Token)
-                    .ConfigureAwait(false);
-
-                Request = await ReadRequestAsync(
-                        sslStream,
-                        _cancellationSource.Token)
-                    .ConfigureAwait(false);
-                bool isAuthorized = _requiredApiKey is null
-                    || Request.Headers.TryGetValue(
-                        "Authorization",
-                        out string authorization)
-                    && authorization == $"Bearer {_requiredApiKey}";
-                await WriteResponseAsync(
-                        sslStream,
-                        _redirectLocation,
-                        isAuthorized,
-                        _cancellationSource.Token)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception exception)
-                when (!_cancellationSource.IsCancellationRequested)
-            {
-                Failure = exception;
-            }
-        }
-
-        private bool ValidateClientCertificate(
-            object sender,
-            X509Certificate certificate,
-            X509Chain chain,
-            SslPolicyErrors sslPolicyErrors)
-        {
-            if (certificate is not X509Certificate2 clientCertificate || chain is null)
-            {
-                return false;
-            }
-
-            chain.ChainPolicy.ApplicationPolicy.Add(new Oid(ClientAuthenticationOid));
-            chain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
-            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-
-            ClientCertificateWasTrusted = chain.Build(clientCertificate);
-            PresentedClientChainThumbprints = chain.ChainElements
-                .Cast<X509ChainElement>()
-                .Select(element => element.Certificate.Thumbprint)
-                .ToArray();
-            return ClientCertificateWasTrusted;
-        }
-
-        private static async Task<ReceivedRequest> ReadRequestAsync(
-            Stream stream,
-            CancellationToken cancellationToken)
-        {
-            using StreamReader reader = new(
-                stream,
-                Encoding.ASCII,
-                detectEncodingFromByteOrderMarks: false,
-                bufferSize: 1024,
-                leaveOpen: true);
-            string requestLine = await reader.ReadLineAsync(cancellationToken)
-                .ConfigureAwait(false);
-            if (string.IsNullOrEmpty(requestLine))
-            {
-                throw new InvalidDataException("Expected an HTTP request line.");
-            }
-
-            string[] requestParts = requestLine.Split(' ');
-            if (requestParts.Length != 3)
-            {
-                throw new InvalidDataException(
-                    $"Unexpected HTTP request line: {requestLine}");
-            }
-
-            Dictionary<string, string> headers =
-                new(StringComparer.OrdinalIgnoreCase);
-            while (await reader.ReadLineAsync(cancellationToken)
-                .ConfigureAwait(false) is { Length: > 0 } headerLine)
-            {
-                int separatorIndex = headerLine.IndexOf(':');
-                if (separatorIndex <= 0)
-                {
-                    throw new InvalidDataException(
-                        $"Unexpected HTTP header: {headerLine}");
-                }
-
-                headers[headerLine[..separatorIndex]] =
-                    headerLine[(separatorIndex + 1)..].Trim();
-            }
-
-            if (!headers.TryGetValue("Content-Length", out string contentLengthValue)
-                || !int.TryParse(contentLengthValue, out int contentLength)
-                || contentLength < 0)
-            {
-                throw new InvalidDataException(
-                    "Expected a valid Content-Length header.");
-            }
-
-            char[] bodyBuffer = new char[contentLength];
-            int bodyLength = 0;
-            while (bodyLength < contentLength)
-            {
-                int read = await reader.ReadAsync(
-                        bodyBuffer.AsMemory(bodyLength, contentLength - bodyLength),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                if (read == 0)
-                {
-                    throw new EndOfStreamException(
-                        "HTTP request body ended before Content-Length bytes were read.");
-                }
-
-                bodyLength += read;
-            }
-
-            return new ReceivedRequest(
-                requestParts[0],
-                requestParts[1],
-                headers,
-                new string(bodyBuffer));
-        }
-
-        private static async Task WriteResponseAsync(
-            Stream stream,
-            Uri redirectLocation,
-            bool isAuthorized,
-            CancellationToken cancellationToken)
-        {
-            string statusLine;
-            string body;
-            string locationHeader;
-            if (!isAuthorized)
-            {
-                statusLine = "HTTP/1.1 401 Unauthorized";
-                body = """
-                    {
-                      "error": {
-                        "message": "Invalid API key",
-                        "type": "invalid_request_error"
-                      }
-                    }
-                    """;
-                locationHeader = string.Empty;
-            }
-            else if (redirectLocation is null)
-            {
-                statusLine = "HTTP/1.1 200 OK";
-                body = SuccessBody;
-                locationHeader = string.Empty;
-            }
-            else
-            {
-                statusLine = "HTTP/1.1 307 Temporary Redirect";
-                body = "{}";
-                locationHeader = $"Location: {redirectLocation}\r\n";
-            }
-
-            byte[] bodyBytes = Encoding.UTF8.GetBytes(body);
-            string responseHeaders =
-                $"{statusLine}\r\n"
-                + "Content-Type: application/json\r\n"
-                + $"Content-Length: {bodyBytes.Length}\r\n"
-                + locationHeader
-                + "Connection: close\r\n"
-                + "\r\n";
-            byte[] headerBytes = Encoding.ASCII.GetBytes(responseHeaders);
-
-            await stream.WriteAsync(headerBytes, cancellationToken)
-                .ConfigureAwait(false);
-            await stream.WriteAsync(bodyBytes, cancellationToken)
-                .ConfigureAwait(false);
-        }
-    }
-
-    private sealed record ReceivedRequest(
-        string Method,
-        string Path,
-        IReadOnlyDictionary<string, string> Headers,
-        string Body);
 }

--- a/tests/MutualTls/MutualTlsServer.cs
+++ b/tests/MutualTls/MutualTlsServer.cs
@@ -1,0 +1,433 @@
+using System;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Tests.MutualTls;
+
+internal sealed class MutualTlsServer : IAsyncDisposable
+{
+    private const string AuthorityKeyIdentifierOid = "2.5.29.35";
+    private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+    private const string SubjectAlternativeNameOid = "2.5.29.17";
+    private const string SuccessBody = """
+        {
+          "id": "chatcmpl-test",
+          "object": "chat.completion",
+          "created": 1704096000,
+          "model": "gpt-4o-mini",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "mTLS request succeeded.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 5,
+            "total_tokens": 14
+          }
+        }
+        """;
+
+    private readonly CancellationTokenSource _cancellationSource = new();
+    private readonly Uri _redirectLocation;
+    private readonly string _requiredApiKey;
+    private readonly X509Certificate2 _serverCertificate;
+    private readonly TcpListener _listener;
+    private readonly X509Certificate2 _trustedClientRoot;
+    private readonly Task _serveTask;
+    private int _connectionCount;
+
+    public Task Completion => _serveTask;
+    public int ConnectionCount => Volatile.Read(ref _connectionCount);
+    public bool ClientCertificateWasAccepted { get; private set; }
+    public Uri Endpoint { get; }
+    public Exception Failure { get; private set; }
+    public IReadOnlyList<string> PresentedClientChainThumbprints { get; private set; } =
+        Array.Empty<string>();
+    public ReceivedRequest Request { get; private set; }
+
+    private MutualTlsServer(
+        X509Certificate2 serverCertificate,
+        X509Certificate2 trustedClientRoot,
+        Uri redirectLocation,
+        string requiredApiKey)
+    {
+        _serverCertificate = serverCertificate;
+        _trustedClientRoot = trustedClientRoot;
+        _redirectLocation = redirectLocation;
+        _requiredApiKey = requiredApiKey;
+        _listener = new TcpListener(IPAddress.Loopback, port: 0);
+        _listener.Start();
+        int port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        Endpoint = new Uri($"https://127.0.0.1:{port}/v1/");
+        _serveTask = ServeOnceAsync();
+    }
+
+    public static MutualTlsServer Start(
+        X509Certificate2 serverCertificate,
+        X509Certificate2 trustedClientRoot,
+        Uri redirectLocation = null,
+        string requiredApiKey = null)
+    {
+        return new MutualTlsServer(
+            serverCertificate,
+            trustedClientRoot,
+            redirectLocation,
+            requiredApiKey);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cancellationSource.Cancel();
+        _listener.Stop();
+        await _serveTask.ConfigureAwait(false);
+        _cancellationSource.Dispose();
+    }
+
+    private async Task ServeOnceAsync()
+    {
+        try
+        {
+            using TcpClient client =
+                await _listener.AcceptTcpClientAsync(_cancellationSource.Token)
+                    .ConfigureAwait(false);
+            Interlocked.Increment(ref _connectionCount);
+
+            using SslStream sslStream = new(
+                client.GetStream(),
+                leaveInnerStreamOpen: false,
+                ValidateClientCertificate);
+            SslServerAuthenticationOptions authenticationOptions = new()
+            {
+                CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                ClientCertificateRequired = true,
+                EnabledSslProtocols =
+                    SslProtocols.Tls12 | SslProtocols.Tls13,
+                ServerCertificate = _serverCertificate,
+            };
+            await sslStream.AuthenticateAsServerAsync(
+                    authenticationOptions,
+                    _cancellationSource.Token)
+                .ConfigureAwait(false);
+
+            Request = await ReadRequestAsync(
+                    sslStream,
+                    _cancellationSource.Token)
+                .ConfigureAwait(false);
+            bool isAuthorized = _requiredApiKey is null
+                || Request.Headers.TryGetValue(
+                    "Authorization",
+                    out string authorization)
+                && authorization == $"Bearer {_requiredApiKey}";
+            await WriteResponseAsync(
+                    sslStream,
+                    _redirectLocation,
+                    isAuthorized,
+                    _cancellationSource.Token)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            if (!_cancellationSource.IsCancellationRequested)
+            {
+                Failure = exception;
+            }
+        }
+    }
+
+    private bool ValidateClientCertificate(
+        object sender,
+        X509Certificate certificate,
+        X509Chain chain,
+        SslPolicyErrors sslPolicyErrors)
+    {
+        if (certificate is not X509Certificate2 clientCertificate || chain is null)
+        {
+            return false;
+        }
+
+        chain.ChainPolicy.ApplicationPolicy.Add(new Oid(ClientAuthenticationOid));
+        chain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+
+        bool chainWasTrusted = chain.Build(clientCertificate);
+        PresentedClientChainThumbprints = chain.ChainElements
+            .Cast<X509ChainElement>()
+            .Select(element => element.Certificate.Thumbprint)
+            .ToArray();
+        ClientCertificateWasAccepted =
+            chainWasTrusted
+            && MeetsCaCertificateRequirements(_trustedClientRoot)
+            && MeetsClientCertificateRequirements(clientCertificate);
+        return ClientCertificateWasAccepted;
+    }
+
+    private static bool MeetsCaCertificateRequirements(
+        X509Certificate2 certificate)
+    {
+        const int MaximumCertificateSize = 16 * 1024;
+        X509KeyUsageFlags requiredKeyUsage =
+            X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign;
+
+        return certificate.RawData.Length < MaximumCertificateSize
+            && certificate.NotAfter.ToUniversalTime()
+                > DateTime.UtcNow.AddDays(1)
+            && certificate.Extensions
+                .OfType<X509BasicConstraintsExtension>()
+                .Any(extension => extension.CertificateAuthority)
+            && HasKeyUsage(certificate, requiredKeyUsage)
+            && HasSubjectKeyIdentifier(certificate)
+            && HasKeyIdentifierAuthorityKeyIdentifier(certificate);
+    }
+
+    private static bool MeetsClientCertificateRequirements(
+        X509Certificate2 certificate)
+    {
+        X509KeyUsageFlags requiredKeyUsage =
+            X509KeyUsageFlags.DigitalSignature
+            | X509KeyUsageFlags.KeyEncipherment;
+
+        return HasKeyUsage(certificate, requiredKeyUsage)
+            && certificate.Extensions
+                .OfType<X509EnhancedKeyUsageExtension>()
+                .Any(
+                    extension => extension.EnhancedKeyUsages
+                        .Cast<Oid>()
+                        .Any(oid => oid.Value == ClientAuthenticationOid))
+            && HasSubjectKeyIdentifier(certificate)
+            && HasKeyIdentifierAuthorityKeyIdentifier(certificate)
+            && certificate.Extensions
+                .Cast<X509Extension>()
+                .Any(
+                    extension =>
+                        extension.Oid?.Value == SubjectAlternativeNameOid
+                        && extension.RawData.Length > 0);
+    }
+
+    private static bool HasKeyUsage(
+        X509Certificate2 certificate,
+        X509KeyUsageFlags requiredKeyUsage)
+    {
+        return certificate.Extensions
+            .OfType<X509KeyUsageExtension>()
+            .Any(
+                extension =>
+                    (extension.KeyUsages & requiredKeyUsage)
+                    == requiredKeyUsage);
+    }
+
+    private static bool HasSubjectKeyIdentifier(
+        X509Certificate2 certificate)
+    {
+        return certificate.Extensions
+            .OfType<X509SubjectKeyIdentifierExtension>()
+            .Any(
+                extension =>
+                    !string.IsNullOrEmpty(extension.SubjectKeyIdentifier));
+    }
+
+    private static bool HasKeyIdentifierAuthorityKeyIdentifier(
+        X509Certificate2 certificate)
+    {
+        X509Extension extension = certificate.Extensions
+            .Cast<X509Extension>()
+            .SingleOrDefault(
+                extension =>
+                    extension.Oid?.Value == AuthorityKeyIdentifierOid);
+        if (extension is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            AsnReader reader =
+                new(extension.RawData, AsnEncodingRules.DER);
+            AsnReader sequence = reader.ReadSequence();
+            byte[] keyIdentifier = sequence.ReadOctetString(
+                new Asn1Tag(TagClass.ContextSpecific, 0));
+            return keyIdentifier.Length > 0
+                && !sequence.HasData
+                && !reader.HasData;
+        }
+        catch (AsnContentException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<ReceivedRequest> ReadRequestAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        const int MaximumHeaderLength = 64 * 1024;
+        using MemoryStream headerBuffer = new();
+        byte[] nextByte = new byte[1];
+        bool headersComplete = false;
+        while (headerBuffer.Length < MaximumHeaderLength)
+        {
+            int bytesRead = await stream.ReadAsync(
+                    nextByte,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                throw new EndOfStreamException(
+                    "HTTP request ended before its headers were complete.");
+            }
+
+            headerBuffer.WriteByte(nextByte[0]);
+            if (headerBuffer.Length >= 4)
+            {
+                byte[] bytes = headerBuffer.GetBuffer();
+                int length = checked((int)headerBuffer.Length);
+                headersComplete =
+                    bytes[length - 4] == '\r'
+                    && bytes[length - 3] == '\n'
+                    && bytes[length - 2] == '\r'
+                    && bytes[length - 1] == '\n';
+                if (headersComplete)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (!headersComplete)
+        {
+            throw new InvalidDataException(
+                $"HTTP request headers exceeded {MaximumHeaderLength} bytes.");
+        }
+
+        string headerText = Encoding.ASCII.GetString(
+            headerBuffer.GetBuffer(),
+            0,
+            checked((int)headerBuffer.Length - 4));
+        string[] headerLines =
+            headerText.Split(
+                new[] { "\r\n" },
+                StringSplitOptions.None);
+        if (headerLines.Length == 0
+            || string.IsNullOrEmpty(headerLines[0]))
+        {
+            throw new InvalidDataException("Expected an HTTP request line.");
+        }
+
+        string[] requestParts = headerLines[0].Split(' ');
+        if (requestParts.Length != 3)
+        {
+            throw new InvalidDataException(
+                $"Unexpected HTTP request line: {headerLines[0]}");
+        }
+
+        Dictionary<string, string> headers =
+            new(StringComparer.OrdinalIgnoreCase);
+        foreach (string headerLine in headerLines.Skip(1))
+        {
+            int separatorIndex = headerLine.IndexOf(':');
+            if (separatorIndex <= 0)
+            {
+                throw new InvalidDataException(
+                    $"Unexpected HTTP header: {headerLine}");
+            }
+
+            headers[headerLine[..separatorIndex]] =
+                headerLine[(separatorIndex + 1)..].Trim();
+        }
+
+        if (!headers.TryGetValue("Content-Length", out string contentLengthValue)
+            || !int.TryParse(contentLengthValue, out int contentLength)
+            || contentLength < 0)
+        {
+            throw new InvalidDataException(
+                "Expected a valid Content-Length header.");
+        }
+
+        byte[] bodyBuffer = new byte[contentLength];
+        await stream.ReadExactlyAsync(bodyBuffer, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new ReceivedRequest(
+            requestParts[0],
+            requestParts[1],
+            headers,
+            Encoding.UTF8.GetString(bodyBuffer));
+    }
+
+    private static async Task WriteResponseAsync(
+        Stream stream,
+        Uri redirectLocation,
+        bool isAuthorized,
+        CancellationToken cancellationToken)
+    {
+        string statusLine;
+        string body;
+        string locationHeader;
+        if (!isAuthorized)
+        {
+            statusLine = "HTTP/1.1 401 Unauthorized";
+            body = """
+                {
+                  "error": {
+                    "message": "Invalid API key",
+                    "type": "invalid_request_error"
+                  }
+                }
+                """;
+            locationHeader = string.Empty;
+        }
+        else if (redirectLocation is null)
+        {
+            statusLine = "HTTP/1.1 200 OK";
+            body = SuccessBody;
+            locationHeader = string.Empty;
+        }
+        else
+        {
+            statusLine = "HTTP/1.1 307 Temporary Redirect";
+            body = "{}";
+            locationHeader = $"Location: {redirectLocation}\r\n";
+        }
+
+        byte[] bodyBytes = Encoding.UTF8.GetBytes(body);
+        string responseHeaders =
+            $"{statusLine}\r\n"
+            + "Content-Type: application/json\r\n"
+            + $"Content-Length: {bodyBytes.Length}\r\n"
+            + locationHeader
+            + "Connection: close\r\n"
+            + "\r\n";
+        byte[] headerBytes = Encoding.ASCII.GetBytes(responseHeaders);
+
+        await stream.WriteAsync(headerBytes, cancellationToken)
+            .ConfigureAwait(false);
+        await stream.WriteAsync(bodyBytes, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+
+internal sealed record ReceivedRequest(
+    string Method,
+    string Path,
+    IReadOnlyDictionary<string, string> Headers,
+    string Body);

--- a/tests/MutualTls/MutualTlsServer.cs
+++ b/tests/MutualTls/MutualTlsServer.cs
@@ -145,12 +145,40 @@ internal sealed class MutualTlsServer : IAsyncDisposable
                     _cancellationSource.Token)
                 .ConfigureAwait(false);
         }
-        catch (Exception exception)
+        catch (OperationCanceledException)
+            when (_cancellationSource.IsCancellationRequested)
         {
-            if (!_cancellationSource.IsCancellationRequested)
-            {
-                Failure = exception;
-            }
+            return;
+        }
+        catch (ObjectDisposedException)
+            when (_cancellationSource.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (SocketException)
+            when (_cancellationSource.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (OperationCanceledException exception)
+        {
+            Failure = exception;
+        }
+        catch (SocketException exception)
+        {
+            Failure = exception;
+        }
+        catch (IOException exception)
+        {
+            Failure = exception;
+        }
+        catch (AuthenticationException exception)
+        {
+            Failure = exception;
+        }
+        catch (CryptographicException exception)
+        {
+            Failure = exception;
         }
     }
 

--- a/tests/MutualTls/MutualTlsServer.cs
+++ b/tests/MutualTls/MutualTlsServer.cs
@@ -168,6 +168,10 @@ internal sealed class MutualTlsServer : IAsyncDisposable
         {
             Failure = exception;
         }
+        catch (InvalidDataException exception)
+        {
+            Failure = exception;
+        }
         catch (IOException exception)
         {
             Failure = exception;
@@ -195,6 +199,7 @@ internal sealed class MutualTlsServer : IAsyncDisposable
 
         chain.ChainPolicy.ApplicationPolicy.Add(new Oid(ClientAuthenticationOid));
         chain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
+        chain.ChainPolicy.DisableCertificateDownloads = true;
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
         chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
 

--- a/tests/OpenAI.Tests.csproj
+++ b/tests/OpenAI.Tests.csproj
@@ -33,6 +33,11 @@
     <Compile Include="..\OpenAI\src\Utility\AppContextSwitchHelper.cs" LinkBase="Telemetry\Shared" />
   </ItemGroup>
 
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <!-- The mTLS sample uses X509CertificateLoader, which is available in .NET 9 and later. -->
+    <Compile Include="..\examples\MutualTls\Example01_MutualTlsAsync.cs" LinkBase="Shared\Examples" />
+  </ItemGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>SourcePath</_Parameter1>

--- a/tests/Snippets/MutualTlsReadMeSnippets.cs
+++ b/tests/Snippets/MutualTlsReadMeSnippets.cs
@@ -43,6 +43,7 @@ public class MutualTlsReadMeSnippets
                 SslStreamCertificateContext.Create(
                     clientCertificate,
                     intermediateCertificates,
+                    // Build the local chain without revocation network lookups.
                     offline: true);
 
             SocketsHttpHandler handler = new()

--- a/tests/Snippets/MutualTlsReadMeSnippets.cs
+++ b/tests/Snippets/MutualTlsReadMeSnippets.cs
@@ -1,0 +1,88 @@
+using NUnit.Framework;
+using OpenAI.Chat;
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace OpenAI.Tests.Snippets;
+
+[Explicit("This test provides compile-time verification for the README mTLS snippet.")]
+[Category("Snippets")]
+[TestFixture]
+public class MutualTlsReadMeSnippets
+{
+#pragma warning disable SYSLIB0057
+    [Test]
+    public async Task MutualTls()
+    {
+        #region Snippet:ReadMe_MutualTls
+        string pfxPath = Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PATH")
+            ?? throw new InvalidOperationException("OPENAI_CLIENT_PFX_PATH is required.");
+        string apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")
+            ?? throw new InvalidOperationException("OPENAI_API_KEY is required.");
+
+#if SNIPPET
+        X509Certificate2Collection certificates =
+            X509CertificateLoader.LoadPkcs12CollectionFromFile(
+                pfxPath,
+                Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PASSWORD"));
+#else
+        X509Certificate2Collection certificates = new();
+        certificates.Import(
+            pfxPath,
+            Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PASSWORD"),
+            X509KeyStorageFlags.DefaultKeySet);
+#endif
+
+        try
+        {
+            X509Certificate2 clientCertificate =
+                certificates.Single(certificate => certificate.HasPrivateKey);
+            X509Certificate2Collection intermediateCertificates = new(
+                certificates
+                    .Where(certificate => !certificate.HasPrivateKey)
+                    .ToArray());
+            SslStreamCertificateContext certificateContext =
+                SslStreamCertificateContext.Create(
+                    clientCertificate,
+                    intermediateCertificates,
+                    offline: true);
+
+            SocketsHttpHandler handler = new()
+            {
+                // Do not automatically follow a redirect with a certificate-bearing handler.
+                AllowAutoRedirect = false,
+            };
+            handler.SslOptions.ClientCertificateContext = certificateContext;
+
+            using HttpClient httpClient = new(handler);
+            OpenAIClientOptions options = new()
+            {
+                Endpoint = new Uri("https://mtls.api.openai.com/v1"),
+                Transport = new HttpClientPipelineTransport(httpClient),
+            };
+
+            OpenAIClient client = new(
+                new ApiKeyCredential(apiKey),
+                options);
+
+            ChatCompletion completion = await client
+                .GetChatClient("gpt-4o-mini")
+                .CompleteChatAsync("Reply with exactly: mTLS request succeeded.");
+        }
+        finally
+        {
+            foreach (X509Certificate2 certificate in certificates)
+            {
+                certificate.Dispose();
+            }
+        }
+        #endregion
+    }
+#pragma warning restore SYSLIB0057
+}

--- a/tests/Snippets/MutualTlsReadMeSnippets.cs
+++ b/tests/Snippets/MutualTlsReadMeSnippets.cs
@@ -1,3 +1,4 @@
+#if SNIPPET || NET9_0_OR_GREATER
 using NUnit.Framework;
 using OpenAI.Chat;
 using System;
@@ -16,7 +17,6 @@ namespace OpenAI.Tests.Snippets;
 [TestFixture]
 public class MutualTlsReadMeSnippets
 {
-#pragma warning disable SYSLIB0057
     [Test]
     public async Task MutualTls()
     {
@@ -26,18 +26,10 @@ public class MutualTlsReadMeSnippets
         string apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")
             ?? throw new InvalidOperationException("OPENAI_API_KEY is required.");
 
-#if SNIPPET
         X509Certificate2Collection certificates =
             X509CertificateLoader.LoadPkcs12CollectionFromFile(
                 pfxPath,
                 Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PASSWORD"));
-#else
-        X509Certificate2Collection certificates = new();
-        certificates.Import(
-            pfxPath,
-            Environment.GetEnvironmentVariable("OPENAI_CLIENT_PFX_PASSWORD"),
-            X509KeyStorageFlags.DefaultKeySet);
-#endif
 
         try
         {
@@ -60,7 +52,11 @@ public class MutualTlsReadMeSnippets
             };
             handler.SslOptions.ClientCertificateContext = certificateContext;
 
-            using HttpClient httpClient = new(handler);
+            using HttpClient httpClient = new(handler)
+            {
+                // Let the SDK pipeline enforce OpenAIClientOptions.NetworkTimeout.
+                Timeout = System.Threading.Timeout.InfiniteTimeSpan,
+            };
             OpenAIClientOptions options = new()
             {
                 Endpoint = new Uri("https://mtls.api.openai.com/v1"),
@@ -84,5 +80,5 @@ public class MutualTlsReadMeSnippets
         }
         #endregion
     }
-#pragma warning restore SYSLIB0057
 }
+#endif


### PR DESCRIPTION
## Summary

- document API-key + HTTP mTLS using the SDK's existing transport override
- add a runnable .NET example with PowerShell setup for global and EU mTLS endpoints
- add deterministic end-to-end TLS tests for full chains, rejected credentials, API-key auth, request/response handling, and redirect safety

## Validation

- `dotnet test tests/OpenAI.Tests.csproj --framework net10.0 --configuration Release --no-restore`
  - 1,451 passed; 87 skipped
- `dotnet test tests/OpenAI.Tests.csproj --framework net10.0 --configuration Release --no-build --no-restore --filter "TestCategory=MutualTls"`
  - 6 passed
- `dotnet build tests/OpenAI.Tests.csproj --configuration Release --no-restore`
  - net8.0/net9.0/net10.0, 0 warnings
- `dotnet build examples/OpenAI.Examples.csproj --framework net10.0 --configuration Release --no-restore`
  - 0 warnings
- formatting, generated snippets, and `git diff --check`

## Live mTLS validation

Using the dedicated smoke-test project and `~/.openai` fixture kit:

- enrolled direct client certificate: passed
- enrolled leaf + intermediate chain: passed
- unregistered CA certificate: rejected as expected
- chained leaf without intermediate: rejected as expected