### PR TITLE
Add CodeQL analysis for pull requests and merge groups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+# Coordinate switching GitHub's existing CodeQL default setup to advanced setup;
+# GitHub rejects advanced CodeQL uploads while default setup remains active.
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '23 5 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - csharp
+          - javascript-typescript
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,13 @@
-# Preserve GitHub's existing default setup and gate on real local CodeQL results.
+# GitHub's existing default CodeQL setup MUST remain enabled: it publishes SARIF
+# and owns repository dashboard alerts. This additional read-only workflow never
+# uploads results and gates pull requests and merge groups on real local findings.
 name: CodeQL
 
 on:
   pull_request:
     branches:
       - main
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
   merge_group:
     types: [checks_requested]
   push:
@@ -79,7 +81,20 @@ jobs:
 
             finding_count="$(jq '[.runs[] | .results // [] | .[]] | length' "${sarif_file}")"
             if [[ ${finding_count} -ne 0 ]]; then
-              jq -r '.runs[] | .results[] | "::error::CodeQL finding: \(.ruleId // "unknown")"' "${sarif_file}"
+              jq -r '
+                def escape_data:
+                  tostring | gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
+                def escape_property:
+                  escape_data | gsub(":"; "%3A") | gsub(","; "%2C");
+
+                .runs[] | .results[] |
+                (.ruleId // "unknown" | escape_property) as $rule |
+                (.message.text // .message.markdown // "CodeQL finding" | escape_data) as $message |
+                (.locations[0].physicalLocation.artifactLocation.uri // "unknown" | escape_property) as $file |
+                (.locations[0].physicalLocation.region.startLine // 1 |
+                  if type == "number" and . > 0 then floor else 1 end) as $line |
+                "::error file=\($file),line=\($line),title=\($rule)::\($message)"
+              ' "${sarif_file}"
               exit 1
             fi
           done

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,4 @@
-# Coordinate switching GitHub's existing CodeQL default setup to advanced setup;
-# GitHub rejects advanced CodeQL uploads while default setup remains active.
+# Preserve GitHub's existing default setup and gate on real local CodeQL results.
 name: CodeQL
 
 on:
@@ -26,7 +25,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +46,40 @@ jobs:
           build-mode: none
 
       - name: Perform CodeQL analysis
+        id: analyze
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: /language:${{ matrix.language }}
+          output: ${{ runner.temp }}/codeql-results/${{ matrix.language }}
+          upload: never
+          upload-database: false
+
+      - name: Reject CodeQL findings
+        env:
+          CODEQL_LANGUAGE: ${{ matrix.language }}
+          SARIF_DIRECTORY: ${{ steps.analyze.outputs.sarif-output }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          sarif_files=("${SARIF_DIRECTORY}"/*.sarif)
+          if [[ ${#sarif_files[@]} -eq 0 ]]; then
+            echo "::error::CodeQL produced no SARIF results for ${CODEQL_LANGUAGE}."
+            exit 1
+          fi
+
+          for sarif_file in "${sarif_files[@]}"; do
+            if ! jq -e \
+              '(.runs | type == "array" and length > 0) and all(.runs[]; .results | type == "array")' \
+              "${sarif_file}" > /dev/null; then
+              echo "::error::CodeQL produced invalid SARIF for ${CODEQL_LANGUAGE}."
+              exit 1
+            fi
+
+            finding_count="$(jq '[.runs[] | .results // [] | .[]] | length' "${sarif_file}")"
+            if [[ ${finding_count} -ne 0 ]]; then
+              jq -r '.runs[] | .results[] | "::error::CodeQL finding: \(.ruleId // "unknown")"' "${sarif_file}"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary

- Add a dedicated supplemental CodeQL workflow for every pull request targeting `main`, future `merge_group` checks, pushes to `main`, a weekly schedule, and manual runs.
- Preserve existing analysis coverage for GitHub Actions, C#, and JavaScript/TypeScript, including the repository's current no-build C# analysis mode.
- Run approved external-fork pull requests through the ordinary `pull_request` event without secrets or persisted checkout credentials.
- Pin checkout and CodeQL actions to full commit SHAs and grant only `contents: read` and `actions: read` job permissions.

## Why

GitHub's current default CodeQL setup analyzes internal pull requests but explicitly excludes pull requests from forks. The repository also requires maintainer approval for all external-contributor workflows; this change preserves that approval boundary while ensuring approved fork PRs receive actual CodeQL analysis.

## Validation

- `actionlint .github/workflows/codeql.yml`
- GitHub Actions workflow JSON-schema validation
- Focused assertions covering every trigger, all three language jobs, safe fork semantics, minimum token permissions, real CodeQL initialization/analysis, full-SHA action pinning, and exact future check names
- `git diff --cached --check`
- Verified the pinned CodeQL Action commit corresponds to upstream `v4.37.7` and has a verified commit signature

## CodeQL setup and rollout

GitHub's existing default CodeQL setup **must remain enabled indefinitely**. It is the authoritative publisher of SARIF results and repository security alerts. This supplemental workflow performs local-only, fail-closed CodeQL analysis for pull requests and merge groups; `upload: never` and `upload-database: false` ensure it does not upload SARIF results or CodeQL databases. It requires only read permissions and does not replace, disable, or modify default setup.

After the supplemental workflow succeeds for internal and maintainer-approved fork PRs, the exact candidate required checks are:

- `CodeQL (actions)`
- `CodeQL (csharp)`
- `CodeQL (javascript-typescript)`

This repository does not currently use a merge queue. If a merge queue is introduced, verify all three checks succeed on `merge_group` before requiring them there. The existing ruleset currently requires only `Build`; this PR intentionally leaves repository settings, contributor approval, and required checks unchanged until those prerequisites are satisfied.

GitHub documentation: [CodeQL default setup excludes fork PRs](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types) and [merge queues require a merge_group trigger](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
