### PR TITLE
Document non-discriminated union pattern and apply to Responses

### DIFF
--- a/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.Serialization.cs
+++ b/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.Serialization.cs
@@ -10,6 +10,14 @@ public partial class CodeInterpreterToolContainer
     // CUSTOM: Edited to remove calls to WriteStartObject() and WriteEndObject(). 
     void IJsonModel<CodeInterpreterToolContainer>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        if (Patch.Contains("$"u8))
+        {
+            writer.WriteRawValue(Patch.GetJson("$"u8));
+            return;
+        }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
         JsonModelWriteCore(writer, options);
     }
 
@@ -24,11 +32,11 @@ public partial class CodeInterpreterToolContainer
         {
             throw new FormatException($"The model {nameof(CodeInterpreterToolContainer)} does not support writing '{format}' format.");
         }
-        if (Optional.IsDefined(ContainerId) && _patch.Contains("$.container_id"u8) != true)
+        if (Optional.IsDefined(ContainerId))
         {
             writer.WriteStringValue(ContainerId);
         }
-        else if (Optional.IsDefined(ContainerConfiguration) && _patch.Contains("$.container"u8) != true)
+        else if (Optional.IsDefined(ContainerConfiguration))
         {
             writer.WriteObjectValue(ContainerConfiguration, options);
         }
@@ -65,4 +73,25 @@ public partial class CodeInterpreterToolContainer
 
         return new CodeInterpreterToolContainer(containerId, container, patch);
     }
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+    private bool PropagateGet(ReadOnlySpan<byte> jsonPath, out JsonPatch.EncodedValue value)
+    {
+        value = default;
+        return ContainerConfiguration is not null
+            && !jsonPath.SequenceEqual("$"u8)
+            && ContainerConfiguration.Patch.TryGetEncodedValue(jsonPath, out value);
+    }
+
+    private bool PropagateSet(ReadOnlySpan<byte> jsonPath, JsonPatch.EncodedValue value)
+    {
+        if (ContainerConfiguration is null || jsonPath.SequenceEqual("$"u8))
+        {
+            return false;
+        }
+
+        ContainerConfiguration.Patch.Set(jsonPath, value);
+        return true;
+    }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 }

--- a/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.Serialization.cs
+++ b/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.Serialization.cs
@@ -54,9 +54,13 @@ public partial class CodeInterpreterToolContainer
         {
             containerId = element.GetString();
         }
-        else
+        else if (element.ValueKind == JsonValueKind.Object)
         {
             container = CodeInterpreterToolContainerConfiguration.DeserializeCodeInterpreterToolContainerConfiguration(element, element.GetUtf8Bytes(), options);
+        }
+        else
+        {
+            throw new JsonException($"Expected code interpreter tool container to be null, an object, or a string but found {element.ValueKind}.");
         }
 
         return new CodeInterpreterToolContainer(containerId, container, patch);

--- a/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.Serialization.cs
+++ b/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.Serialization.cs
@@ -28,7 +28,7 @@ public partial class CodeInterpreterToolContainer
         {
             writer.WriteStringValue(ContainerId);
         }
-        if (Optional.IsDefined(ContainerConfiguration) && _patch.Contains("$.container"u8) != true)
+        else if (Optional.IsDefined(ContainerConfiguration) && _patch.Contains("$.container"u8) != true)
         {
             writer.WriteObjectValue(ContainerConfiguration, options);
         }

--- a/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.cs
+++ b/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.cs
@@ -18,7 +18,7 @@ public partial class CodeInterpreterToolContainer
 
     // CUSTOM: Added to support the corresponding component of the union.
     /// <summary>
-    /// Initializes a new instance of the <see cref="CodeInterpreterContainer"/> class.
+    /// Initializes a new instance of the <see cref="CodeInterpreterToolContainer"/> class.
     /// </summary>
     /// <param name="containerId">The ID of the container.</param>
     public CodeInterpreterToolContainer(string containerId)
@@ -30,7 +30,7 @@ public partial class CodeInterpreterToolContainer
 
     // CUSTOM: Added to support the corresponding component of the union.
     /// <summary>
-    /// Initializes a new instance of the <see cref="CodeInterpreterContainer"/> class.
+    /// Initializes a new instance of the <see cref="CodeInterpreterToolContainer"/> class.
     /// </summary>
     /// <param name="containerConfiguration">The configuration of the container.</param>
     public CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration)

--- a/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.cs
+++ b/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.cs
@@ -23,6 +23,8 @@ public partial class CodeInterpreterToolContainer
     /// <param name="containerId">The ID of the container.</param>
     public CodeInterpreterToolContainer(string containerId)
     {
+        Argument.AssertNotNull(containerId, nameof(containerId));
+
         ContainerId = containerId;
     }
 
@@ -33,6 +35,8 @@ public partial class CodeInterpreterToolContainer
     /// <param name="containerConfiguration">The configuration of the container.</param>
     public CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration)
     {
+        Argument.AssertNotNull(containerConfiguration, nameof(containerConfiguration));
+
         ContainerConfiguration = containerConfiguration;
     }
 
@@ -45,4 +49,10 @@ public partial class CodeInterpreterToolContainer
     // - Removed setter.
     [CodeGenMember("Container")]
     public CodeInterpreterToolContainerConfiguration ContainerConfiguration { get; }
+
+    // CUSTOM: Added for convenience.
+    public static implicit operator CodeInterpreterToolContainer(string containerId) => containerId is null ? null : new(containerId);
+
+    // CUSTOM: Added for convenience.
+    public static implicit operator CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration) => containerConfiguration is null ? null : new(containerConfiguration);
 }

--- a/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.cs
+++ b/OpenAI.Responses/src/Custom/Tools/CodeInterpreterTool/CodeInterpreterToolContainer.cs
@@ -9,13 +9,10 @@ namespace OpenAI.Responses;
 /// Represents a container for the code interpreter tool.
 /// </summary>
 [CodeGenType("DotNetCodeInterpreterToolContainer")]
+[CodeGenVisibility(nameof(CodeInterpreterToolContainer), CodeGenVisibility.Internal)]
+[CodeGenVisibility("Patch", CodeGenVisibility.Internal)]
 public partial class CodeInterpreterToolContainer
 {
-    // CUSTOM: Made internal.
-    internal CodeInterpreterToolContainer()
-    {
-    }
-
     // CUSTOM: Added to support the corresponding component of the union.
     /// <summary>
     /// Initializes a new instance of the <see cref="CodeInterpreterToolContainer"/> class.
@@ -26,6 +23,9 @@ public partial class CodeInterpreterToolContainer
         Argument.AssertNotNull(containerId, nameof(containerId));
 
         ContainerId = containerId;
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        _patch.SetPropagators(PropagateSet, PropagateGet);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
     }
 
     // CUSTOM: Added to support the corresponding component of the union.
@@ -38,6 +38,9 @@ public partial class CodeInterpreterToolContainer
         Argument.AssertNotNull(containerConfiguration, nameof(containerConfiguration));
 
         ContainerConfiguration = containerConfiguration;
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        _patch.SetPropagators(PropagateSet, PropagateGet);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
     }
 
     // CUSTOM: Removed setter.

--- a/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.Serialization.cs
+++ b/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.Serialization.cs
@@ -55,9 +55,13 @@ public partial class McpToolCallApprovalPolicy
         {
             globalPolicy = new GlobalMcpToolCallApprovalPolicy(element.GetString());
         }
-        else
+        else if (element.ValueKind == JsonValueKind.Object)
         {
             customPolicy = CustomMcpToolCallApprovalPolicy.DeserializeCustomMcpToolCallApprovalPolicy(element, element.GetUtf8Bytes(), options);
+        }
+        else
+        {
+            throw new JsonException($"Expected MCP tool call approval policy to be null, an object, or a string but found {element.ValueKind}.");
         }
 
         return new McpToolCallApprovalPolicy(globalPolicy, customPolicy, patch);

--- a/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.Serialization.cs
+++ b/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.Serialization.cs
@@ -11,6 +11,14 @@ public partial class McpToolCallApprovalPolicy
     // CUSTOM: Edited to remove calls to WriteStartObject() and WriteEndObject(). 
     void IJsonModel<McpToolCallApprovalPolicy>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        if (Patch.Contains("$"u8))
+        {
+            writer.WriteRawValue(Patch.GetJson("$"u8));
+            return;
+        }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
         JsonModelWriteCore(writer, options);
     }
 
@@ -25,11 +33,11 @@ public partial class McpToolCallApprovalPolicy
         {
             throw new FormatException($"The model {nameof(McpToolCallApprovalPolicy)} does not support writing '{format}' format.");
         }
-        if (Optional.IsDefined(GlobalPolicy) && _patch.Contains("$.global_policy"u8) != true)
+        if (Optional.IsDefined(GlobalPolicy))
         {
             writer.WriteStringValue(GlobalPolicy.Value.ToString());
         }
-        else if (Optional.IsDefined(CustomPolicy) && _patch.Contains("$.custom_policy"u8) != true)
+        else if (Optional.IsDefined(CustomPolicy))
         {
             writer.WriteObjectValue(CustomPolicy, options);
         }
@@ -66,4 +74,25 @@ public partial class McpToolCallApprovalPolicy
 
         return new McpToolCallApprovalPolicy(globalPolicy, customPolicy, patch);
     }
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+    private bool PropagateGet(ReadOnlySpan<byte> jsonPath, out JsonPatch.EncodedValue value)
+    {
+        value = default;
+        return CustomPolicy is not null
+            && !jsonPath.SequenceEqual("$"u8)
+            && CustomPolicy.Patch.TryGetEncodedValue(jsonPath, out value);
+    }
+
+    private bool PropagateSet(ReadOnlySpan<byte> jsonPath, JsonPatch.EncodedValue value)
+    {
+        if (CustomPolicy is null || jsonPath.SequenceEqual("$"u8))
+        {
+            return false;
+        }
+
+        CustomPolicy.Patch.Set(jsonPath, value);
+        return true;
+    }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 }

--- a/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.Serialization.cs
+++ b/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.Serialization.cs
@@ -29,7 +29,7 @@ public partial class McpToolCallApprovalPolicy
         {
             writer.WriteStringValue(GlobalPolicy.Value.ToString());
         }
-        if (Optional.IsDefined(CustomPolicy) && _patch.Contains("$.custom_policy"u8) != true)
+        else if (Optional.IsDefined(CustomPolicy) && _patch.Contains("$.custom_policy"u8) != true)
         {
             writer.WriteObjectValue(CustomPolicy, options);
         }

--- a/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.cs
+++ b/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.cs
@@ -35,5 +35,5 @@ public partial class McpToolCallApprovalPolicy
     public static implicit operator McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy) => new(globalPolicy);
 
     // CUSTOM: Added for convenience.
-    public static implicit operator McpToolCallApprovalPolicy(CustomMcpToolCallApprovalPolicy customPolicy) => new(customPolicy);
+    public static implicit operator McpToolCallApprovalPolicy(CustomMcpToolCallApprovalPolicy customPolicy) => customPolicy is null ? null : new(customPolicy);
 }

--- a/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.cs
+++ b/OpenAI.Responses/src/Custom/Tools/McpTool/McpToolCallApprovalPolicy.cs
@@ -7,12 +7,16 @@ namespace OpenAI.Responses;
 // * A CustomPolicy defined as an object.
 [CodeGenType("DotNetToolCallApprovalPolicy")]
 [CodeGenVisibility(nameof(McpToolCallApprovalPolicy), CodeGenVisibility.Internal)]
+[CodeGenVisibility("Patch", CodeGenVisibility.Internal)]
 public partial class McpToolCallApprovalPolicy
 {
     // CUSTOM: Added to support the corresponding component of the union.
     public McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy)
     {
         GlobalPolicy = globalPolicy;
+    #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        _patch.SetPropagators(PropagateSet, PropagateGet);
+    #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
     }
 
     // CUSTOM: Added to support the corresponding component of the union.
@@ -21,6 +25,9 @@ public partial class McpToolCallApprovalPolicy
         Argument.AssertNotNull(customPolicy, nameof(customPolicy));
 
         CustomPolicy = customPolicy;
+    #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        _patch.SetPropagators(PropagateSet, PropagateGet);
+    #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
     }
 
     // CUSTOM: Removed setter.

--- a/OpenAI.Responses/src/Generated/Models/CodeInterpreterToolContainer.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CodeInterpreterToolContainer.Serialization.cs
@@ -56,33 +56,5 @@ namespace OpenAI.Responses
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
             return DeserializeCodeInterpreterToolContainer(document.RootElement, null, options);
         }
-
-#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-        private bool PropagateGet(ReadOnlySpan<byte> jsonPath, out JsonPatch.EncodedValue value)
-        {
-            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
-            value = default;
-
-            if (local.StartsWith("container"u8))
-            {
-                return ContainerConfiguration.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("container"u8.Length)], out value);
-            }
-            return false;
-        }
-#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-
-#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-        private bool PropagateSet(ReadOnlySpan<byte> jsonPath, JsonPatch.EncodedValue value)
-        {
-            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
-
-            if (local.StartsWith("container"u8))
-            {
-                ContainerConfiguration.Patch.Set([.. "$"u8, .. local.Slice("container"u8.Length)], value);
-                return true;
-            }
-            return false;
-        }
-#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
     }
 }

--- a/OpenAI.Responses/src/Generated/Models/CodeInterpreterToolContainer.cs
+++ b/OpenAI.Responses/src/Generated/Models/CodeInterpreterToolContainer.cs
@@ -15,6 +15,10 @@ namespace OpenAI.Responses
         [Experimental("SCME0001")]
         private JsonPatch _patch;
 
+        internal CodeInterpreterToolContainer()
+        {
+        }
+
 #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         internal CodeInterpreterToolContainer(string containerId, CodeInterpreterToolContainerConfiguration containerConfiguration, in JsonPatch patch)
         {
@@ -28,6 +32,6 @@ namespace OpenAI.Responses
         [JsonIgnore]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Experimental("SCME0001")]
-        public ref JsonPatch Patch => ref _patch;
+        internal ref JsonPatch Patch => ref _patch;
     }
 }

--- a/OpenAI.Responses/src/Generated/Models/McpToolCallApprovalPolicy.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/McpToolCallApprovalPolicy.Serialization.cs
@@ -56,33 +56,5 @@ namespace OpenAI.Responses
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
             return DeserializeMcpToolCallApprovalPolicy(document.RootElement, null, options);
         }
-
-#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-        private bool PropagateGet(ReadOnlySpan<byte> jsonPath, out JsonPatch.EncodedValue value)
-        {
-            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
-            value = default;
-
-            if (local.StartsWith("custom_policy"u8))
-            {
-                return CustomPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("custom_policy"u8.Length)], out value);
-            }
-            return false;
-        }
-#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-
-#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-        private bool PropagateSet(ReadOnlySpan<byte> jsonPath, JsonPatch.EncodedValue value)
-        {
-            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
-
-            if (local.StartsWith("custom_policy"u8))
-            {
-                CustomPolicy.Patch.Set([.. "$"u8, .. local.Slice("custom_policy"u8.Length)], value);
-                return true;
-            }
-            return false;
-        }
-#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
     }
 }

--- a/OpenAI.Responses/src/Generated/Models/McpToolCallApprovalPolicy.cs
+++ b/OpenAI.Responses/src/Generated/Models/McpToolCallApprovalPolicy.cs
@@ -32,6 +32,6 @@ namespace OpenAI.Responses
         [JsonIgnore]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Experimental("SCME0001")]
-        public ref JsonPatch Patch => ref _patch;
+        internal ref JsonPatch Patch => ref _patch;
     }
 }

--- a/api/net10.0/OpenAI.Responses.net10.0.cs
+++ b/api/net10.0/OpenAI.Responses.net10.0.cs
@@ -131,10 +131,6 @@ namespace OpenAI.Responses {
         public CodeInterpreterToolContainer(string containerId);
         public CodeInterpreterToolContainerConfiguration ContainerConfiguration { get; }
         public string ContainerId { get; }
-        [Serialization.JsonIgnore]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Experimental("SCME0001")]
-        public ref JsonPatch Patch { get; }
         public static implicit operator CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration);
         public static implicit operator CodeInterpreterToolContainer(string containerId);
     }
@@ -663,10 +659,6 @@ namespace OpenAI.Responses {
         public McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy);
         public CustomMcpToolCallApprovalPolicy CustomPolicy { get; }
         public GlobalMcpToolCallApprovalPolicy? GlobalPolicy { get; }
-        [Serialization.JsonIgnore]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Experimental("SCME0001")]
-        public ref JsonPatch Patch { get; }
         public static implicit operator McpToolCallApprovalPolicy(CustomMcpToolCallApprovalPolicy customPolicy);
         public static implicit operator McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy);
     }

--- a/api/net10.0/OpenAI.Responses.net10.0.cs
+++ b/api/net10.0/OpenAI.Responses.net10.0.cs
@@ -135,6 +135,8 @@ namespace OpenAI.Responses {
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Experimental("SCME0001")]
         public ref JsonPatch Patch { get; }
+        public static implicit operator CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration);
+        public static implicit operator CodeInterpreterToolContainer(string containerId);
     }
     [Experimental("OPENAI001")]
     public class CodeInterpreterToolContainerConfiguration : IJsonModel<CodeInterpreterToolContainerConfiguration>, IPersistableModel<CodeInterpreterToolContainerConfiguration> {

--- a/api/net8.0/OpenAI.Responses.net8.0.cs
+++ b/api/net8.0/OpenAI.Responses.net8.0.cs
@@ -131,10 +131,6 @@ namespace OpenAI.Responses {
         public CodeInterpreterToolContainer(string containerId);
         public CodeInterpreterToolContainerConfiguration ContainerConfiguration { get; }
         public string ContainerId { get; }
-        [Serialization.JsonIgnore]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Experimental("SCME0001")]
-        public ref JsonPatch Patch { get; }
         public static implicit operator CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration);
         public static implicit operator CodeInterpreterToolContainer(string containerId);
     }
@@ -663,10 +659,6 @@ namespace OpenAI.Responses {
         public McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy);
         public CustomMcpToolCallApprovalPolicy CustomPolicy { get; }
         public GlobalMcpToolCallApprovalPolicy? GlobalPolicy { get; }
-        [Serialization.JsonIgnore]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Experimental("SCME0001")]
-        public ref JsonPatch Patch { get; }
         public static implicit operator McpToolCallApprovalPolicy(CustomMcpToolCallApprovalPolicy customPolicy);
         public static implicit operator McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy);
     }

--- a/api/net8.0/OpenAI.Responses.net8.0.cs
+++ b/api/net8.0/OpenAI.Responses.net8.0.cs
@@ -135,6 +135,8 @@ namespace OpenAI.Responses {
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Experimental("SCME0001")]
         public ref JsonPatch Patch { get; }
+        public static implicit operator CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration);
+        public static implicit operator CodeInterpreterToolContainer(string containerId);
     }
     [Experimental("OPENAI001")]
     public class CodeInterpreterToolContainerConfiguration : IJsonModel<CodeInterpreterToolContainerConfiguration>, IPersistableModel<CodeInterpreterToolContainerConfiguration> {

--- a/api/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
+++ b/api/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
@@ -115,6 +115,8 @@ namespace OpenAI.Responses {
         [Serialization.JsonIgnore]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ref JsonPatch Patch { get; }
+        public static implicit operator CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration);
+        public static implicit operator CodeInterpreterToolContainer(string containerId);
     }
     public class CodeInterpreterToolContainerConfiguration : IJsonModel<CodeInterpreterToolContainerConfiguration>, IPersistableModel<CodeInterpreterToolContainerConfiguration> {
         [Serialization.JsonIgnore]

--- a/api/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
+++ b/api/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
@@ -112,9 +112,6 @@ namespace OpenAI.Responses {
         public CodeInterpreterToolContainer(string containerId);
         public CodeInterpreterToolContainerConfiguration ContainerConfiguration { get; }
         public string ContainerId { get; }
-        [Serialization.JsonIgnore]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ref JsonPatch Patch { get; }
         public static implicit operator CodeInterpreterToolContainer(CodeInterpreterToolContainerConfiguration containerConfiguration);
         public static implicit operator CodeInterpreterToolContainer(string containerId);
     }
@@ -589,9 +586,6 @@ namespace OpenAI.Responses {
         public McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy);
         public CustomMcpToolCallApprovalPolicy CustomPolicy { get; }
         public GlobalMcpToolCallApprovalPolicy? GlobalPolicy { get; }
-        [Serialization.JsonIgnore]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ref JsonPatch Patch { get; }
         public static implicit operator McpToolCallApprovalPolicy(CustomMcpToolCallApprovalPolicy customPolicy);
         public static implicit operator McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy);
     }

--- a/eng/patterns/README.md
+++ b/eng/patterns/README.md
@@ -1,0 +1,7 @@
+# Engineering patterns
+
+This directory documents common implementation patterns used across the OpenAI .NET library. These documents are intended to help engineers and AI agents apply the patterns consistently.
+
+## Patterns
+
+- [Non-discriminated unions](non-discriminated-unions.md)

--- a/eng/patterns/non-discriminated-unions.md
+++ b/eng/patterns/non-discriminated-unions.md
@@ -97,18 +97,20 @@ The union class must follow these rules:
 6. Keep collection component properties nullable as an exception to the library's usual collection-property convention. A `null` collection is necessary to indicate that another component is active.
 7. Provide implicit conversions from each component type to the union type. When a component parameter can be `null`, the conversion must return `null` rather than call the constructor. This keeps implicit conversions from throwing when constructors reject `null`. Components that cannot be `null`, such as non-nullable value types, do not need this check.
 
-## Usage
+See the implementation of `McpToolCallApprovalPolicy` and the associated tests for a reference implementation of this pattern.
+
+### Usage
 
 Callers determine the active component by checking the properties for `null`:
 
 ```csharp
-if (policy.GlobalPolicy is not null)
+if (policy.CustomPolicy is not null)
 {
-    Console.WriteLine(policy.GlobalPolicy.Value);
+    // ...
 }
-else if (policy.CustomPolicy is not null)
+else if (policy.GlobalPolicy is not null)
 {
-    Console.WriteLine(policy.CustomPolicy.ToolsAlwaysRequiringApproval);
+    // ...
 }
 ```
 
@@ -118,7 +120,7 @@ Implicit conversions allow callers to assign a component without explicitly cons
 McpToolCallApprovalPolicy policy = GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval;
 ```
 
-## Serialization requirements
+### Serialization requirements
 
 The union class is a .NET representation of multiple possible JSON values; it is not an additional JSON object. Its custom serialization must directly write the active component:
 
@@ -128,6 +130,9 @@ The union class is a .NET representation of multiple possible JSON values; it is
 - Dispatch deserialization according to the JSON value shape and populate only the matching component property.
 - Handle JSON `null` as nullability of the containing property rather than as an initialized union instance.
 - Preserve unknown properties associated with an object component according to the library's normal model round-trip behavior.
+- Preserve `JsonPatch` behavior. When deserializing, create the `JsonPatch` from the source payload and pass it to the generated model constructor. When serializing, do not write a component directly when its corresponding patch path is present; this preserves the generated model's patch propagation and round-trip behavior.
+
+### Test requirements
 
 Tests for a conventional non-discriminated union must cover:
 
@@ -139,9 +144,7 @@ Tests for a conventional non-discriminated union must cover:
 - Confirming that only one component property is populated.
 - Confirming that implicitly converting a nullable component with a `null` value produces a `null` union.
 
-See the `McpToolCallApprovalPolicy` customizations and the associated tests for a reference implementation of this pattern.
-
-## Shorthand notation
+## Pattern 2: Normalize shorthand to longhand
 
 Some non-discriminated unions use one component only as shorthand for another. For example, the `allowed_tools` property of the MCP tool of the Responses API accepts either a list of tool names or a complete filter:
 
@@ -160,8 +163,6 @@ model MCPToolFilter {
 
 The shorthand is a logical subset of the longhand representation. These components do not represent distinct concepts, so exposing both through a union wrapper as described in the pattern above would add another type and two properties to represent the same single concept. It would also make callers decide between forms that are functionally equivalent.
 
-## Pattern 2: Normalize shorthand to longhand
-
 When one component is strictly shorthand for another, expose only the longhand type in the public .NET API:
 
 ```csharp
@@ -171,6 +172,8 @@ public partial class McpTool
 }
 ```
 
+### Serialization requirements
+
 Customize deserialization for the property so that it accepts both wire representations:
 
 - Deserialize the longhand object normally.
@@ -178,7 +181,7 @@ Customize deserialization for the property so that it accepts both wire represen
 - Store only the longhand object in the public property.
 - Continue to reject JSON shapes that are not members of the service-defined union.
 
-For `allowed_tools`, an incoming array is normalized into an `McpToolFilter` whose `ToolNames` collection contains the array values. Serialization then uses the longhand object form:
+For `allowed_tools` in the example above, an incoming array is normalized into an `McpToolFilter` whose `ToolNames` collection contains the array values. Serialization then uses the longhand object form:
 
 ```json
 {
@@ -188,6 +191,8 @@ For `allowed_tools`, an incoming array is normalized into an `McpToolFilter` who
 }
 ```
 
+### Test requirements
+
 Tests for shorthand normalization must cover:
 
 - Deserializing shorthand and longhand inputs.
@@ -196,7 +201,7 @@ Tests for shorthand normalization must cover:
 - Preserving longhand-only fields when the longhand form is received.
 - Handling `null` and rejecting unsupported JSON shapes.
 
-## Limitations of shorthand normalization
+### Limitations of shorthand normalization
 
 Normalization deliberately does not preserve the original wire representation:
 

--- a/eng/patterns/non-discriminated-unions.md
+++ b/eng/patterns/non-discriminated-unions.md
@@ -130,7 +130,21 @@ The union class is a .NET representation of multiple possible JSON values; it is
 - Dispatch deserialization according to the JSON value shape and populate only the matching component property.
 - Handle JSON `null` as nullability of the containing property rather than as an initialized union instance.
 - Preserve unknown properties associated with an object component according to the library's normal model round-trip behavior.
-- Preserve `JsonPatch` behavior. When deserializing, create the `JsonPatch` from the source payload and pass it to the generated model constructor. When serializing, do not write a component directly when its corresponding patch path is present; this preserves the generated model's patch propagation and round-trip behavior.
+
+#### `JsonPatch` implementation
+
+A union wrapper is a JSON value, not a JSON object with properties corresponding to its .NET component properties. Callers therefore patch the property on the containing model, not the wrapper directly. The wrapper still needs an internal `JsonPatch` to receive those delegated paths, preserve a replacement for the complete union value, and forward nested paths to an active object component.
+
+The union wrapper's patch support must follow these rules:
+
+1. Make the generated `Patch` property internal by applying `[CodeGenVisibility("Patch", CodeGenVisibility.Internal)]` to the customization class. Do not expose synthetic component paths such as `$.global_policy` or `$.custom_policy` to callers.
+2. Implement the patch propagators `PropagateSet` and `PropagateGet` to reflect the union's wire representation rather than the synthetic TypeSpec model.
+3. Initialize the propagators along all valid construction paths. Call `_patch.SetPropagators(PropagateSet, PropagateGet)` in each component constructor because those constructors initialize their components directly.
+4. Keep a patch for `$` on the wrapper by returning `false` from both propagators for that path. Before normal serialization, write the raw root patch when `Patch.Contains("$"u8)` is true. This supports replacing the complete union value through a containing model, such as patching `$.require_approval` from an object to a string.
+5. For any non-root path, forward the path unchanged to the active object component's `Patch`. The object component owns its properties, nested model propagation, and additional-property round-tripping. For example, forward `$.always.tool_names` to the custom policy as `$.always.tool_names`, not through `$.custom_policy`.
+6. Return `false` for non-root paths when the active component is a scalar. A scalar has no nested properties to patch; callers can replace the complete union value through the containing model's property path instead.
+7. During normal serialization, select and write the active component without consulting patch paths for the wrapper's synthetic .NET component properties. Additional properties for an object component are emitted by that component's serializer.
+8. During deserialization, create the wrapper's `JsonPatch` from the source `data` and pass it to the generated constructor together with the active component. Deserialize an object component with its own source data so its `Patch` independently preserves unknown object properties.
 
 ### Test requirements
 
@@ -143,6 +157,8 @@ Tests for a conventional non-discriminated union must cover:
 - Preserving additional properties when the object model supports them.
 - Confirming that only one component property is populated.
 - Confirming that implicitly converting a nullable component with a `null` value produces a `null` union.
+- Patching a nested path through a containing model and confirming that it reaches the active object component.
+- Patching the complete union-valued property on a containing model and confirming that the raw replacement value is serialized.
 
 ## Pattern 2: Normalize shorthand to longhand
 

--- a/eng/patterns/non-discriminated-unions.md
+++ b/eng/patterns/non-discriminated-unions.md
@@ -1,0 +1,223 @@
+# Non-discriminated unions
+
+This document defines how the OpenAI .NET library represents non-discriminated unions, including the special case where one union component is shorthand for another.
+
+## Definition
+
+A non-discriminated union is a union whose components do not share a discriminator. For example, the `require_approval` property of an MCP tool in the Responses API accepts either an object or one of two string values:
+
+```typespec
+require_approval?:
+  | {
+      always?: MCPToolFilter;
+      `never`?: MCPToolFilter;
+    }
+  | "always"
+  | "never"
+  | null;
+```
+
+The object contains granular approval policies based on an MCP tool filter:
+
+```typespec
+model MCPToolFilter {
+  tool_names?: string[];
+  read_only?: boolean;
+}
+```
+
+Apply these interpretations before modeling the union in .NET:
+
+- When a union contains `null`, model the containing property as nullable. Do not treat `null` as a component represented by the union type. In other words, only consider this to be a proper union if it includes two or more non-`null` components.
+- When a union contains one or more string literals, such as `"always"` and `"never"`, model them as an extensible enum.
+
+After applying these rules, `require_approval` translates to a non-discriminated union between an object and an extensible enum.
+
+## Pattern 1: Represent distinct components through composition
+
+When the components represent distinct concepts, define a public type for each component. For `require_approval`, the object component represents a custom policy:
+
+```csharp
+public partial class CustomMcpToolCallApprovalPolicy
+{
+    public CustomMcpToolCallApprovalPolicy();
+
+    public McpToolFilter ToolsAlwaysRequiringApproval { get; set; }
+    public McpToolFilter ToolsNeverRequiringApproval { get; set; }
+}
+```
+
+The string-literal component is represented by an extensible enum:
+
+```csharp
+public readonly partial struct GlobalMcpToolCallApprovalPolicy : IEquatable<GlobalMcpToolCallApprovalPolicy>
+{
+    public GlobalMcpToolCallApprovalPolicy(string value);
+
+    public static GlobalMcpToolCallApprovalPolicy AlwaysRequireApproval { get; }
+    public static GlobalMcpToolCallApprovalPolicy NeverRequireApproval { get; }
+
+    public static implicit operator GlobalMcpToolCallApprovalPolicy(string value);
+    public override string ToString();
+}
+```
+
+Then, define a class that composes the component types and represents the union:
+
+```csharp
+public partial class McpToolCallApprovalPolicy
+{
+  public McpToolCallApprovalPolicy(CustomMcpToolCallApprovalPolicy customPolicy)
+  {
+    Argument.AssertNotNull(customPolicy, nameof(customPolicy));
+
+    CustomPolicy = customPolicy;
+  }
+
+  public McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy)
+  {
+    GlobalPolicy = globalPolicy;
+  }
+
+    public CustomMcpToolCallApprovalPolicy CustomPolicy { get; }
+    public GlobalMcpToolCallApprovalPolicy? GlobalPolicy { get; }
+
+    public static implicit operator McpToolCallApprovalPolicy(CustomMcpToolCallApprovalPolicy customPolicy) => customPolicy is null ? null : new(customPolicy);
+    public static implicit operator McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy globalPolicy) => new(globalPolicy);
+}
+```
+
+The union class must follow these rules:
+
+1. Expose one property for each component of the union.
+2. Provide one constructor for each component. Each constructor accepts only its corresponding component and rejects `null` for reference-type arguments.
+3. Populate exactly one component property for every instance. All other component properties must be `null`.
+4. Keep component properties read-only so an instance cannot be mutated from one component into another.
+5. Make every component property nullable. In projects without nullable reference type annotations, reference-type properties are nullable by behavior; value-type properties use `?` explicitly.
+6. Keep collection component properties nullable as an exception to the library's usual collection-property convention. A `null` collection is necessary to indicate that another component is active.
+7. Provide implicit conversions from each component type to the union type. When a component parameter can be `null`, the conversion must return `null` rather than call the constructor. This keeps implicit conversions from throwing when constructors reject `null`. Components that cannot be `null`, such as non-nullable value types, do not need this check.
+
+## Usage
+
+Callers determine the active component by checking the properties for `null`:
+
+```csharp
+if (policy.GlobalPolicy is not null)
+{
+    Console.WriteLine(policy.GlobalPolicy.Value);
+}
+else if (policy.CustomPolicy is not null)
+{
+    Console.WriteLine(policy.CustomPolicy.ToolsAlwaysRequiringApproval);
+}
+```
+
+Implicit conversions allow callers to assign a component without explicitly constructing the wrapper:
+
+```csharp
+McpToolCallApprovalPolicy policy = GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval;
+```
+
+## Serialization requirements
+
+The union class is a .NET representation of multiple possible JSON values; it is not an additional JSON object. Its custom serialization must directly write the active component:
+
+- Write an extensible enum component as its JSON string value.
+- Write an object component as a JSON object.
+- Do not emit the union's .NET property names into the payload.
+- Dispatch deserialization according to the JSON value shape and populate only the matching component property.
+- Handle JSON `null` as nullability of the containing property rather than as an initialized union instance.
+- Preserve unknown properties associated with an object component according to the library's normal model round-trip behavior.
+
+Tests for a conventional non-discriminated union must cover:
+
+- Constructing and serializing every component.
+- Deserializing every supported JSON shape and inspecting its component property.
+- Round-tripping every supported JSON shape.
+- Rejecting unsupported JSON shapes.
+- Preserving additional properties when the object model supports them.
+- Confirming that only one component property is populated.
+- Confirming that implicitly converting a nullable component with a `null` value produces a `null` union.
+
+See the `McpToolCallApprovalPolicy` customizations and the associated tests for a reference implementation of this pattern.
+
+## Shorthand notation
+
+Some non-discriminated unions use one component only as shorthand for another. For example, the `allowed_tools` property of the MCP tool of the Responses API accepts either a list of tool names or a complete filter:
+
+```typespec
+allowed_tools?: string[] | MCPToolFilter | null;
+```
+
+The `string[]` component is shorthand for setting the `tool_names` property of `MCPToolFilter`:
+
+```typespec
+model MCPToolFilter {
+  tool_names?: string[];
+  read_only?: boolean;
+}
+```
+
+The shorthand is a logical subset of the longhand representation. These components do not represent distinct concepts, so exposing both through a union wrapper as described in the pattern above would add another type and two properties to represent the same single concept. It would also make callers decide between forms that are functionally equivalent.
+
+## Pattern 2: Normalize shorthand to longhand
+
+When one component is strictly shorthand for another, expose only the longhand type in the public .NET API:
+
+```csharp
+public partial class McpTool
+{
+    public McpToolFilter AllowedTools { get; set; }
+}
+```
+
+Customize deserialization for the property so that it accepts both wire representations:
+
+- Deserialize the longhand object normally.
+- Convert the shorthand value into the equivalent longhand object.
+- Store only the longhand object in the public property.
+- Continue to reject JSON shapes that are not members of the service-defined union.
+
+For `allowed_tools`, an incoming array is normalized into an `McpToolFilter` whose `ToolNames` collection contains the array values. Serialization then uses the longhand object form:
+
+```json
+{
+  "allowed_tools": {
+    "tool_names": ["search"]
+  }
+}
+```
+
+Tests for shorthand normalization must cover:
+
+- Deserializing shorthand and longhand inputs.
+- Producing equivalent public model state from both forms.
+- Serializing normalized shorthand as longhand.
+- Preserving longhand-only fields when the longhand form is received.
+- Handling `null` and rejecting unsupported JSON shapes.
+
+## Limitations of shorthand normalization
+
+Normalization deliberately does not preserve the original wire representation:
+
+1. If the service sends shorthand and the caller sends the model back, the library emits longhand. A service operation that requires the exact shorthand representation might not accept that result.
+2. If a caller must send shorthand specifically, they must use `JsonPatch` to control the wire payload.
+
+These limitations are preferable to adding a public wrapper when shorthand and longhand represent the same concept. If preserving the original representation becomes a functional requirement, reevaluate whether the alternatives should instead use the composition pattern.
+
+## Choosing the pattern
+
+Use the following decision process for each non-discriminated union:
+
+1. Remove `null` from consideration as a union component and model it as property nullability.
+2. Group string literals into a single extensible enum component.
+3. Decide whether the remaining components represent distinct concepts.
+4. If they are distinct, use a compositional union class with one nullable, read-only property and one constructor per component.
+5. If one component is only shorthand for another, expose the longhand type and normalize shorthand during deserialization.
+6. Add serialization tests for every accepted JSON shape and for the expected round-trip behavior.
+
+When TypeSpec files are changed while implementing either pattern, regenerate the code by running:
+
+```powershell
+./scripts/Invoke-CodeGen.ps1
+```

--- a/tests/Responses/ResponsesSmokeTests.cs
+++ b/tests/Responses/ResponsesSmokeTests.cs
@@ -618,6 +618,52 @@ public partial class ResponsesSmokeTests
         }
     }
 
+    [Test]
+    public void MCPToolCallApprovalPolicyPropagatesJsonPatchToObjectComponent()
+    {
+        CustomMcpToolCallApprovalPolicy customPolicy = new()
+        {
+            ToolsAlwaysRequiringApproval = new McpToolFilter()
+        };
+        McpTool tool = ResponseTool.CreateMcpTool(
+            "test",
+            new Uri("https://example.com"),
+            toolCallApprovalPolicy: new McpToolCallApprovalPolicy(customPolicy));
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        tool.Patch.Set("$.require_approval.always.additional_property"u8, "patched");
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        using JsonDocument json = JsonDocument.Parse(ModelReaderWriter.Write(tool));
+        JsonElement additionalProperty = json.RootElement
+            .GetProperty("require_approval")
+            .GetProperty("always")
+            .GetProperty("additional_property");
+        Assert.That(additionalProperty.GetString(), Is.EqualTo("patched"));
+    }
+
+    [Test]
+    public void MCPToolCallApprovalPolicySupportsRootJsonPatchFromContainingModel()
+    {
+        BinaryData data = BinaryData.FromString("""
+        {
+            "type": "mcp",
+            "server_label": "test",
+            "require_approval": {
+                "always": {}
+            }
+        }
+        """);
+        McpTool tool = ModelReaderWriter.Read<McpTool>(data);
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        tool.Patch.Set("$.require_approval"u8, "\"never\""u8);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        using JsonDocument json = JsonDocument.Parse(ModelReaderWriter.Write(tool));
+        Assert.That(json.RootElement.GetProperty("require_approval").GetString(), Is.EqualTo("never"));
+    }
+
     [TestCase("[]")]
     [TestCase("42")]
     [TestCase("true")]
@@ -810,6 +856,41 @@ public partial class ResponsesSmokeTests
             Assert.That(additionalPropertyProperty, Is.Not.Null);
             Assert.That(additionalPropertyProperty.ValueKind, Is.EqualTo(JsonValueKind.True));
         }
+    }
+
+    [Test]
+    public void CodeInterpreterToolContainerPropagatesJsonPatchToObjectComponent()
+    {
+        ResponseTool tool = ResponseTool.CreateCodeInterpreterTool(
+            new CodeInterpreterToolContainer(new AutomaticCodeInterpreterToolContainerConfiguration()));
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        tool.Patch.Set("$.container.additional_property"u8, "patched");
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        using JsonDocument json = JsonDocument.Parse(ModelReaderWriter.Write(tool));
+        Assert.That(json.RootElement.GetProperty("container").GetProperty("additional_property").GetString(), Is.EqualTo("patched"));
+    }
+
+    [Test]
+    public void CodeInterpreterToolContainerSupportsRootJsonPatchFromContainingModel()
+    {
+        BinaryData data = BinaryData.FromString("""
+        {
+            "type": "code_interpreter",
+            "container": {
+                "type": "auto"
+            }
+        }
+        """);
+        CodeInterpreterTool tool = ModelReaderWriter.Read<CodeInterpreterTool>(data);
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        tool.Patch.Set("$.container"u8, "\"container_123\""u8);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        using JsonDocument json = JsonDocument.Parse(ModelReaderWriter.Write(tool));
+        Assert.That(json.RootElement.GetProperty("container").GetString(), Is.EqualTo("container_123"));
     }
 
     [TestCase("[]")]

--- a/tests/Responses/ResponsesSmokeTests.cs
+++ b/tests/Responses/ResponsesSmokeTests.cs
@@ -480,7 +480,7 @@ public partial class ResponsesSmokeTests
     [Test]
     [TestCase(true)]
     [TestCase(false)]
-    public void SerializeMCPToolCallPolicyApprovalAsString(bool fromRawJson)
+    public void SerializeMCPToolCallApprovalPolicyAsString(bool fromRawJson)
     {
         McpToolCallApprovalPolicy policy;
 
@@ -497,11 +497,40 @@ public partial class ResponsesSmokeTests
             policy = GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval;
         }
 
+        Assert.Multiple(() =>
+        {
+            Assert.That(policy.GlobalPolicy, Is.EqualTo(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
+            Assert.That(policy.CustomPolicy, Is.Null);
+        });
+
         BinaryData serializedPolicy = ModelReaderWriter.Write(policy);
         using JsonDocument policyAsJson = JsonDocument.Parse(serializedPolicy);
         Assert.That(policyAsJson.RootElement, Is.Not.Null);
         Assert.That(policyAsJson.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
         Assert.That(policyAsJson.RootElement.ToString(), Is.EqualTo("always"));
+    }
+
+    [Test]
+    public void MCPToolCallApprovalPolicyRejectsNullComponents()
+    {
+        Assert.Throws<ArgumentNullException>(() => new McpToolCallApprovalPolicy((CustomMcpToolCallApprovalPolicy)null));
+    }
+
+    [Test]
+    public void MCPToolCallApprovalPolicyImplicitConversionsPreserveNull()
+    {
+        CustomMcpToolCallApprovalPolicy customPolicy = null;
+        McpToolCallApprovalPolicy policy = customPolicy;
+
+        Assert.That(policy, Is.Null);
+    }
+
+    [Test]
+    public void DeserializeNullMCPToolCallApprovalPolicy()
+    {
+        McpToolCallApprovalPolicy policy = ModelReaderWriter.Read<McpToolCallApprovalPolicy>(BinaryData.FromString("null"));
+
+        Assert.That(policy, Is.Null);
     }
 
     [Test]
@@ -547,6 +576,12 @@ public partial class ResponsesSmokeTests
             };
         }
 
+        Assert.Multiple(() =>
+        {
+            Assert.That(policy.GlobalPolicy, Is.Null);
+            Assert.That(policy.CustomPolicy, Is.Not.Null);
+        });
+
         BinaryData serializedPolicy = ModelReaderWriter.Write(policy);
         using JsonDocument policyAsJson = JsonDocument.Parse(serializedPolicy);
         Assert.That(policyAsJson.RootElement, Is.Not.Null);
@@ -581,6 +616,16 @@ public partial class ResponsesSmokeTests
             Assert.That(additionalPropertyProperty, Is.Not.Null);
             Assert.That(additionalPropertyProperty.ValueKind, Is.EqualTo(JsonValueKind.True));
         }
+    }
+
+    [TestCase("[]")]
+    [TestCase("42")]
+    [TestCase("true")]
+    public void DeserializeMCPToolCallApprovalPolicyRejectsUnsupportedJsonShapes(string json)
+    {
+        BinaryData data = BinaryData.FromString(json);
+
+        Assert.Throws<JsonException>(() => ModelReaderWriter.Read<McpToolCallApprovalPolicy>(data));
     }
 
     [Test]
@@ -655,14 +700,51 @@ public partial class ResponsesSmokeTests
         else
         {
             // We construct a new instance. Later, we serialize it and confirm it was constructed correctly.
-            container = new CodeInterpreterToolContainer(containerId);
+            container = containerId;
         }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(container.ContainerId, Is.EqualTo(containerId));
+            Assert.That(container.ContainerConfiguration, Is.Null);
+        });
 
         BinaryData serializedContainer = ModelReaderWriter.Write(container);
         using JsonDocument containerAsJson = JsonDocument.Parse(serializedContainer);
         Assert.That(containerAsJson.RootElement, Is.Not.Null);
         Assert.That(containerAsJson.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
         Assert.That(containerAsJson.RootElement.ToString(), Is.EqualTo(containerId));
+    }
+
+    [Test]
+    public void CodeInterpreterToolContainerRejectsNullComponents()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CodeInterpreterToolContainer((string)null));
+        Assert.Throws<ArgumentNullException>(() => new CodeInterpreterToolContainer((CodeInterpreterToolContainerConfiguration)null));
+    }
+
+    [Test]
+    public void CodeInterpreterToolContainerImplicitConversionsPreserveNull()
+    {
+        string containerId = null;
+        CodeInterpreterToolContainerConfiguration containerConfiguration = null;
+
+        CodeInterpreterToolContainer containerFromId = containerId;
+        CodeInterpreterToolContainer containerFromConfiguration = containerConfiguration;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(containerFromId, Is.Null);
+            Assert.That(containerFromConfiguration, Is.Null);
+        });
+    }
+
+    [Test]
+    public void DeserializeNullCodeInterpreterToolContainer()
+    {
+        CodeInterpreterToolContainer container = ModelReaderWriter.Read<CodeInterpreterToolContainer>(BinaryData.FromString("null"));
+
+        Assert.That(container, Is.Null);
     }
 
     [Test]
@@ -695,8 +777,14 @@ public partial class ResponsesSmokeTests
                 FileIds = { fileId }
             };
 
-            container = new CodeInterpreterToolContainer(autoConfig);
+            container = autoConfig;
         }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(container.ContainerId, Is.Null);
+            Assert.That(container.ContainerConfiguration, Is.Not.Null);
+        });
 
         BinaryData serializedContainer = ModelReaderWriter.Write(container);
         using JsonDocument containerAsJson = JsonDocument.Parse(serializedContainer);
@@ -722,6 +810,16 @@ public partial class ResponsesSmokeTests
             Assert.That(additionalPropertyProperty, Is.Not.Null);
             Assert.That(additionalPropertyProperty.ValueKind, Is.EqualTo(JsonValueKind.True));
         }
+    }
+
+    [TestCase("[]")]
+    [TestCase("42")]
+    [TestCase("true")]
+    public void DeserializeCodeInterpreterToolContainerRejectsUnsupportedJsonShapes(string json)
+    {
+        BinaryData data = BinaryData.FromString(json);
+
+        Assert.Throws<JsonException>(() => ModelReaderWriter.Read<CodeInterpreterToolContainer>(data));
     }
 
     [Test]


### PR DESCRIPTION
This pull request introduces and documents a robust pattern for modeling non-discriminated unions in the OpenAI .NET library, and applies this pattern to both the `McpToolCallApprovalPolicy` and `CodeInterpreterToolContainer` types. It adds convenience implicit conversions, enforces null-safety, improves deserialization error handling, and significantly expands test coverage for these union types. Additionally, it documents the union modeling pattern for future contributors.

**Non-discriminated union modeling and documentation:**

* Added comprehensive documentation for representing non-discriminated unions in .NET, including patterns for distinct components and shorthand normalization, in `eng/patterns/non-discriminated-unions.md` and updated the patterns index. [[1]](diffhunk://#diff-fcacd0930d6836faf2de4b654a43347f4cc9cce64baa9f01ba8ec8a1457215a9R1-R223) [[2]](diffhunk://#diff-f1d5f3fbbfdc0459e03c287064602d4ecacc3f57322a4d1a2437b4321f5d332bR1-R7)

**Improvements to `McpToolCallApprovalPolicy`:**

* Updated implicit conversion from `CustomMcpToolCallApprovalPolicy` to `McpToolCallApprovalPolicy` to return `null` for `null` input, preventing exceptions and ensuring conversions are safe.
* Enhanced deserialization to throw a `JsonException` when encountering unsupported JSON shapes, improving error handling and reliability.

**Improvements to `CodeInterpreterToolContainer`:**

* Added implicit conversions from `string` and `CodeInterpreterToolContainerConfiguration` to `CodeInterpreterToolContainer`, returning `null` for `null` input, and enforced null-checks in constructors. [[1]](diffhunk://#diff-0463dfbab8c36d2b23c3c38635754e3aee1b598c1f17f20fa0a27bf1aaaf305eR26-R27) [[2]](diffhunk://#diff-0463dfbab8c36d2b23c3c38635754e3aee1b598c1f17f20fa0a27bf1aaaf305eR38-R39) [[3]](diffhunk://#diff-0463dfbab8c36d2b23c3c38635754e3aee1b598c1f17f20fa0a27bf1aaaf305eR52-R57) [[4]](diffhunk://#diff-ff2e8403e17945d9143f75659f1ada0685a026b4edd47f4b3b780f84a0b52be7R138-R139) [[5]](diffhunk://#diff-4f379572de9762e951ead752a9fafd7f816550888930d854b051dc572ab944f5R118-R119)
* Improved deserialization to throw a `JsonException` for unsupported JSON shapes, aligning with the union modeling pattern.

**Test coverage enhancements:**

* Added and improved tests to verify null-safety, correct component population, implicit conversion behavior, deserialization error handling, and round-tripping for both union types. [[1]](diffhunk://#diff-c53cd066d2e994b593bab87ce73432a7b5a7b104b59084c0909352d9768d8c56L483-R483) [[2]](diffhunk://#diff-c53cd066d2e994b593bab87ce73432a7b5a7b104b59084c0909352d9768d8c56R500-R535) [[3]](diffhunk://#diff-c53cd066d2e994b593bab87ce73432a7b5a7b104b59084c0909352d9768d8c56R579-R584) [[4]](diffhunk://#diff-c53cd066d2e994b593bab87ce73432a7b5a7b104b59084c0909352d9768d8c56R621-R630) [[5]](diffhunk://#diff-c53cd066d2e994b593bab87ce73432a7b5a7b104b59084c0909352d9768d8c56L658-R749)