### PR TITLE
Standardize vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Please report suspected vulnerabilities privately through OpenAI's
 [Bugcrowd program](https://bugcrowd.com/engagements/openai). The program page
 contains OpenAI's vulnerability disclosure guidelines and scope.
 
-Do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
+Do not report security vulnerabilities through public GitHub issues, pull
+requests, or discussions.
 
 This policy applies to the source code in this repository and the official
 [`OpenAI` NuGet package](https://www.nuget.org/packages/OpenAI) published from
@@ -26,8 +27,10 @@ When reporting a vulnerability, include:
 - The .NET runtime, target framework, and operating system.
 - Any known mitigations or workarounds.
 
-Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
+Do not include live credentials, API keys, customer data, or unredacted
+sensitive logs.
 
 ## Coordinated disclosure
 
-Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.
+Please give the maintainers a reasonable opportunity to investigate and
+address the issue before public disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ When reporting a vulnerability, include:
 - The affected package or product and version, or the affected commit.
 - A clear description of the potential impact.
 - Sanitized steps to reproduce the issue or a minimal proof of concept.
-- The .NET runtime, target framework, and operating system.
+- The .NET runtime, target framework, and operating system, when relevant.
 - Any known mitigations or workarounds.
 
 Do not include live credentials, API keys, customer data, or unredacted

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,28 +1,12 @@
 # Security Policy
 
-Thank you for helping us keep the OpenAI .NET library secure.
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
-
-Do not report security vulnerabilities through public GitHub issues or pull
-requests.
-
-Please report suspected vulnerabilities through OpenAI's
+Please report suspected vulnerabilities privately through OpenAI's
 [Bugcrowd program](https://bugcrowd.com/engagements/openai). The program page
 contains OpenAI's vulnerability disclosure guidelines and scope.
 
-When possible, include:
-
-- the affected package version or commit;
-- the .NET runtime, target framework, and operating system;
-- steps to reproduce the issue or a minimal proof of concept;
-- the potential impact; and
-- any known mitigations or workarounds.
-
-Please allow OpenAI a reasonable opportunity to investigate and address the
-issue before sharing it publicly.
-
-## Scope
+Do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
 
 This policy applies to the source code in this repository and the official
 [`OpenAI` NuGet package](https://www.nuget.org/packages/OpenAI) published from
@@ -31,3 +15,19 @@ it.
 For vulnerabilities in other OpenAI products or services, use the same
 [OpenAI Bugcrowd program](https://bugcrowd.com/engagements/openai) and select
 the appropriate target.
+
+## What to include
+
+When reporting a vulnerability, include:
+
+- The affected package or product and version, or the affected commit.
+- A clear description of the potential impact.
+- Sanitized steps to reproduce the issue or a minimal proof of concept.
+- The .NET runtime, target framework, and operating system.
+- Any known mitigations or workarounds.
+
+Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
+
+## Coordinated disclosure
+
+Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.


### PR DESCRIPTION
## Summary

- Standardize `SECURITY.md` around the shared **Reporting a vulnerability**, **What to include**, and **Coordinated disclosure** sections and exact cross-SDK warning language.
- Require private vulnerability reporting and explicitly prohibit disclosure through public GitHub issues, pull requests, or discussions.
- Require affected package/version or commit, impact, sanitized reproduction details, and the existing .NET runtime/target-framework/OS and mitigation information; prohibit live credentials, API keys, customer data, and unredacted sensitive logs.
- Preserve the existing OpenAI Bugcrowd reporting destination, official `OpenAI` NuGet/source-code scope, other-product routing, and coordinated-disclosure commitment.

## Validation

- Parsed the document as CommonMark and asserted the exact shared section ordering and required policy sentences.
- Verified all existing Bugcrowd and NuGet URLs remain unchanged and reachable, and preserved every repository-specific scope/reporting commitment.
- Confirmed the change is limited to root `SECURITY.md` and passes `git diff --cached --check`.