### PR TITLE
Add CodeQL analysis for pull requests and merge queues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL analysis
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types:
+      - checks_requested
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL Analysis (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - csharp
+          - javascript-typescript
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Problem

GitHub-managed CodeQL is enabled for this repository, but managed/default setup explicitly excludes pull requests from forks. Existing approved fork PRs can therefore pass the required `Build` check with no CodeQL analysis, while same-repository PRs receive CodeQL scans. The repository currently has no merge queue, but any future queue also needs explicit `merge_group` coverage.

## Changes

- Add one advanced CodeQL workflow for every `pull_request` targeting `main`, `merge_group` `checks_requested`, pushes to `main`, weekly maintenance, and manual verification.
- Preserve all existing analysis languages (`actions`, `csharp`, `javascript-typescript`) and the existing C# `build-mode: none`, using real CodeQL initialization, analysis, and SARIF uploads.
- Pin `actions/checkout` and both CodeQL actions to verified full commit SHAs, disable persisted checkout credentials, request only `contents: read`, `actions: read`, and `security-events: write`, and preserve external-contributor approval by using `pull_request` rather than `pull_request_target`.
- Produce distinct future required-check candidates: `CodeQL Analysis (actions)`, `CodeQL Analysis (csharp)`, and `CodeQL Analysis (javascript-typescript)`.

## Required rollout prerequisite

**GitHub default CodeQL setup is currently configured and rejects CodeQL SARIF uploads from advanced workflows.** This workflow cannot upload successfully until a maintainer coordinates the supported transition from default to advanced CodeQL; changing that setting immediately would interrupt existing coverage, so this draft intentionally does not change it.

Safe sequence:

1. Review and land the workflow without adding new required checks, keeping the existing `Build` requirement intact.
2. In a coordinated rollout window, switch the repository from default to advanced CodeQL, activate/dispatch the workflow, and verify successful analysis on both an internal PR and an approved external-fork PR; also verify `merge_group` before enabling any future merge queue.
3. Only after every legitimate path emits successful checks, update the existing ruleset to retain `Build` and require the three exact `CodeQL Analysis (...)` checks from the GitHub Actions integration.

No live ruleset, external-contributor approval policy, managed CodeQL setting, existing documentation PR, or Dependabot PR is changed here.

## Validation

- Parsed duplicate-safe YAML and validated against the current GitHub Actions workflow JSON schema.
- Simulated internal/fork PR, merge-group, push, scheduled, and manual event coverage.
- Verified all language/category mappings, no-build extraction, real SARIF upload behavior, exact future check names, least-privilege permissions, and immutable action SHAs.
- Confirmed only `.github/workflows/codeql.yml` changes and `git diff --cached --check` passes.