### PR TITLE
Reduce memory pressure for large data URIs

### DIFF
--- a/OpenAI/src/Utility/DataEncodingHelpers.cs
+++ b/OpenAI/src/Utility/DataEncodingHelpers.cs
@@ -1,6 +1,9 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+
+#if !NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 
 #nullable enable
 

--- a/OpenAI/src/Utility/DataEncodingHelpers.cs
+++ b/OpenAI/src/Utility/DataEncodingHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 #nullable enable
@@ -46,7 +47,24 @@ internal static partial class DataEncodingHelpers
 
     public static string CreateDataUri(BinaryData bytes, string bytesMediaType)
     {
-        string base64Bytes = Convert.ToBase64String(bytes.ToArray());
+        ReadOnlyMemory<byte> memory = bytes.ToMemory();
+#if NET8_0_OR_GREATER
+        string base64Bytes = Convert.ToBase64String(memory.Span);
+#else
+        string base64Bytes;
+        if (MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment)
+            && segment.Array is not null)
+        {
+            base64Bytes = Convert.ToBase64String(
+                segment.Array,
+                segment.Offset,
+                segment.Count);
+        }
+        else
+        {
+            base64Bytes = Convert.ToBase64String(memory.ToArray());
+        }
+#endif
         return $"data:{bytesMediaType};base64,{base64Bytes}";
     }
 }

--- a/tests/Responses/ResponsesSmokeTests.cs
+++ b/tests/Responses/ResponsesSmokeTests.cs
@@ -297,7 +297,10 @@ public partial class ResponsesSmokeTests
         }
 
         string imageMediaType = "image/png";
-        BinaryData imageBytes = BinaryData.FromBytes(Encoding.UTF8.GetBytes("image data"), imageMediaType);
+        byte[] imageBuffer = Encoding.UTF8.GetBytes("prefiximage datasuffix");
+        BinaryData imageBytes = BinaryData.FromBytes(
+            imageBuffer.AsMemory("prefix".Length, "image data".Length),
+            imageMediaType);
 
         ResponseContentPart imagePart = ResponseContentPart.CreateInputImagePart(
             imageBytes,


### PR DESCRIPTION
# Summary
 
 Reduce memory pressure when creating Base64 data URIs from large image and file payloads.
 
 This addresses the unnecessary buffer copy reported in #1276. Previously, `BinaryData.ToArray()` copied the entire payload before Base64 encoding, which could add significant memory pressure for images approaching the supported size limit.
 
 ## Changes
 
 - Use span-based Base64 encoding on .NET 8 and later, avoiding the intermediate byte-array allocation.
 - Reuse array-backed `BinaryData` directly on .NET Standard 2.0 while preserving the original array offset and count.
 - Retain the existing copy-based fallback for non-array-backed memory on .NET Standard 2.0.
 - Keep the optimization isolated to `DataEncodingHelpers` without changing public content-part APIs or serialization behavior.
 - Update serialization coverage to verify that sliced memory encodes only the intended bytes.
 
 ## Validation
 
 - Built the library for `netstandard2.0`, `net8.0`, and `net10.0`.
 - Ran the focused Responses regression test on `net8.0`, `net9.0`, and `net10.0`.
 - Ran the existing Chat image-content serialization tests on `net8.0`.
