### PR TITLE
Add ExtraHigh and Max values to response reasoning effort level

### DIFF
--- a/OpenAI.Responses/src/Generated/Models/ResponseReasoningEffortLevel.cs
+++ b/OpenAI.Responses/src/Generated/Models/ResponseReasoningEffortLevel.cs
@@ -18,6 +18,8 @@ namespace OpenAI.Responses
         private const string LowValue = "low";
         private const string MediumValue = "medium";
         private const string HighValue = "high";
+        private const string ExtraHighValue = "xhigh";
+        private const string MaxValue = "max";
 
         public ResponseReasoningEffortLevel(string value)
         {
@@ -35,6 +37,10 @@ namespace OpenAI.Responses
         public static ResponseReasoningEffortLevel Medium { get; } = new ResponseReasoningEffortLevel(MediumValue);
 
         public static ResponseReasoningEffortLevel High { get; } = new ResponseReasoningEffortLevel(HighValue);
+
+        public static ResponseReasoningEffortLevel ExtraHigh { get; } = new ResponseReasoningEffortLevel(ExtraHighValue);
+
+        public static ResponseReasoningEffortLevel Max { get; } = new ResponseReasoningEffortLevel(MaxValue);
 
         public static bool operator ==(ResponseReasoningEffortLevel left, ResponseReasoningEffortLevel right) => left.Equals(right);
 

--- a/api/in-progress/net10.0/OpenAI.Responses.net10.0.cs
+++ b/api/in-progress/net10.0/OpenAI.Responses.net10.0.cs
@@ -1141,8 +1141,10 @@ namespace OpenAI.Responses {
     [Experimental("OPENAI001")]
     public readonly partial struct ResponseReasoningEffortLevel : IEquatable<ResponseReasoningEffortLevel> {
         public ResponseReasoningEffortLevel(string value);
+        public static ResponseReasoningEffortLevel ExtraHigh { get; }
         public static ResponseReasoningEffortLevel High { get; }
         public static ResponseReasoningEffortLevel Low { get; }
+        public static ResponseReasoningEffortLevel Max { get; }
         public static ResponseReasoningEffortLevel Medium { get; }
         public static ResponseReasoningEffortLevel Minimal { get; }
         public static ResponseReasoningEffortLevel None { get; }

--- a/api/in-progress/net8.0/OpenAI.Responses.net8.0.cs
+++ b/api/in-progress/net8.0/OpenAI.Responses.net8.0.cs
@@ -1141,8 +1141,10 @@ namespace OpenAI.Responses {
     [Experimental("OPENAI001")]
     public readonly partial struct ResponseReasoningEffortLevel : IEquatable<ResponseReasoningEffortLevel> {
         public ResponseReasoningEffortLevel(string value);
+        public static ResponseReasoningEffortLevel ExtraHigh { get; }
         public static ResponseReasoningEffortLevel High { get; }
         public static ResponseReasoningEffortLevel Low { get; }
+        public static ResponseReasoningEffortLevel Max { get; }
         public static ResponseReasoningEffortLevel Medium { get; }
         public static ResponseReasoningEffortLevel Minimal { get; }
         public static ResponseReasoningEffortLevel None { get; }

--- a/api/in-progress/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
+++ b/api/in-progress/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
@@ -1016,8 +1016,10 @@ namespace OpenAI.Responses {
     }
     public readonly partial struct ResponseReasoningEffortLevel : IEquatable<ResponseReasoningEffortLevel> {
         public ResponseReasoningEffortLevel(string value);
+        public static ResponseReasoningEffortLevel ExtraHigh { get; }
         public static ResponseReasoningEffortLevel High { get; }
         public static ResponseReasoningEffortLevel Low { get; }
+        public static ResponseReasoningEffortLevel Max { get; }
         public static ResponseReasoningEffortLevel Medium { get; }
         public static ResponseReasoningEffortLevel Minimal { get; }
         public static ResponseReasoningEffortLevel None { get; }

--- a/specification/base/typespec/responses/models.tsp
+++ b/specification/base/typespec/responses/models.tsp
@@ -1,8 +1,3 @@
-/*
- * This file was automatically generated from an OpenAPI .yaml file.
- * Edits made directly to this file will be lost.
- */
-
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
@@ -16,16 +11,18 @@ namespace OpenAI;
   
   Constrains effort on reasoning for
   [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-  Currently supported values are `none`, `minimal`, `low`, `medium`, and `high`. Reducing
+  Currently supported values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Reducing
   reasoning effort can result in faster responses and fewer tokens used
   on reasoning in a response.
   """)
 union ResponsesReasoningEffort {
-  "none",
-  "minimal",
-  "low",
-  "medium",
-  "high",
+  none: "none",
+  minimal: "minimal",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+  max: "max"
 }
 
 /** Controls how much reasoning context is preserved across turns. */

--- a/specification/client/responses.client.tsp
+++ b/specification/client/responses.client.tsp
@@ -129,6 +129,7 @@ using TypeSpec.HttpClient.CSharp;
 @@clientName(CreateResponse.prompt_cache_retention, "PromptCacheRetentionPolicy");
 @@clientName(Response.prompt_cache_retention, "PromptCacheRetentionPolicy");
 @@clientName(PromptCacheRetention.`24h`, "Max24Hours");
+@@clientName(ResponsesReasoningEffort.xhigh, "ExtraHigh");
 
 // ------------ JsonPatch ------------
 

--- a/tests/Responses/ResponsesTests.cs
+++ b/tests/Responses/ResponsesTests.cs
@@ -340,6 +340,7 @@ public partial class ResponsesTests : OpenAIRecordedTestBase
         Assert.That(response, Is.Not.Null);
         Assert.That(response.Id, Is.Not.Null);
         Assert.That(response.OutputItems, Has.Count.EqualTo(2));
+        Assert.That(response.ReasoningOptions, Is.Not.Null);
         Assert.That(response.ReasoningOptions.ReasoningEffortLevel, Is.EqualTo(ResponseReasoningEffortLevel.ExtraHigh));
 
         ReasoningResponseItem reasoningItem = response.OutputItems[0] as ReasoningResponseItem;

--- a/tests/Responses/ResponsesTests.cs
+++ b/tests/Responses/ResponsesTests.cs
@@ -326,12 +326,12 @@ public partial class ResponsesTests : OpenAIRecordedTestBase
     {
         ResponsesClient client = GetProxiedResponsesClient();
 
-        CreateResponseOptions options = new("gpt-5", [ResponseItem.CreateUserMessageItem("What's the best way to fold a burrito?")])
+        CreateResponseOptions options = new("gpt-5.6", [ResponseItem.CreateUserMessageItem("What's the best way to fold a burrito?")])
         {
             ReasoningOptions = new()
             {
                 ReasoningSummaryVerbosity = ResponseReasoningSummaryVerbosity.Detailed,
-                ReasoningEffortLevel = ResponseReasoningEffortLevel.Low,
+                ReasoningEffortLevel = ResponseReasoningEffortLevel.ExtraHigh,
             },
             Instructions = "Perform reasoning over any questions asked by the user.",
         };
@@ -340,6 +340,7 @@ public partial class ResponsesTests : OpenAIRecordedTestBase
         Assert.That(response, Is.Not.Null);
         Assert.That(response.Id, Is.Not.Null);
         Assert.That(response.OutputItems, Has.Count.EqualTo(2));
+        Assert.That(response.ReasoningOptions.ReasoningEffortLevel, Is.EqualTo(ResponseReasoningEffortLevel.ExtraHigh));
 
         ReasoningResponseItem reasoningItem = response.OutputItems[0] as ReasoningResponseItem;
         MessageResponseItem messageItem = response.OutputItems[1] as MessageResponseItem;

--- a/tests/SessionRecords/ResponsesTests/ResponsesWithReasoning.json
+++ b/tests/SessionRecords/ResponsesTests/ResponsesWithReasoning.json
@@ -6,17 +6,16 @@
       "RequestHeaders": {
         "Accept": "application/json, text/event-stream",
         "Authorization": "Sanitized",
-        "Content-Length": "265",
+        "Content-Length": "269",
         "Content-Type": "application/json",
-        "User-Agent": "OpenAI/2.8.0 (.NET 10.0.1; Microsoft Windows 10.0.26200)"
+        "User-Agent": "OpenAI/2.13.0 (.NET 10.0.10; Ubuntu 24.04.1 LTS)"
       },
       "RequestBody": {
-        "model": "gpt-5",
+        "model": "gpt-5.6",
         "reasoning": {
-          "effort": "low",
+          "effort": "xhigh",
           "summary": "detailed"
         },
-        "instructions": "Perform reasoning over any questions asked by the user.",
         "input": [
           {
             "type": "message",
@@ -28,15 +27,21 @@
               }
             ]
           }
-        ]
+        ],
+        "instructions": "Perform reasoning over any questions asked by the user."
       },
       "StatusCode": 200,
       "ResponseHeaders": {
+        "Access-Control-Expose-Headers": [
+          "X-Request-ID",
+          "CF-Ray",
+          "CF-Ray"
+        ],
         "Alt-Svc": "h3=\":443\"",
-        "cf-cache-status": "DYNAMIC",
-        "CF-RAY": "9c9117861c8827ea-SEA",
+        "CF-Cache-Status": "DYNAMIC",
+        "CF-Ray": "a2a2044278bdaff6-EWR",
         "Connection": "keep-alive",
-        "Content-Length": "4180",
+        "Content-Length": "2832",
         "Content-Type": "application/json",
         "Date": "Sanitized",
         "openai-organization": "Sanitized",
@@ -44,50 +49,50 @@
         "openai-project": "Sanitized",
         "openai-version": "2020-10-01",
         "Server": "cloudflare",
+        "Set-Cookie": "Sanitized",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-ratelimit-limit-requests": "15000",
         "x-ratelimit-limit-tokens": "40000000",
         "x-ratelimit-remaining-requests": "14999",
-        "x-ratelimit-remaining-tokens": "39999640",
+        "x-ratelimit-remaining-tokens": "39999922",
         "x-ratelimit-reset-requests": "4ms",
         "x-ratelimit-reset-tokens": "0s",
         "X-Request-ID": "Sanitized"
       },
       "ResponseBody": {
-        "id": "resp_07d68e67219d15cc006984570628988196a19ff3cb996f5154",
+        "id": "resp_0cc0a58be930d768006a7cced25fbc819e8fa80571fbf90047",
         "object": "response",
-        "created_at": 1770280710,
+        "created_at": 1786564306,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
-        "completed_at": 1770280725,
+        "completed_at": 1786564310,
         "error": null,
         "frequency_penalty": 0.0,
         "incomplete_details": null,
         "instructions": "Perform reasoning over any questions asked by the user.",
         "max_output_tokens": null,
         "max_tool_calls": null,
-        "model": "gpt-5-2025-08-07",
+        "model": "gpt-5.6-sol",
+        "moderation": null,
         "output": [
           {
-            "id": "rs_07d68e67219d15cc00698457066a688196a5543925521174fa",
+            "id": "rs_0cc0a58be930d768006a7cced2e63c819ea6aeb034e95080f0",
             "type": "reasoning",
+            "content": [],
+            "encrypted_content": "Sanitized",
             "summary": [
               {
                 "type": "summary_text",
-                "text": "**Providing taco advice**\n\nThe user is looking for general advice on making tacos, so I want to give some concise step-by-step tips. First, I would emphasize warming the tortilla to make it pliable before filling. I should mention filling placement, folding the sides, and rolling it up while tucking in the fillings. I'll also touch on variations for wet fillings and sizes, suggesting using a rice barrier to soak up moisture. It’s important to keep it concise and practical!"
-              },
-              {
-                "type": "summary_text",
-                "text": "**Summarizing burrito tips**\n\nI want to finish by placing the burrito seam side down to let it rest and seal, or I could toast it on the seam. If I have a very full filling, I can use the envelope method by folding the bottom up, tucking the sides in, then rolling it from the top down. Wrapping it in foil can help keep everything together. I should also mention common mistakes and clarify that smaller tortillas should be used for tacos, not burritos. Keeping it actionable is key!"
+                "text": "**Creating clear instructions**\n\nI need to provide a concise answer while following the desired instructions. It sounds like a good approach is to explain the steps clearly: warm the tortilla, avoid overfilling, tuck in the sides, and roll it tightly. I should include specific quantities and helpful tips to eliminate any confusion. I might also mention placing the seam-side down and toasting it for better results. Let’s aim to create bullet points for clarity!"
               }
             ]
           },
           {
-            "id": "msg_07d68e67219d15cc006984571388508196854195003f1f2283",
+            "id": "msg_0cc0a58be930d768006a7cced4d71c819e9b32c8cfaab0b303",
             "type": "message",
             "status": "completed",
             "content": [
@@ -95,9 +100,10 @@
                 "type": "output_text",
                 "annotations": [],
                 "logprobs": [],
-                "text": "Here’s a reliable, tidy way to fold a burrito so it doesn’t fall apart:\n\n1) Warm the tortilla\n- Use a 10–12 inch flour tortilla.\n- Heat 15–30 seconds per side (pan, griddle, or microwave with a damp towel) until pliable.\n\n2) Build the filling smartly\n- Drain wet fillings; use rice/beans as a moisture barrier.\n- Place fillings in a horizontal line slightly below center.\n- Keep it compact; leave 2 inches clear on left/right edges and 1–2 inches at the bottom. Don’t overfill.\n\n3) Start the fold\n- Fold the left and right sides in so they just overlap the filling.\n\n4) Tuck and roll\n- Lift the bottom edge up over the filling.\n- Tuck it back toward you to compress and tighten.\n- Roll forward away from you, keeping sides tucked, until seam is underneath.\n\n5) Set the seam\n- Rest seam-side down for 30 seconds, or toast the seam on a dry pan to seal.\n- For transport, wrap snugly in foil; cut through foil to eat.\n\nTips\n- Super-saucy fillings: add cheese/rice first, then meat/veg, sauce last in a thin line.\n- Overfilled burrito: use the “envelope” variation—bottom up, sides in, top down, then roll.\n- Add crunch: toast the rolled burrito on all sides.\n- If your tortilla is smaller than 10 inches, make two smaller burritos or tacos instead of overstuffing one."
+                "text": "For a tight, leak-resistant burrito:\n\n1. **Warm the tortilla** for 10–15 seconds so it’s flexible.\n2. **Place filling just below the center**, leaving about 2 inches clear on each side. Don’t overfill.\n3. **Fold the bottom edge up and over the filling.**\n4. **Pull it back gently** to compact the filling into a tight cylinder.\n5. **Fold both sides inward** over the filling.\n6. **Roll forward tightly**, keeping the sides tucked in, until the seam is underneath.\n7. Optionally, **toast seam-side down** in a dry skillet for 1–2 minutes to seal it.\n\nKey tip: use less filling than you think—about 1½ cups for a large tortilla."
               }
             ],
+            "phase": "final_answer",
             "role": "assistant"
           }
         ],
@@ -105,9 +111,11 @@
         "presence_penalty": 0.0,
         "previous_response_id": null,
         "prompt_cache_key": null,
-        "prompt_cache_retention": null,
+        "prompt_cache_retention": "24h",
         "reasoning": {
-          "effort": "low",
+          "context": "all_turns",
+          "effort": "xhigh",
+          "mode": "standard",
           "summary": "detailed"
         },
         "safety_identifier": null,
@@ -121,20 +129,39 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
-        "top_p": 1.0,
+        "top_p": 0.98,
         "truncation": "disabled",
         "usage": {
           "input_tokens": 30,
           "input_tokens_details": {
+            "cache_write_tokens": 0,
             "cached_tokens": 0
           },
-          "output_tokens": 576,
+          "output_tokens": 221,
           "output_tokens_details": {
-            "reasoning_tokens": 192
+            "reasoning_tokens": 56
           },
-          "total_tokens": 606
+          "total_tokens": 251
         },
         "user": null,
         "metadata": {}
@@ -142,6 +169,6 @@
     }
   ],
   "Variables": {
-    "OPEN-API-KEY": "api-key"
+    "OPENAI_API_KEY": "api-key"
   }
 }

--- a/tests/SessionRecords/ResponsesTests/ResponsesWithReasoningAsync.json
+++ b/tests/SessionRecords/ResponsesTests/ResponsesWithReasoningAsync.json
@@ -6,17 +6,16 @@
       "RequestHeaders": {
         "Accept": "application/json, text/event-stream",
         "Authorization": "Sanitized",
-        "Content-Length": "265",
+        "Content-Length": "269",
         "Content-Type": "application/json",
-        "User-Agent": "OpenAI/2.8.0 (.NET 10.0.1; Microsoft Windows 10.0.26200)"
+        "User-Agent": "OpenAI/2.13.0 (.NET 10.0.10; Ubuntu 24.04.1 LTS)"
       },
       "RequestBody": {
-        "model": "gpt-5",
+        "model": "gpt-5.6",
         "reasoning": {
-          "effort": "low",
+          "effort": "xhigh",
           "summary": "detailed"
         },
-        "instructions": "Perform reasoning over any questions asked by the user.",
         "input": [
           {
             "type": "message",
@@ -28,15 +27,21 @@
               }
             ]
           }
-        ]
+        ],
+        "instructions": "Perform reasoning over any questions asked by the user."
       },
       "StatusCode": 200,
       "ResponseHeaders": {
+        "Access-Control-Expose-Headers": [
+          "X-Request-ID",
+          "CF-Ray",
+          "CF-Ray"
+        ],
         "Alt-Svc": "h3=\":443\"",
-        "cf-cache-status": "DYNAMIC",
-        "CF-RAY": "9c9111260f0bc366-SEA",
+        "CF-Cache-Status": "DYNAMIC",
+        "CF-Ray": "a2a203b33d71c8b9-EWR",
         "Connection": "keep-alive",
-        "Content-Length": "4221",
+        "Content-Length": "2808",
         "Content-Type": "application/json",
         "Date": "Sanitized",
         "openai-organization": "Sanitized",
@@ -44,50 +49,50 @@
         "openai-project": "Sanitized",
         "openai-version": "2020-10-01",
         "Server": "cloudflare",
-        "Set-Cookie": [
-          "Sanitized",
-          "Sanitized"
-        ],
+        "Set-Cookie": "Sanitized",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-ratelimit-limit-requests": "15000",
         "x-ratelimit-limit-tokens": "40000000",
         "x-ratelimit-remaining-requests": "14999",
-        "x-ratelimit-remaining-tokens": "39999646",
+        "x-ratelimit-remaining-tokens": "39999934",
         "x-ratelimit-reset-requests": "4ms",
         "x-ratelimit-reset-tokens": "0s",
         "X-Request-ID": "Sanitized"
       },
       "ResponseBody": {
-        "id": "resp_030eb364fd130acd006984560108a08193840b5cfa52e29069",
+        "id": "resp_09eee8807d93b3e0006a7ccebb910c8192b394ac3e7afde4fa",
         "object": "response",
-        "created_at": 1770280449,
+        "created_at": 1786564283,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
-        "completed_at": 1770280464,
+        "completed_at": 1786564289,
         "error": null,
         "frequency_penalty": 0.0,
         "incomplete_details": null,
         "instructions": "Perform reasoning over any questions asked by the user.",
         "max_output_tokens": null,
         "max_tool_calls": null,
-        "model": "gpt-5-2025-08-07",
+        "model": "gpt-5.6-sol",
+        "moderation": null,
         "output": [
           {
-            "id": "rs_030eb364fd130acd00698456015a348193b83613a7b98cb771",
+            "id": "rs_09eee8807d93b3e0006a7ccebd9ac4819296fd903b81ff7857",
             "type": "reasoning",
+            "content": [],
+            "encrypted_content": "Sanitized",
             "summary": [
               {
                 "type": "summary_text",
-                "text": "**Folding a burrito**\n\nThe user wants clear instructions on how to fold a burrito, which is great! I’ll provide a step-by-step method with tips for different tortilla sizes. First, I'll cover steaming or heating the tortillas and how to place the filling. Then, I can explain the envelope fold and the tuck-and-roll methods. It’s important to avoid overfilling and to seal properly by toasting the seam-side down. I should also mention foil wrapping and troubleshoot if tortillas crack, suggesting fresher or larger options. I'll keep it concise!"
+                "text": "**Explaining burrito folding steps**\n\nI need to provide concise yet useful steps for folding a burrito. First, I want to mention using a warm tortilla and avoiding overfilling it. Then, I’ll outline how to tuck and fold in the sides. After that, I’ll explain rolling it up with the seam side down, and maybe suggest toasting it for a crispy finish. It might also help to include ratios for filling! Let’s organize this into numbered steps."
               }
             ]
           },
           {
-            "id": "msg_030eb364fd130acd006984560ea3ac819398646a9b97a030d1",
+            "id": "msg_09eee8807d93b3e0006a7ccebf683081928d370a94e6739898",
             "type": "message",
             "status": "completed",
             "content": [
@@ -95,9 +100,10 @@
                 "type": "output_text",
                 "annotations": [],
                 "logprobs": [],
-                "text": "Here’s a reliable, neat fold that keeps fillings in and holds up to eating:\n\n1) Warm the tortilla\n- Use a 10–12 inch flour tortilla (corn cracks more easily).\n- Heat 15–30 seconds per side in a dry pan or 20–30 seconds in the microwave wrapped in a damp paper towel until pliable.\n\n2) Place the filling correctly\n- Keep all fillings in a horizontal line across the center, slightly closer to you than the center.\n- Use less than you think: about 1 to 1.5 cups total. Put heavier items (rice/beans/meat) on the bottom, then cheese, then wet items (salsa/guac/sour cream) last to prevent sogginess.\n- Leave 1–2 inches clear on the left and right edges.\n\n3) Fold the sides\n- Fold the left and right edges toward the center so they just overlap the ends of the filling line. This creates “walls.”\n\n4) Tuck and roll\n- Lift the edge closest to you up and over the filling, tucking it snugly underneath with your fingers to compress.\n- Roll away from you, keeping it tight so the side folds stay closed. Continue rolling until the seam is underneath.\n\n5) Set the seam\n- Place seam-side down in a hot pan for 30–60 seconds to lightly toast and seal, or wrap tightly in foil with the seam down.\n\nTips and fixes:\n- Overfilling is the #1 cause of blowouts. If it struggles to close, remove a bit.\n- If the tortilla cracks, it’s too cold or dry—rewarm, or lightly brush the inside with a bit of water or oil and reheat.\n- For extra-juicy fillings, line the tortilla with cheese or rice first to act as a moisture barrier.\n- For portable burritos, wrap in foil, twisting the ends. Peel back the foil as you eat.\n- Big burrito option: use a 12-inch tortilla or two overlapped tortillas for “Mission-style” size.\n\nThat’s it—warm, place, fold sides, tuck, tight roll, and set the seam."
+                "text": "### Best way to fold a burrito\n\n1. **Warm the tortilla** for 10–20 seconds so it’s flexible.\n2. **Place filling just below the center**, leaving about 2 inches clear on both sides. Don’t overfill.\n3. **Fold the bottom edge up and over the filling.**\n4. **Pull it back slightly** to tuck the filling into a tight cylinder.\n5. **Fold both sides inward** over the tucked filling.\n6. **Roll forward tightly**, keeping the sides tucked in, until the seam is underneath.\n7. Optional: **toast seam-side down** in a dry skillet for 1–2 minutes to seal it.\n\nThe key is using less filling than you think and making the first tuck tight."
               }
             ],
+            "phase": "final_answer",
             "role": "assistant"
           }
         ],
@@ -105,9 +111,11 @@
         "presence_penalty": 0.0,
         "previous_response_id": null,
         "prompt_cache_key": null,
-        "prompt_cache_retention": null,
+        "prompt_cache_retention": "24h",
         "reasoning": {
-          "effort": "low",
+          "context": "all_turns",
+          "effort": "xhigh",
+          "mode": "standard",
           "summary": "detailed"
         },
         "safety_identifier": null,
@@ -121,20 +129,39 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
-        "top_p": 1.0,
+        "top_p": 0.98,
         "truncation": "disabled",
         "usage": {
           "input_tokens": 30,
           "input_tokens_details": {
+            "cache_write_tokens": 0,
             "cached_tokens": 0
           },
-          "output_tokens": 571,
+          "output_tokens": 209,
           "output_tokens_details": {
-            "reasoning_tokens": 64
+            "reasoning_tokens": 48
           },
-          "total_tokens": 601
+          "total_tokens": 239
         },
         "user": null,
         "metadata": {}
@@ -142,6 +169,6 @@
     }
   ],
   "Variables": {
-    "OPEN-API-KEY": "api-key"
+    "OPENAI_API_KEY": "api-key"
   }
 }


### PR DESCRIPTION
This pull request introduces two new reasoning effort levels—`ExtraHigh` and `Max`—to the `ResponseReasoningEffortLevel` type across all supported .NET versions and updates the corresponding type specification. It also updates the test suite and session records to use the new `ExtraHigh` effort level, reflecting changes in API model versions, test data, and output formats.

**Enhancements to Reasoning Effort Levels:**

* Added new static members `ExtraHigh` and `Max` to the `ResponseReasoningEffortLevel` struct in `OpenAI.Responses` for .NET 8.0, .NET 10.0, and .NET Standard 2.0, enabling higher granularity in specifying reasoning effort. [[1]](diffhunk://#diff-ff2e8403e17945d9143f75659f1ada0685a026b4edd47f4b3b780f84a0b52be7R1127-R1130) [[2]](diffhunk://#diff-4f379572de9762e951ead752a9fafd7f816550888930d854b051dc572ab944f5R1003-R1006)
* Updated the type specification in `models.tsp` to include `ExtraHigh` ("xhigh") and `max` as valid values for reasoning effort.

**Test and Session Record Updates:**

* Modified the `ResponsesWithReasoning` test to use the new `ExtraHigh` effort level and the updated model version (`gpt-5.6`). Also added an assertion to verify the correct effort level is used in the response. [[1]](diffhunk://#diff-15ccfb694e622190639348548cefe00179e859c24e6b93bb5f89cf7b72bb4d93L329-R334) [[2]](diffhunk://#diff-15ccfb694e622190639348548cefe00179e859c24e6b93bb5f89cf7b72bb4d93R343)
* Updated session records (`ResponsesWithReasoning.json` and `ResponsesWithReasoningAsync.json`) to reflect the new effort level (`xhigh`), model version, and various changes in API request/response structure and metadata, including more detailed tool usage and token usage statistics. [[1]](diffhunk://#diff-c2039ef1c8e045886fb19b6545a6ddc6329e0ce1b8cf0205f80606c810ee0801L9-L19) [[2]](diffhunk://#diff-c2039ef1c8e045886fb19b6545a6ddc6329e0ce1b8cf0205f80606c810ee0801L31-R118) [[3]](diffhunk://#diff-c2039ef1c8e045886fb19b6545a6ddc6329e0ce1b8cf0205f80606c810ee0801R132-R172) [[4]](diffhunk://#diff-c91ba1142c0e815a243fd3bba3ae5522829903716b819db7630fa54c3679dae8L9-L19) [[5]](diffhunk://#diff-c91ba1142c0e815a243fd3bba3ae5522829903716b819db7630fa54c3679dae8L31-R118) [[6]](diffhunk://#diff-c91ba1142c0e815a243fd3bba3ae5522829903716b819db7630fa54c3679dae8R132-R172)