### PR TITLE
Reduce test payload sizes to prevent CI timeouts

### DIFF
--- a/tests/Audio/TranscriptionMockTests.cs
+++ b/tests/Audio/TranscriptionMockTests.cs
@@ -206,12 +206,12 @@ public partial class TranscriptionMockTests : ClientTestBase
     private async ValueTask<AudioTranscription> InvokeTranscribeAudioSyncOrAsync(OpenAIClientOptions clientOptions, AudioSourceKind audioSourceKind)
     {
         AudioClient client = CreateProxyFromClient(new AudioClient("model", s_fakeCredential, clientOptions));
-        string filename = "audio_french.wav";
+        string filename = "audio_hello_world.mp3";
         string path = Path.Combine("Assets", filename);
 
         if (audioSourceKind == AudioSourceKind.UsingStream)
         {
-            using FileStream audio = File.OpenRead(path);
+            using Stream audio = new MemoryStream([0x01, 0x02, 0x03, 0x04, 0x05]);
 
             return await client.TranscribeAudioAsync(audio, filename);
         }

--- a/tests/Audio/TranslationMockTests.cs
+++ b/tests/Audio/TranslationMockTests.cs
@@ -141,12 +141,12 @@ public partial class TranslationMockTests : ClientTestBase
     private async ValueTask<AudioTranslation> InvokeTranslateAudioSyncOrAsync(OpenAIClientOptions clientOptions, AudioSourceKind audioSourceKind)
     {
         AudioClient client = CreateProxyFromClient(new AudioClient("model", s_fakeCredential, clientOptions));
-        string filename = "audio_french.wav";
+        string filename = "audio_hello_world.mp3";
         string path = Path.Combine("Assets", filename);
 
         if (audioSourceKind == AudioSourceKind.UsingStream)
         {
-            using FileStream audio = File.OpenRead(path);
+            using Stream audio = new MemoryStream([0x01, 0x02, 0x03, 0x04, 0x05]);
 
             return await client.TranslateAudioAsync(audio, filename);
         }

--- a/tests/Chat/ChatSmokeTests.cs
+++ b/tests/Chat/ChatSmokeTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -418,11 +417,7 @@ public class ChatSmokeTests : ClientTestBase
     public void SerializeChatMessageContentPartAsImageBytes(bool fromRawJson)
     {
         string imageMediaType = "image/png";
-        string imageFilename = "images_dog_and_cat.png";
-        string imagePath = Path.Combine("Assets", imageFilename);
-        using Stream image = File.OpenRead(imagePath);
-
-        BinaryData imageData = BinaryData.FromStream(image);
+        BinaryData imageData = BinaryData.FromBytes([0x01, 0x02, 0x03, 0x04, 0x05]);
         string base64EncodedData = Convert.ToBase64String(imageData.ToArray());
         string dataUri = $"data:{imageMediaType};base64,{base64EncodedData}";
 

--- a/tests/Files/FilesMockTests.cs
+++ b/tests/Files/FilesMockTests.cs
@@ -260,7 +260,7 @@ public class FilesMockTests : ClientTestBase
             .Split(["\r\n", "\n"], StringSplitOptions.None)
             .Single(line => line.StartsWith("Content-Disposition: form-data; name=file", StringComparison.Ordinal));
 
-        Assert.That(fileContentDisposition, Does.Contain("filename=images_dog_and_cat.png"));
+        Assert.That(fileContentDisposition, Does.Contain("filename=files_travis_favorite_food.pdf"));
         Assert.That(fileContentDisposition, Does.Not.Contain("Assets"));
     }
 
@@ -436,23 +436,23 @@ public class FilesMockTests : ClientTestBase
     private async ValueTask<OpenAIFile> InvokeUploadFileSyncOrAsync(OpenAIClientOptions clientOptions, FileSourceKind fileSourceKind)
     {
         OpenAIFileClient client = CreateProxyFromClient(new OpenAIFileClient(s_fakeCredential, clientOptions));
-        string filename = "images_dog_and_cat.png";
-        string path = Path.Combine("Assets", filename);
+        string filename = "test-file.txt";
 
         if (fileSourceKind == FileSourceKind.UsingStream)
         {
-            using FileStream file = File.OpenRead(path);
+            using Stream file = new MemoryStream([0x01, 0x02, 0x03, 0x04, 0x05]);
 
             return await client.UploadFileAsync(file, filename, purpose: FileUploadPurpose.Assistants);
         }
         else if (fileSourceKind == FileSourceKind.UsingFilePath)
         {
+            string path = Path.Combine("Assets", "files_travis_favorite_food.pdf");
+
             return await client.UploadFileAsync(path, purpose: FileUploadPurpose.Assistants);
         }
         else if (fileSourceKind == FileSourceKind.UsingBinaryData)
         {
-            using FileStream file = File.OpenRead(path);
-            BinaryData content = BinaryData.FromStream(file);
+            BinaryData content = BinaryData.FromBytes([0x01, 0x02, 0x03, 0x04, 0x05]);
 
             return await client.UploadFileAsync(content, filename, purpose: FileUploadPurpose.Assistants);
         }


### PR DESCRIPTION
## Summary

Replace large image and audio assets with small synthetic byte payloads in smoke and mock tests where the actual media content is not relevant.

The affected tests validate serialization, multipart request construction, API overloads, and mocked response deserialization. They do not require valid image or audio content.

## Changes

- Use a five-byte `BinaryData` payload for chat image serialization tests.
- Use small in-memory streams for mocked audio transcription and translation tests.
- Use synthetic stream and `BinaryData` content for mocked file uploads.
- Retain file-path overload coverage using smaller existing test assets.
- Remove the now-unused `System.IO` import from `ChatSmokeTests`.

This reduces file I/O, Base64 expansion, memory allocations, and GC pressure when tests run concurrently in CI.