### PR TITLE
fix(realtime): normalize trailing slash in websocket endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Thank you to our developer community members who helped to make the OpenAI clien
 - Aditya Singh _([GitHub](https://github.com/adityasingh2400))_
 - JS van Dijk _([GitHub](https://github.com/hogeheer499-commits))_
 - Rohan Santhosh Kumar _([GitHub](https://github.com/Rohan5commit))_
+- King Star _([GitHub](https://github.com/jstar0))_
 
 ### Features Added
 
@@ -17,6 +18,8 @@ Thank you to our developer community members who helped to make the OpenAI clien
 
 ### Bugs Fixed
 
+- OpenAI.Realtime:
+  - Fixed WebSocket endpoint construction for custom endpoints that already end in `/realtime/`, avoiding duplicate path segments. _(A community contribution, courtesy of [jstar0](https://github.com/jstar0))_
 - Fixed streaming responses ending early when the service emits an event that the library does not model. The server-sent event enumerator stopped at the first event that produced no updates, so an unrecognized event in the middle of a stream silently terminated the whole stream and looked like a clean, early completion. Unrecognized events are now skipped and every later update still surfaces. This affects all streaming APIs, including `OpenAI.Assistants`, `OpenAI.Chat`, `OpenAI.Responses`, and `OpenAI.Audio`, on both the synchronous and asynchronous paths. _(A community contribution, courtesy of [adityasingh2400](https://github.com/adityasingh2400))_
 
 ### Other Changes

--- a/OpenAI/src/Custom/Realtime/RealtimeClient.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeClient.cs
@@ -110,10 +110,12 @@ public partial class RealtimeClient
             _ => uriBuilder.Scheme
         };
         uriBuilder.Query = "";
-        if (!uriBuilder.Path.EndsWith("/realtime"))
+        string path = uriBuilder.Path.TrimEnd('/');
+        if (!path.EndsWith("/realtime", StringComparison.Ordinal))
         {
-            uriBuilder.Path += uriBuilder.Path[uriBuilder.Path.Length - 1] == '/' ? "realtime" : "/realtime";
+            path += "/realtime";
         }
+        uriBuilder.Path = path;
 
         return uriBuilder.Uri;
     }

--- a/tests/Realtime/RealtimeUnitTests.cs
+++ b/tests/Realtime/RealtimeUnitTests.cs
@@ -156,6 +156,7 @@ public class RealtimeUnitTests
         FieldInfo field = typeof(RealtimeClient).GetField(
             "_webSocketEndpoint",
             BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(field, Is.Not.Null, "RealtimeClient should expose its WebSocket endpoint field");
         return (Uri)field.GetValue(client);
     }
 }

--- a/tests/Realtime/RealtimeUnitTests.cs
+++ b/tests/Realtime/RealtimeUnitTests.cs
@@ -3,6 +3,7 @@ using OpenAI.Realtime;
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Reflection;
 using System.Text.Json;
 
 namespace OpenAI.Tests.Realtime;
@@ -119,6 +120,19 @@ public class RealtimeUnitTests
     }
 
     [Test]
+    public void ClientDoesNotDuplicateRealtimePathWithTrailingSlash()
+    {
+        RealtimeClientOptions options = new()
+        {
+            Endpoint = new Uri("https://custom.openai.com/v1/realtime/"),
+        };
+
+        RealtimeClient client = new(new ApiKeyCredential("test-key"), options);
+
+        Assert.That(GetWebSocketEndpoint(client), Is.EqualTo(new Uri("wss://custom.openai.com/v1/realtime")));
+    }
+
+    [Test]
     public void AudioEndMsSerializesAsInteger()
     {
         // A TimeSpan with sub-millisecond precision that would produce a fractional double
@@ -135,5 +149,13 @@ public class RealtimeUnitTests
         var audioEndMs = root.GetProperty("audio_end_ms");
         Assert.That(audioEndMs.TryGetInt64(out long value), Is.True);
         Assert.That(value, Is.EqualTo(1235));
+    }
+
+    private static Uri GetWebSocketEndpoint(RealtimeClient client)
+    {
+        FieldInfo field = typeof(RealtimeClient).GetField(
+            "_webSocketEndpoint",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return (Uri)field.GetValue(client);
     }
 }


### PR DESCRIPTION
## Summary

When a custom Realtime endpoint already ends in `/realtime/`, the WebSocket endpoint builder appends another `realtime` segment and produces `/realtime/realtime`. This normalizes trailing slashes before checking the suffix, then writes the normalized path back to the URI builder.

A regression test covers a custom `https://.../v1/realtime/` endpoint and verifies the generated WebSocket URI is `wss://.../v1/realtime`.

## Verification

- `dotnet test tests/OpenAI.Tests.csproj --framework net10.0 --filter FullyQualifiedName~RealtimeUnitTests` — 10 passed
- `git diff --check` — passed
- Full net10 test run attempted: 969 passed and 71 skipped; 628 tests failed during recorded-test setup because the repository test proxy invokes SDK `10.0.400`, while this environment provides `10.0.301`. No failures were in the focused Realtime suite.