### PR TITLE
Isolate recording credentials from repository write access

### DIFF
--- a/.github/workflows/record-test.yml
+++ b/.github/workflows/record-test.yml
@@ -19,8 +19,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Runs targeting the same branch are queued to prevent conflicting recording branches.
 # Runs targeting different branches are allowed in parallel.
@@ -33,6 +32,8 @@ jobs:
     name: Record tests
     runs-on: ubuntu-latest
     environment: Live Testing
+    outputs:
+      has_changes: ${{ steps.changes.outputs.has_changes }}
     env:
       LATEST_TEST_TFM: net10.0
       TEST_NUNIT_WHERE: ${{ inputs.nunit_where }}
@@ -40,6 +41,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
@@ -86,17 +89,6 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Scan recordings for unsanitized secrets
-        if: steps.changes.outputs.has_changes == 'true'
-        run: |
-          CHANGED_FILES="$(git status --porcelain tests/SessionRecords/ | awk '{print $NF}')"
-          if echo "$CHANGED_FILES" | xargs grep -qE '(sk-|ek-)[A-Za-z0-9]'; then
-            echo "::error::Potential unsanitized secret key detected in session recordings. Please inspect and sanitize before committing."
-            exit 1
-          else
-            echo "### No unsanitized secrets detected in recordings" >> $GITHUB_STEP_SUMMARY
-          fi
-
       # Playback deliberately omits --framework to validate recordings across all TFMs.
       - name: Validate recordings in Playback mode
         if: steps.changes.outputs.has_changes == 'true'
@@ -110,18 +102,137 @@ jobs:
           CLIENTMODEL_TEST_MODE: Playback
           CLIENTMODEL_DISABLE_AUTO_RECORDING: "true"
 
-      - name: Create PR with recordings
+      - name: Scan recordings for unsanitized secrets
         if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git add -- tests/SessionRecords/
+
+          python -I - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+          paths = filter(None, subprocess.check_output(
+              ["git", "diff", "--cached", "--name-only", "-z"]
+          ).split(b"\0"))
+
+          for encoded_path in paths:
+              path = os.fsdecode(encoded_path)
+              if not path.startswith("tests/SessionRecords/") or not path.endswith(".json"):
+                  sys.exit("::error::Unexpected file in session recording changes.")
+
+              entry = subprocess.check_output(["git", "ls-files", "--stage", "-z", "--", path])
+              if not entry:
+                  continue
+              if not entry.startswith(b"100644 "):
+                  sys.exit("::error::Session recordings must be regular JSON files.")
+
+              content = subprocess.check_output(["git", "show", f":{path}"])
+              try:
+                  parsed = json.loads(content)
+              except (UnicodeDecodeError, json.JSONDecodeError):
+                  sys.exit("::error::Session recording contains invalid JSON.")
+              if (re.search(rb"(sk-|ek-)[A-Za-z0-9]", content)
+                      or re.search(r"(sk-|ek-)[A-Za-z0-9]", json.dumps(parsed))):
+                  sys.exit("::error::Potential unsanitized secret key detected in session recordings.")
+          PY
+
+          echo "### No unsanitized secrets detected in recordings" >> $GITHUB_STEP_SUMMARY
+
+      - name: Prepare sanitized recording changes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: git diff --cached --binary -- tests/SessionRecords/ > "$RUNNER_TEMP/session-recordings.patch"
+
+      - name: Upload sanitized recording changes
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: session-recordings-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/session-recordings.patch
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ success() }}
+        with:
+          name: test-artifacts-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/artifacts/test-results/playback*.trx
+          if-no-files-found: ignore
+          retention-days: 1
+
+  create-pr:
+    name: Create recording pull request
+    needs: record
+    if: needs.record.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download sanitized recording changes
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: session-recordings-${{ github.run_attempt }}
+          path: ${{ runner.temp }}
+
+      - name: Apply sanitized recording changes
+        run: |
+          git apply --index --include='tests/SessionRecords/*' "$RUNNER_TEMP/session-recordings.patch"
+
+          if git diff --cached --quiet -- tests/SessionRecords/; then
+            echo "::error::No valid session recording changes were found."
+            exit 1
+          fi
+
+          python -I - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+          paths = filter(None, subprocess.check_output(
+              ["git", "diff", "--cached", "--name-only", "-z"]
+          ).split(b"\0"))
+
+          for encoded_path in paths:
+              path = os.fsdecode(encoded_path)
+              if not path.startswith("tests/SessionRecords/") or not path.endswith(".json"):
+                  sys.exit("::error::Unexpected file in session recording changes.")
+
+              entry = subprocess.check_output(["git", "ls-files", "--stage", "-z", "--", path])
+              if not entry:
+                  continue
+              if not entry.startswith(b"100644 "):
+                  sys.exit("::error::Session recordings must be regular JSON files.")
+
+              content = subprocess.check_output(["git", "show", f":{path}"])
+              try:
+                  parsed = json.loads(content)
+              except (UnicodeDecodeError, json.JSONDecodeError):
+                  sys.exit("::error::Session recording contains invalid JSON.")
+              if (re.search(rb"(sk-|ek-)[A-Za-z0-9]", content)
+                      or re.search(r"(sk-|ek-)[A-Za-z0-9]", json.dumps(parsed))):
+                  sys.exit("::error::Potential unsanitized secret key detected in session recordings.")
+          PY
+
+      - name: Create PR with recordings
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          TEST_NUNIT_WHERE: ${{ inputs.nunit_where }}
         run: |
-          BASE_BRANCH="${{ github.ref_name }}"
-          RECORDING_BRANCH="recordings/${{ github.run_id }}-${{ github.run_attempt }}"
+          RECORDING_BRANCH="recordings/$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
           
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git checkout -b "$RECORDING_BRANCH"
-          git add tests/SessionRecords/
           git commit -m "Record tests for $BASE_BRANCH"
           git push origin "$RECORDING_BRANCH"
           
@@ -130,7 +241,7 @@ jobs:
 
           printf 'This PR contains session recordings generated by the record-test workflow.\n\n**NUnit.Where:** `%s`\n**Workflow run:** %s' \
             "$TEST_NUNIT_WHERE" \
-            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             > "$BODY_FILE"
           
           PR_URL=$(gh pr create \
@@ -139,14 +250,7 @@ jobs:
             --title "Record tests for $BASE_BRANCH" \
             --draft \
             --body-file "$BODY_FILE" \
-            --assignee "${{ github.actor }}")
+            --assignee "$GITHUB_ACTOR")
           
           echo "### Pull request created:" >> $GITHUB_STEP_SUMMARY
           echo "$PR_URL" >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ !cancelled() }}
-        with:
-          name: test-artifacts-${{ github.run_attempt }}
-          path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/record-test.yml
+++ b/.github/workflows/record-test.yml
@@ -34,6 +34,8 @@ jobs:
     environment: Live Testing
     outputs:
       has_changes: ${{ steps.changes.outputs.has_changes }}
+      patch_sha256: ${{ steps.patch.outputs.sha256 }}
+      patch_artifact_id: ${{ steps.upload_patch.outputs.artifact-id }}
     env:
       LATEST_TEST_TFM: net10.0
       TEST_NUNIT_WHERE: ${{ inputs.nunit_where }}
@@ -89,22 +91,11 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
-      # Playback deliberately omits --framework to validate recordings across all TFMs.
-      - name: Validate recordings in Playback mode
-        if: steps.changes.outputs.has_changes == 'true'
-        run: dotnet test ./tests/OpenAI.Tests.csproj
-          --configuration Release
-          --logger "trx;LogFilePrefix=playback"
-          --results-directory ${{ github.workspace }}/artifacts/test-results
-          ${{ env.VERSION_SUFFIX_ARGS }}
-          -- NUnit.Where="$TEST_NUNIT_WHERE"
-        env:
-          CLIENTMODEL_TEST_MODE: Playback
-          CLIENTMODEL_DISABLE_AUTO_RECORDING: "true"
-
       - name: Scan recordings for unsanitized secrets
         if: steps.changes.outputs.has_changes == 'true'
+        shell: bash
         run: |
+          set -euo pipefail
           git add -- tests/SessionRecords/
 
           python -I - <<'PY'
@@ -141,11 +132,38 @@ jobs:
 
           echo "### No unsanitized secrets detected in recordings" >> $GITHUB_STEP_SUMMARY
 
-      - name: Prepare sanitized recording changes
+      # Playback deliberately omits --framework to validate recordings across all TFMs.
+      - name: Validate recordings in Playback mode
         if: steps.changes.outputs.has_changes == 'true'
-        run: git diff --cached --binary -- tests/SessionRecords/ > "$RUNNER_TEMP/session-recordings.patch"
+        run: dotnet test ./tests/OpenAI.Tests.csproj
+          --configuration Release
+          --logger "trx;LogFilePrefix=playback"
+          --results-directory ${{ github.workspace }}/artifacts/test-results
+          ${{ env.VERSION_SUFFIX_ARGS }}
+          -- NUnit.Where="$TEST_NUNIT_WHERE"
+        env:
+          CLIENTMODEL_TEST_MODE: Playback
+          CLIENTMODEL_DISABLE_AUTO_RECORDING: "true"
+
+      - name: Prepare sanitized recording changes
+        id: patch
+        if: steps.changes.outputs.has_changes == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          patch_path="${RUNNER_TEMP}/session-recordings.patch"
+          git diff --cached --binary -- tests/SessionRecords/ > "${patch_path}"
+
+          if [[ ! -s "${patch_path}" ]]; then
+            echo "::error::No validated session recording patch was produced."
+            exit 1
+          fi
+
+          patch_sha256="$(sha256sum -- "${patch_path}")"
+          printf 'sha256=%s\n' "${patch_sha256%% *}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload sanitized recording changes
+        id: upload_patch
         if: steps.changes.outputs.has_changes == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -172,17 +190,56 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate sanitized recording artifact identity
+        env:
+          EXPECTED_ARTIFACT_ID: ${{ needs.record.outputs.patch_artifact_id }}
+          EXPECTED_PATCH_SHA256: ${{ needs.record.outputs.patch_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${EXPECTED_ARTIFACT_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::The sanitized recording artifact ID is invalid."
+            exit 1
+          fi
+
+          if [[ ! "${EXPECTED_PATCH_SHA256}" =~ ^[a-f0-9]{64}$ ]]; then
+            echo "::error::The sanitized recording patch digest is invalid."
+            exit 1
+          fi
 
       - name: Download sanitized recording changes
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: session-recordings-${{ github.run_attempt }}
+          artifact-ids: ${{ needs.record.outputs.patch_artifact_id }}
           path: ${{ runner.temp }}
 
-      - name: Apply sanitized recording changes
+      - name: Verify sanitized recording patch
+        env:
+          EXPECTED_PATCH_SHA256: ${{ needs.record.outputs.patch_sha256 }}
+        shell: bash
         run: |
+          set -euo pipefail
+          patch_path="${RUNNER_TEMP}/session-recordings.patch"
+
+          if [[ ! -f "${patch_path}" || -L "${patch_path}" || ! -s "${patch_path}" ]]; then
+            echo "::error::The sanitized recording patch is missing, empty, or unsafe."
+            exit 1
+          fi
+
+          actual_patch_sha256="$(sha256sum -- "${patch_path}")"
+          if [[ "${actual_patch_sha256%% *}" != "${EXPECTED_PATCH_SHA256}" ]]; then
+            echo "::error::The sanitized recording patch failed SHA-256 verification."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Apply sanitized recording changes
+        shell: bash
+        run: |
+          set -euo pipefail
           git apply --index --include='tests/SessionRecords/*' "$RUNNER_TEMP/session-recordings.patch"
 
           if git diff --cached --quiet -- tests/SessionRecords/; then


### PR DESCRIPTION
## Summary

- Change the manual test-recording workflow default token to `contents: read` and isolate its live `OPENAI_API_KEY` inside a read-only recording job with checkout credential persistence disabled.
- Move Git pushes and draft recording-PR creation into a separate job with only `contents: write` and `pull-requests: write`; the publishing job receives no live environment, API key, or branch-controlled .NET execution.
- Transfer only a one-day, SHA-pinned artifact containing a compact recording patch, then independently validate staged JSON paths, regular-file modes, Unicode-escaped credentials, and secret patterns on both sides of the job boundary.
- Preserve arbitrary trusted target branches, the existing NUnit input, all-framework Playback validation, recording PR draft/assignment behavior, and fully SHA-pinned Actions. Upload only successful Playback diagnostics, never live Record-mode test logs.

## Validation

- `/tmp/actionlint -oneline .github/workflows/record-test.yml`
- Validation against the GitHub Actions workflow JSON schema.
- Synthetic end-to-end recording/publisher regressions covering additions, modifications, deletions, nested paths, filenames containing spaces, unrelated patch paths, malformed JSON, fake plain/Unicode-escaped API keys, symlinks, executable files, and non-JSON payloads.
- `git diff --cached --check`; verified only `.github/workflows/record-test.yml` changes.
- No Record/Live tests, live credentials, repository settings, OIDC signing, release workflows, branch protections, or existing PRs were modified.

## Owner-managed configuration follow-up (not changed in this PR)

1. Change the repository Actions default from `write` to `read`. Keep GitHub Actions PR creation/approval enabled until the existing recording and weekly generator PR automations have a verified alternative; GitHub combines PR creation and approval in that setting.
2. Add deployment branch/tag policies to the Azure OIDC `release` environment for `main` and `OpenAI_*`, matching the already-protected `publish` environment. Preserve unattended daily signing; requiring reviewers without redesign would block scheduled releases.
3. Add `Live Testing` environment reviewer protections only after the daily release-build job has moved to an appropriate non-secret CI environment; preserve approved trusted recording branches instead of restricting all recordings to `main`.
4. These follow-ups require repository-owner access and, where organization policy is inherited, an organization Actions-policy administrator.