### PR TITLE
Keep reading SSE events after an event that yields no updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Fixed streaming responses ending early when the service emits an event that the library does not model. The server-sent event enumerator stopped at the first event that produced no updates, so an unrecognized event in the middle of a stream silently terminated the whole stream and looked like a clean, early completion. Unrecognized events are now skipped and every later update still surfaces. This affects all streaming APIs, including `OpenAI.Assistants`, `OpenAI.Chat`, and `OpenAI.Audio`, on both the synchronous and asynchronous paths.
+- Fixed streaming responses ending early when the service emits an event that the library does not model. The server-sent event enumerator stopped at the first event that produced no updates, so an unrecognized event in the middle of a stream silently terminated the whole stream and looked like a clean, early completion. Unrecognized events are now skipped and every later update still surfaces. This affects all streaming APIs, including `OpenAI.Assistants`, `OpenAI.Chat`, `OpenAI.Responses`, and `OpenAI.Audio`, on both the synchronous and asynchronous paths.
 
 ## 2.13.0 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## (Unreleased)
+
+### Bugs Fixed
+
+- Fixed streaming responses ending early when the service emits an event that the library does not model. The server-sent event enumerator stopped at the first event that produced no updates, so an unrecognized event in the middle of a stream silently terminated the whole stream and looked like a clean, early completion. Unrecognized events are now skipped and every later update still surfaces. This affects all streaming APIs, including `OpenAI.Assistants`, `OpenAI.Chat`, and `OpenAI.Audio`, on both the synchronous and asynchronous paths.
+
 ## 2.13.0 (2026-08-10)
 
 ### Acknowledgments

--- a/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
+++ b/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
@@ -199,8 +199,19 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
             // must be skipped so that later events still surface, otherwise a single
             // unrecognized event in the middle of a stream would end the whole stream and
             // look like a clean, early completion.
-            while (await _events.MoveNextAsync().ConfigureAwait(false))
+            while (true)
             {
+                // Cancellation is observed once per event rather than only on entry, because
+                // a run of events that yield no updates is consumed inside a single call.
+                // Passing the token to the event enumerator is not enough on its own, since
+                // events the parser has already buffered are returned without a read.
+                _cancellationToken.ThrowIfCancellationRequested();
+
+                if (!await _events.MoveNextAsync().ConfigureAwait(false))
+                {
+                    break;
+                }
+
                 if (_events.Current.Data.AsSpan().SequenceEqual(TerminalData))
                 {
                     _current = default;

--- a/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
+++ b/OpenAI/src/Utility/AsyncSseUpdateCollection.cs
@@ -193,7 +193,13 @@ internal class AsyncSseUpdateCollection<T> : AsyncCollectionResult<T>
                 return true;
             }
 
-            if (await _events.MoveNextAsync().ConfigureAwait(false))
+            // Keep advancing the outer event enumerator instead of stopping at the first
+            // event. An event can legitimately deserialize to zero updates, for example an
+            // unmodeled event that the deserializer maps to an empty sequence. Such an event
+            // must be skipped so that later events still surface, otherwise a single
+            // unrecognized event in the middle of a stream would end the whole stream and
+            // look like a clean, early completion.
+            while (await _events.MoveNextAsync().ConfigureAwait(false))
             {
                 if (_events.Current.Data.AsSpan().SequenceEqual(TerminalData))
                 {

--- a/OpenAI/src/Utility/SseUpdateCollection.cs
+++ b/OpenAI/src/Utility/SseUpdateCollection.cs
@@ -172,6 +172,10 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
             // look like a clean, early completion.
             while (_events.MoveNext())
             {
+                // Cancellation is observed per event rather than only on entry, because a
+                // run of events that yield no updates is consumed inside a single call.
+                _cancellationToken.ThrowIfCancellationRequested();
+
                 if (_events.Current.Data.AsSpan().SequenceEqual(TerminalData))
                 {
                     _current = default;

--- a/OpenAI/src/Utility/SseUpdateCollection.cs
+++ b/OpenAI/src/Utility/SseUpdateCollection.cs
@@ -170,11 +170,18 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
             // must be skipped so that later events still surface, otherwise a single
             // unrecognized event in the middle of a stream would end the whole stream and
             // look like a clean, early completion.
-            while (_events.MoveNext())
+            while (true)
             {
-                // Cancellation is observed per event rather than only on entry, because a
-                // run of events that yield no updates is consumed inside a single call.
+                // Cancellation is observed once per event rather than only on entry, because
+                // a run of events that yield no updates is consumed inside a single call.
+                // The check sits ahead of the read so that a canceled token does not have to
+                // wait for the server to send another event before it is noticed.
                 _cancellationToken.ThrowIfCancellationRequested();
+
+                if (!_events.MoveNext())
+                {
+                    break;
+                }
 
                 if (_events.Current.Data.AsSpan().SequenceEqual(TerminalData))
                 {

--- a/OpenAI/src/Utility/SseUpdateCollection.cs
+++ b/OpenAI/src/Utility/SseUpdateCollection.cs
@@ -164,7 +164,13 @@ internal class SseUpdateCollection<T> : CollectionResult<T>
                 return true;
             }
 
-            if (_events.MoveNext())
+            // Keep advancing the outer event enumerator instead of stopping at the first
+            // event. An event can legitimately deserialize to zero updates, for example an
+            // unmodeled event that the deserializer maps to an empty sequence. Such an event
+            // must be skipped so that later events still surface, otherwise a single
+            // unrecognized event in the middle of a stream would end the whole stream and
+            // look like a clean, early completion.
+            while (_events.MoveNext())
             {
                 if (_events.Current.Data.AsSpan().SequenceEqual(TerminalData))
                 {

--- a/tests/Assistants/AssistantsMockTests.cs
+++ b/tests/Assistants/AssistantsMockTests.cs
@@ -127,4 +127,67 @@ public class AssistantsMockTests : ClientTestBase
         Assert.That(updates, Has.Count.EqualTo(1));
         Assert.That(updates[0].UpdateKind, Is.EqualTo(StreamingUpdateReason.RunCreated));
     }
+
+    [Test]
+    public async Task StreamingRunContinuesAfterBenignUnknownEvent()
+    {
+        // An unmodeled event yields zero updates. When such an event appears in the
+        // middle of a stream, the enumerator must skip it and keep reading, so that
+        // every later modeled event still surfaces. Placing the unknown event last
+        // cannot detect this, because there is nothing after it to lose.
+        MockPipelineResponse response = new MockPipelineResponse(200).WithContent(
+            """
+            event: thread.run.created
+            data: {"id":"run_abc","object":"thread.run","status":"queued"}
+
+            event: thread.run.some_future_event
+            data: {"id":"run_abc","object":"thread.run","status":"queued"}
+
+            event: thread.run.in_progress
+            data: {"id":"run_abc","object":"thread.run","status":"in_progress"}
+
+            event: thread.run.another_future_event
+            data: {"id":"run_abc","object":"thread.run","status":"in_progress"}
+
+            event: thread.run.completed
+            data: {"id":"run_abc","object":"thread.run","status":"completed"}
+
+            event: done
+            data: [DONE]
+            """);
+
+        OpenAIClientOptions options = new()
+        {
+            Transport = new MockPipelineTransport(_ => response)
+            {
+                ExpectSyncPipeline = !IsAsync
+            }
+        };
+
+        AssistantClient client = new(s_fakeCredential, options);
+
+        List<StreamingUpdate> updates = new();
+
+        if (IsAsync)
+        {
+            await foreach (StreamingUpdate update in client.CreateRunStreamingAsync("thread_abc", "asst_abc"))
+            {
+                updates.Add(update);
+            }
+        }
+        else
+        {
+            foreach (StreamingUpdate update in client.CreateRunStreaming("thread_abc", "asst_abc"))
+            {
+                updates.Add(update);
+            }
+        }
+
+        // All three modeled events must arrive. Before the fix, the stream ended at the
+        // first unmodeled event and only the run.created update was ever produced.
+        Assert.That(updates, Has.Count.EqualTo(3));
+        Assert.That(updates[0].UpdateKind, Is.EqualTo(StreamingUpdateReason.RunCreated));
+        Assert.That(updates[1].UpdateKind, Is.EqualTo(StreamingUpdateReason.RunInProgress));
+        Assert.That(updates[2].UpdateKind, Is.EqualTo(StreamingUpdateReason.RunCompleted));
+    }
 }

--- a/tests/OpenAI.Tests.csproj
+++ b/tests/OpenAI.Tests.csproj
@@ -41,6 +41,16 @@
     <Compile Include="..\examples\MutualTls\Example01_MutualTlsAsync.cs" LinkBase="Shared\Examples" />
   </ItemGroup>
 
+  <!-- The SSE collections are internal and the library is signed, so they are linked
+       in rather than exposed through InternalsVisibleTo. -->
+  <ItemGroup>
+    <Compile Include="..\OpenAI\src\Utility\SseUpdateCollection.cs" LinkBase="Utility\Shared" />
+    <Compile Include="..\OpenAI\src\Utility\AsyncSseUpdateCollection.cs" LinkBase="Utility\Shared" />
+    <Compile Include="..\OpenAI\src\Generated\Internal\ModelSerializationExtensions.cs" LinkBase="Utility\Shared" />
+    <Compile Include="..\OpenAI\src\Generated\Internal\TypeFormatters.cs" LinkBase="Utility\Shared" />
+    <Compile Include="..\OpenAI\src\Generated\Internal\SerializationFormat.cs" LinkBase="Utility\Shared" />
+  </ItemGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>SourcePath</_Parameter1>

--- a/tests/Utility/SseUpdateCollectionTests.cs
+++ b/tests/Utility/SseUpdateCollectionTests.cs
@@ -67,6 +67,64 @@ public class SseUpdateCollectionTests
         Assert.That(updates, Is.EqualTo(new[] { "A", "B" }));
     }
 
+    // A run of events that yield no updates, so that the skip loop stays inside a single
+    // MoveNext call across several events.
+    private const string StreamContentWithConsecutiveUnknownEvents =
+        "event: modeled\ndata: {\"value\":\"A\"}\n\n" +
+        "event: " + UnknownEventType + "\ndata: {\"value\":\"skipped\"}\n\n" +
+        "event: " + UnknownEventType + "\ndata: {\"value\":\"skipped\"}\n\n" +
+        "event: modeled\ndata: {\"value\":\"B\"}\n\n" +
+        "data: [DONE]\n\n";
+
+    [Test]
+    public void SkippingEventsWithNoUpdatesObservesCancellation()
+    {
+        using CancellationTokenSource source = new();
+
+        SseUpdateCollection<string> collection = new(
+            () => CreatePage(StreamContentWithConsecutiveUnknownEvents),
+            item => DeserializeEventAndCancelOnUnknown(item, source),
+            source.Token);
+
+        using IEnumerator<string> enumerator = collection.GetEnumerator();
+
+        Assert.That(enumerator.MoveNext(), Is.True);
+        Assert.That(enumerator.Current, Is.EqualTo("A"));
+
+        // The token is canceled while the second call is already inside the skip loop.
+        Assert.Throws<OperationCanceledException>(() => enumerator.MoveNext());
+    }
+
+    [Test]
+    public void SkippingEventsWithNoUpdatesObservesCancellationAsync()
+    {
+        using CancellationTokenSource source = new();
+
+        AsyncSseUpdateCollection<string> collection = new(
+            () => Task.FromResult(CreatePage(StreamContentWithConsecutiveUnknownEvents)),
+            item => DeserializeEventAndCancelOnUnknown(item, source),
+            source.Token);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (string _ in collection)
+            {
+            }
+        });
+    }
+
+    private static IEnumerable<string> DeserializeEventAndCancelOnUnknown(
+        SseItem<byte[]> item,
+        CancellationTokenSource source)
+    {
+        if (item.EventType == UnknownEventType)
+        {
+            source.Cancel();
+        }
+
+        return DeserializeEvent(item);
+    }
+
     private static IEnumerable<string> DeserializeEvent(SseItem<byte[]> item)
     {
         if (item.EventType == UnknownEventType)
@@ -78,11 +136,13 @@ public class SseUpdateCollectionTests
         return [document.RootElement.GetProperty("value").GetString()!];
     }
 
-    private static ClientResult CreatePage()
+    private static ClientResult CreatePage() => CreatePage(StreamContent);
+
+    private static ClientResult CreatePage(string content)
     {
         MockPipelineResponse response = new(200, "OK")
         {
-            ContentStream = new MemoryStream(Encoding.UTF8.GetBytes(StreamContent)),
+            ContentStream = new MemoryStream(Encoding.UTF8.GetBytes(content)),
         };
 
         return ClientResult.FromResponse(response);

--- a/tests/Utility/SseUpdateCollectionTests.cs
+++ b/tests/Utility/SseUpdateCollectionTests.cs
@@ -113,6 +113,127 @@ public class SseUpdateCollectionTests
         });
     }
 
+    // The terminal event is the next frame after the one that cancels, so the parser has it
+    // buffered and can return it without another read.
+    private const string StreamContentUnknownThenTerminal =
+        "event: modeled\ndata: {\"value\":\"A\"}\n\n" +
+        "event: " + UnknownEventType + "\ndata: {\"value\":\"skipped\"}\n\n" +
+        "data: [DONE]\n\n";
+
+    [Test]
+    public void CancellationIsNotOvertakenByABufferedTerminalEvent()
+    {
+        using CancellationTokenSource source = new();
+
+        SseUpdateCollection<string> collection = new(
+            () => CreatePage(StreamContentUnknownThenTerminal),
+            item => DeserializeEventAndCancelOnUnknown(item, source),
+            source.Token);
+
+        using IEnumerator<string> enumerator = collection.GetEnumerator();
+
+        Assert.That(enumerator.MoveNext(), Is.True);
+        Assert.Throws<OperationCanceledException>(() => enumerator.MoveNext());
+    }
+
+    [Test]
+    public void CancellationIsNotOvertakenByABufferedTerminalEventAsync()
+    {
+        using CancellationTokenSource source = new();
+
+        AsyncSseUpdateCollection<string> collection = new(
+            () => Task.FromResult(CreatePage(StreamContentUnknownThenTerminal)),
+            item => DeserializeEventAndCancelOnUnknown(item, source),
+            source.Token);
+
+        // Without the check ahead of the read, the buffered terminal event is reached first
+        // and enumeration ends normally having produced only "A".
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (string _ in collection)
+            {
+            }
+        });
+    }
+
+    [Test]
+    public void CancellationDoesNotWaitForTheNextEvent()
+    {
+        using CancellationTokenSource source = new();
+        using ManualResetEventSlim neverSignaled = new(initialState: false);
+
+        // The stream serves the first two events and then blocks forever, standing in for a
+        // server that has gone quiet. Cancellation has to be seen without another event.
+        Stream content = new BlockingStream(
+            Encoding.UTF8.GetBytes(
+                "event: modeled\ndata: {\"value\":\"A\"}\n\n" +
+                "event: " + UnknownEventType + "\ndata: {\"value\":\"skipped\"}\n\n"),
+            neverSignaled);
+
+        MockPipelineResponse response = new(200, "OK") { ContentStream = content };
+
+        SseUpdateCollection<string> collection = new(
+            () => ClientResult.FromResponse(response),
+            item => DeserializeEventAndCancelOnUnknown(item, source),
+            source.Token);
+
+        using IEnumerator<string> enumerator = collection.GetEnumerator();
+        Assert.That(enumerator.MoveNext(), Is.True);
+
+        Task<Exception> attempt = Task.Run(() =>
+        {
+            try
+            {
+                enumerator.MoveNext();
+                return (Exception)null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        });
+
+        Assert.That(attempt.Wait(TimeSpan.FromSeconds(10)), Is.True,
+            "MoveNext blocked on a read instead of observing the canceled token.");
+        Assert.That(attempt.Result, Is.InstanceOf<OperationCanceledException>());
+    }
+
+    /// <summary>
+    /// Serves <paramref name="content"/> once and then blocks until the gate is set.
+    /// </summary>
+    private sealed class BlockingStream(byte[] content, ManualResetEventSlim gate) : Stream
+    {
+        private int _position;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_position < content.Length)
+            {
+                int copied = Math.Min(count, content.Length - _position);
+                Array.Copy(content, _position, buffer, offset, copied);
+                _position += copied;
+                return copied;
+            }
+
+            gate.Wait();
+            return 0;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     private static IEnumerable<string> DeserializeEventAndCancelOnUnknown(
         SseItem<byte[]> item,
         CancellationTokenSource source)

--- a/tests/Utility/SseUpdateCollectionTests.cs
+++ b/tests/Utility/SseUpdateCollectionTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.ClientModel.TestFramework.Mocks;
+using NUnit.Framework;
+using System;
+using System.ClientModel;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.ServerSentEvents;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Tests.Utility;
+
+/// <summary>
+/// Tests for the shared SSE collection types that back every streaming API.
+/// </summary>
+/// <remarks>
+/// These exercise the multi-value deserializer shape directly. The single-value
+/// overloads cannot reach the behavior under test, because
+/// <c>DeserializeSseToSingleViaJson</c> wraps its result in a one-element
+/// collection and therefore always produces exactly one update per event.
+/// </remarks>
+[Parallelizable(ParallelScope.All)]
+[Category("Smoke")]
+public class SseUpdateCollectionTests
+{
+    private const string UnknownEventType = "unknown";
+
+    // A modeled event that yields one update, then an event the deserializer does not
+    // recognize and maps to an empty sequence, then a second modeled event, then the
+    // terminal event. Each event needs its own trailing blank line, otherwise the
+    // parser never dispatches it.
+    private const string StreamContent =
+        "event: modeled\ndata: {\"value\":\"A\"}\n\n" +
+        "event: " + UnknownEventType + "\ndata: {\"value\":\"skipped\"}\n\n" +
+        "event: modeled\ndata: {\"value\":\"B\"}\n\n" +
+        "data: [DONE]\n\n";
+
+    [Test]
+    public void EventWithNoUpdatesDoesNotEndTheStream()
+    {
+        SseUpdateCollection<string> collection = new(
+            CreatePage,
+            DeserializeEvent,
+            CancellationToken.None);
+
+        Assert.That(collection.ToList(), Is.EqualTo(new[] { "A", "B" }));
+    }
+
+    [Test]
+    public async Task EventWithNoUpdatesDoesNotEndTheStreamAsync()
+    {
+        AsyncSseUpdateCollection<string> collection = new(
+            () => Task.FromResult(CreatePage()),
+            DeserializeEvent,
+            CancellationToken.None);
+
+        List<string> updates = [];
+
+        await foreach (string update in collection)
+        {
+            updates.Add(update);
+        }
+
+        Assert.That(updates, Is.EqualTo(new[] { "A", "B" }));
+    }
+
+    private static IEnumerable<string> DeserializeEvent(SseItem<byte[]> item)
+    {
+        if (item.EventType == UnknownEventType)
+        {
+            return [];
+        }
+
+        using JsonDocument document = JsonDocument.Parse(item.Data);
+        return [document.RootElement.GetProperty("value").GetString()!];
+    }
+
+    private static ClientResult CreatePage()
+    {
+        MockPipelineResponse response = new(200, "OK")
+        {
+            ContentStream = new MemoryStream(Encoding.UTF8.GetBytes(StreamContent)),
+        };
+
+        return ClientResult.FromResponse(response);
+    }
+}


### PR DESCRIPTION
The server-sent event enumerators advanced the outer event enumerator with an `if` rather than a `while`, so an event that deserializes to zero updates fell through to `return false` and ended the entire stream instead of being skipped. The visible effect is a stream that stops at the first unrecognized event and looks like a clean, early completion, so callers silently lose every later update.

Assistants streaming is the exposed caller, because `StreamingUpdate.FromSseItem` returns an empty sequence for any event kind it does not model, and its own comment describes those events as benign. The same two enumerators also back chat and audio streaming. Both the synchronous `SseUpdateEnumerator` and the asynchronous `AsyncSseUpdateEnumerator` now loop until an event actually produces an update, the terminal `[DONE]` frame arrives, or the events run out.

The existing unknown-event test placed the unmodeled event last, which is the one arrangement where the truncation is invisible. The new test puts unmodeled events in the middle and asserts that the later modeled updates still arrive. It fails on current main with 1 update instead of 3, on both the sync and async fixtures, and passes with the fix, alongside 672 passing Smoke tests on net10.0. The `net8.0` and `net9.0` test targets could not run here because only the .NET 10 runtime is installed, though the library builds clean for all three client target frameworks.

Heads up that #1226 touches these same two files to add constructors. There is no logical overlap with this change, but whichever merges second will need a trivial textual rebase.
