### PR TITLE
Fix mTLS tests on Windows with Schannel-compatible certificate keys

### DIFF
--- a/tests/MutualTls/CertificateFixture.cs
+++ b/tests/MutualTls/CertificateFixture.cs
@@ -102,8 +102,10 @@ internal sealed class CertificateFixture : IDisposable
                 notBefore,
                 notAfter,
                 CreateSerialNumber());
-        X509Certificate2 clientCertificate =
+        using X509Certificate2 ephemeralClientCertificate =
             clientPublicCertificate.CopyWithPrivateKey(clientKey);
+        X509Certificate2 clientCertificate =
+            LoadPkcs12(ephemeralClientCertificate.Export(X509ContentType.Pkcs12));
 
         using RSA serverKey = RSA.Create(2048);
         CertificateRequest serverRequest = CreateCertificateRequest(
@@ -123,8 +125,10 @@ internal sealed class CertificateFixture : IDisposable
                 notBefore,
                 notAfter,
                 CreateSerialNumber());
-        X509Certificate2 serverCertificate =
+        using X509Certificate2 ephemeralServerCertificate =
             serverPublicCertificate.CopyWithPrivateKey(serverKey);
+        X509Certificate2 serverCertificate =
+            LoadPkcs12(ephemeralServerCertificate.Export(X509ContentType.Pkcs12));
 
         return new CertificateFixture(
             rootCertificate,
@@ -225,5 +229,24 @@ internal sealed class CertificateFixture : IDisposable
         serialNumber[0] &= 0x7F;
         serialNumber[^1] |= 0x01;
         return serialNumber;
+    }
+
+    private static X509Certificate2 LoadPkcs12(byte[] pfx)
+    {
+        // Schannel cannot use the ephemeral key from CopyWithPrivateKey. Reloading
+        // creates a provider-backed key that is removed when the certificate is disposed.
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(
+            pfx,
+            password: null,
+            X509KeyStorageFlags.DefaultKeySet | X509KeyStorageFlags.Exportable);
+#else
+#pragma warning disable SYSLIB0057
+        return new X509Certificate2(
+            pfx,
+            password: (string)null,
+            X509KeyStorageFlags.DefaultKeySet | X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+#endif
     }
 }

--- a/tests/MutualTls/MutualTlsServer.cs
+++ b/tests/MutualTls/MutualTlsServer.cs
@@ -197,14 +197,18 @@ internal sealed class MutualTlsServer : IAsyncDisposable
             return false;
         }
 
-        chain.ChainPolicy.ApplicationPolicy.Add(new Oid(ClientAuthenticationOid));
-        chain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
-        chain.ChainPolicy.DisableCertificateDownloads = true;
-        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        // The callback-provided chain may retain platform TLS policy. Use a fresh
+        // chain so this validation applies only our client-auth and trust settings.
+        using X509Chain validationChain = new();
+        validationChain.ChainPolicy.ApplicationPolicy.Add(
+            new Oid(ClientAuthenticationOid));
+        validationChain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
+        validationChain.ChainPolicy.DisableCertificateDownloads = true;
+        validationChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        validationChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
 
-        bool chainWasTrusted = chain.Build(clientCertificate);
-        PresentedClientChainThumbprints = chain.ChainElements
+        bool chainWasTrusted = validationChain.Build(clientCertificate);
+        PresentedClientChainThumbprints = validationChain.ChainElements
             .Cast<X509ChainElement>()
             .Select(element => element.Certificate.Thumbprint)
             .ToArray();

--- a/tests/MutualTls/MutualTlsServer.cs
+++ b/tests/MutualTls/MutualTlsServer.cs
@@ -203,6 +203,7 @@ internal sealed class MutualTlsServer : IAsyncDisposable
         validationChain.ChainPolicy.ApplicationPolicy.Add(
             new Oid(ClientAuthenticationOid));
         validationChain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
+        validationChain.ChainPolicy.ExtraStore.AddRange(chain.ChainPolicy.ExtraStore);
         validationChain.ChainPolicy.DisableCertificateDownloads = true;
         validationChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
         validationChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;

--- a/tests/MutualTls/MutualTlsServer.cs
+++ b/tests/MutualTls/MutualTlsServer.cs
@@ -203,7 +203,12 @@ internal sealed class MutualTlsServer : IAsyncDisposable
         validationChain.ChainPolicy.ApplicationPolicy.Add(
             new Oid(ClientAuthenticationOid));
         validationChain.ChainPolicy.CustomTrustStore.Add(_trustedClientRoot);
+
+        // Carry peer-supplied intermediates into the fresh chain explicitly. Windows may
+        // rediscover them from its certificate cache, while OpenSSL requires ExtraStore.
+        // These remain untrusted candidates; trust is anchored to the custom root.
         validationChain.ChainPolicy.ExtraStore.AddRange(chain.ChainPolicy.ExtraStore);
+
         validationChain.ChainPolicy.DisableCertificateDownloads = true;
         validationChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
         validationChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;


### PR DESCRIPTION
## Summary

Fixes the mutual TLS tests on Windows by ensuring that generated client and server test certificates use private keys that Windows Schannel can access.

The change also isolates client certificate validation from platform-specific policy attached to the `X509Chain` supplied to the TLS validation callback.

## Problem

The `InvalidApiKeyIsRejectedAfterSuccessfulTlsAuthentication` test is intended to verify this sequence:

1. The client successfully authenticates with its TLS certificate.
2. The server accepts the client certificate.
3. The server receives the HTTP request.
4. The server rejects the invalid API key with `401 Unauthorized`.

On Windows, the test failed before reaching the API-key check:

- The resulting `ClientResultException` had status `0`, rather than `401`.
- `ClientCertificateWasAccepted` was `false`.
- The server never received an HTTP request.

The underlying TLS errors included:

```text
The credentials supplied to the package were not recognized
```

and:

```text
Authentication failed because the platform does not support ephemeral keys.
```

## Root Cause

The test certificates were generated with [`CertificateRequest`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.certificaterequest) and had their private keys attached using [`CopyWithPrivateKey`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.copywithprivatekey).

Those keys were usable through .NET cryptography APIs, but remained ephemeral. On Windows, .NET uses Schannel for TLS. Schannel needs a private key exposed through a Windows cryptographic provider and could not use the ephemeral key representation during the TLS handshake.

This issue is specific to the Windows Schannel path. Linux uses OpenSSL, which can generally use the in-memory key produced by `CopyWithPrivateKey`.

A second platform-dependent issue existed in client certificate validation. The server modified and reused the `X509Chain` supplied to the remote certificate validation callback. That chain can contain policy configured by the platform TLS implementation. On Windows, rebuilding it with additional policy caused the otherwise valid client chain to be rejected.

## Changes

### Use Schannel-compatible private keys

The generated client and server certificates are now exported to PKCS#12 and reloaded using:

```csharp
X509KeyStorageFlags.DefaultKeySet | X509KeyStorageFlags.Exportable
```

The PKCS#12 round trip creates provider-backed private keys that Schannel can use.

`Exportable` is required because the full-chain test subsequently exports the client certificate and intermediate certificate as another PKCS#12 bundle.

`PersistKeySet` is intentionally not used. The imported keys are associated with their owning `X509Certificate2` instances and are cleaned up when `CertificateFixture.Dispose()` disposes the certificates. The certificates are not installed into a Windows certificate store.

The .NET 8 path uses the legacy `X509Certificate2` constructor, while .NET 9 and later use `X509CertificateLoader`.

### Validate with an isolated certificate chain

The server now creates a fresh `X509Chain` for client certificate validation instead of modifying the chain supplied by the TLS callback. This ensures validation depends only on the test’s intended trust and client-authentication policy, rather than platform-specific policy retained by the callback-provided chain.

## Validation

Ran the complete mutual TLS test category across all supported test frameworks on Windows.