### PR TITLE
docs: clarify experimental API lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It is generated from our [OpenAPI specification](https://github.com/openai/opena
 - [Getting started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Install the NuGet package](#install-the-nuget-package)
+  - [Experimental APIs](#experimental-apis)
 - [Using the client library](#using-the-client-library)
   - [Namespace organization](#namespace-organization)
   - [Using the async API](#using-the-async-api)
@@ -42,25 +43,6 @@ It is generated from our [OpenAPI specification](https://github.com/openai/opena
 
 To call the OpenAI REST API, you will need an API key. To obtain one, first [create a new OpenAI account](https://platform.openai.com/signup) or [log in](https://platform.openai.com/login). Next, navigate to the [API key page](https://platform.openai.com/account/api-keys) and select "Create new secret key", optionally naming the key. Make sure to save your API key somewhere safe and do not share it with anyone.
 
-### Experimental APIs
-
-Some APIs in this library are marked with `[Experimental]` while the corresponding service surface is still evolving. When you use one of these types or members, the compiler emits a warning code so you can opt in deliberately.
-
-| Warning code | Examples of affected API areas |
-| --- | --- |
-| `OPENAI001` | Assistants, vector stores, batches, evals, realtime client entry points, and other preview client surface area |
-| `OPENAI002` | Realtime session types and session options |
-
-If your project treats warnings as errors, experimental APIs can fail the build until you suppress the relevant warning in the narrowest possible scope:
-
-```csharp
-#pragma warning disable OPENAI001
-AssistantClient assistantClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-#pragma warning restore OPENAI001
-```
-
-Prefer suppressing only the specific warning code around the experimental call site so stable APIs continue surfacing new warnings normally.
-
 ### Install the NuGet package
 
 Add the client library to your .NET project by installing the [NuGet](https://www.nuget.org/) package via your IDE or by running the following command in the .NET CLI:
@@ -70,6 +52,12 @@ dotnet add package OpenAI
 ```
 
 Note that the code examples included below were written using [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0). The OpenAI .NET library is compatible with all .NET Standard 2.0 applications, but the syntax used in some of the code examples in this document may depend on newer language features.
+
+### Experimental APIs
+
+Some client APIs are marked with `[Experimental]` while they undergo iteration and may introduce breaking compile-time or behavioral changes. To use an experimental API, you must acknowledge this risk by suppressing its compiler warning using your preferred approach. See [Suppress code analysis warnings](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/suppress-warnings) for guidance.
+
+The designation describes the lifecycle of the client API only. It does not communicate the state of the REST API feature, its quality or reliability, or its supportability. Stable APIs carry a strong backward-compatibility commitment. Consult the [OpenAI platform API reference](https://developers.openai.com/api/reference/overview) for service documentation and the [feature lifecycle](https://github.com/openai/openai-dotnet/wiki/%F0%9F%93%A6-Feature-Lifecycle-in-the-OpenAI-.NET-Client-Library) for this library's API lifecycle.
 
 ## Using the client library
 
@@ -718,7 +706,7 @@ In this example, you have a JSON document with the monthly sales information of 
 
 To achieve this, use both `OpenAIFileClient` from the `OpenAI.Files` namespace and `AssistantClient` from the `OpenAI.Assistants` namespace.
 
-Important: The Assistants REST API is currently in beta. As such, the details are subject to change, and correspondingly the `AssistantClient` is attributed as `[Experimental]`. To use it, you must suppress the `OPENAI001` warning first.
+Important: `AssistantClient` is attributed as `[Experimental]`. See [Experimental APIs](#experimental-apis) for what this designation means and how to acknowledge its compiler warning.
 
 ```C# Snippet:ReadMe_Assistants_CreateClients
 OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));

--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ Note that the code examples included below were written using [.NET 10](https://
 
 ### Experimental APIs
 
-Some client APIs are marked with `[Experimental]` while they undergo iteration and may introduce breaking compile-time or behavioral changes. To use an experimental API, you must acknowledge this risk by suppressing its compiler warning using your preferred approach. See [Suppress code analysis warnings](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/suppress-warnings) for guidance.
-
-The designation describes the lifecycle of the client API only. It does not communicate the state of the REST API feature, its quality or reliability, or its supportability. Stable APIs carry a strong backward-compatibility commitment. Consult the [OpenAI platform API reference](https://developers.openai.com/api/reference/overview) for service documentation and the [feature lifecycle](https://github.com/openai/openai-dotnet/wiki/%F0%9F%93%A6-Feature-Lifecycle-in-the-OpenAI-.NET-Client-Library) for this library's API lifecycle.
+Some client APIs are marked with `[Experimental]` while their .NET design is still evolving. Using one produces a compiler error that you must explicitly suppress for its diagnostic ID. See [Preview APIs](https://learn.microsoft.com/dotnet/fundamentals/apicompat/preview-apis) for .NET guidance and [Feature lifecycle](./docs/FeatureLifecycle.md) for how OpenAI .NET APIs are introduced and promoted to stable.
 
 ## Using the client library
 
@@ -706,7 +704,7 @@ In this example, you have a JSON document with the monthly sales information of 
 
 To achieve this, use both `OpenAIFileClient` from the `OpenAI.Files` namespace and `AssistantClient` from the `OpenAI.Assistants` namespace.
 
-Important: `AssistantClient` is attributed as `[Experimental]`. See [Experimental APIs](#experimental-apis) for what this designation means and how to acknowledge its compiler warning.
+Important: `AssistantClient` is attributed as `[Experimental]`. See [Experimental APIs](#experimental-apis) for what this designation means and how to acknowledge its compiler error.
 
 ```C# Snippet:ReadMe_Assistants_CreateClients
 OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ It is generated from our [OpenAPI specification](https://github.com/openai/opena
 
 To call the OpenAI REST API, you will need an API key. To obtain one, first [create a new OpenAI account](https://platform.openai.com/signup) or [log in](https://platform.openai.com/login). Next, navigate to the [API key page](https://platform.openai.com/account/api-keys) and select "Create new secret key", optionally naming the key. Make sure to save your API key somewhere safe and do not share it with anyone.
 
+### Experimental APIs
+
+Some APIs in this library are marked with `[Experimental]` while the corresponding service surface is still evolving. When you use one of these types or members, the compiler emits a warning code so you can opt in deliberately.
+
+| Warning code | Examples of affected API areas |
+| --- | --- |
+| `OPENAI001` | Assistants, vector stores, batches, evals, realtime client entry points, and other preview client surface area |
+| `OPENAI002` | Realtime session types and session options |
+
+If your project treats warnings as errors, experimental APIs can fail the build until you suppress the relevant warning in the narrowest possible scope:
+
+```csharp
+#pragma warning disable OPENAI001
+AssistantClient assistantClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+#pragma warning restore OPENAI001
+```
+
+Prefer suppressing only the specific warning code around the experimental call site so stable APIs continue surfacing new warnings normally.
+
 ### Install the NuGet package
 
 Add the client library to your .NET project by installing the [NuGet](https://www.nuget.org/) package via your IDE or by running the following command in the .NET CLI:

--- a/docs/FeatureLifecycle.md
+++ b/docs/FeatureLifecycle.md
@@ -1,0 +1,75 @@
+# Feature lifecycle in the OpenAI .NET client library
+
+This document explains how new OpenAI features are introduced in the OpenAI client library for .NET and what to expect as an API matures.
+
+## Goals
+
+The library is designed to make new OpenAI capabilities available quickly while providing a high-quality, idiomatic .NET experience for APIs that warrant it.
+
+The library provides three complementary API layers. Applications can use the layer that best fits their scenario and move to a lower-level layer when they need more control.
+
+- **Convenience APIs** are opinionated, high-level APIs designed to make common scenarios easy to discover and implement.
+- **Protocol models** cover the majority of scenarios with .NET types that more closely follow the REST contract.
+- **Protocol methods** are the low-level, JSON-focused escape hatch for advanced, specialized, or highly customized scenarios.
+
+Not every OpenAI feature needs all three layers. A straightforward or less commonly used feature may be fully supported by protocol models without requiring a convenience API.
+
+## Feature lifecycle
+
+### 1. Available in the OpenAI REST API
+
+A new capability is added to the OpenAI service and documented in the REST API specification.
+
+### 2. Available through protocol methods
+
+Protocol methods generally fast-follow OpenAI service features. They provide the earliest library access to an HTTP operation and are the most flexible layer in the client library.
+
+Protocol methods are JSON-focused. They accept request bodies as `BinaryContent` and expose response bodies as `BinaryData`. They are intended for scenarios that need complete control over the request, response, headers, or other details of the underlying REST operation.
+
+This layer is appropriate when an application needs a feature immediately, has advanced requirements, or needs behavior not represented by higher-level APIs. It also requires more work from the application, including constructing valid JSON and interpreting the service response.
+
+### 3. Available through protocol models
+
+Protocol models generally follow protocol methods once the library has completed the design work needed to represent REST request and response shapes as .NET types.
+
+These models more closely follow the REST contract while providing an object-based alternative to raw JSON. They are intended to cover the majority of application scenarios without imposing the opinions and abstractions of a convenience API.
+
+For many straightforward or less frequently used features, protocol models are the final API form. Applications that need lower-level control can continue to use protocol methods.
+
+### 4. Available through a convenience API
+
+Convenience APIs are considered for feature areas that are complex, broadly used, or benefit substantially from a guided .NET experience.
+
+They provide opinionated models, abstractions, validation, and workflow-focused methods that make common scenarios easy to discover and implement. They are optimized for typical "Hello World" usage rather than every possible service scenario.
+
+Because convenience APIs require significant design to establish an idiomatic and durable .NET experience, they typically follow protocol methods and protocol models. Applications that need more control can continue to use protocol models or protocol methods.
+
+## Stable and experimental APIs
+
+A feature area can be stable while new APIs are still introduced within it. Stability of a feature area means that its established public API is covered by the library's strong backward compatibility commitment.
+
+For a stable feature area, new protocol methods are introduced as stable because their public shape closely reflects the REST operation. New protocol models and convenience APIs are introduced as experimental while their .NET design is validated.
+
+Protocol models are generally promoted to stable after a short period of feedback and refinement. Convenience APIs undergo a more thorough feedback and tuning process because they introduce opinionated abstractions intended for long-term use.
+
+Experimental APIs are marked with .NET's `[Experimental]` attribute. The C# compiler reports an error when code consumes an experimental API. Each experimental feature has its own diagnostic ID, so acknowledging one feature does not acknowledge another.
+
+To acknowledge use of an experimental feature for a project, add its diagnostic ID to the `NoWarn` property. For example, to use an API marked with `OPENAI001`:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);OPENAI001</NoWarn>
+</PropertyGroup>
+```
+
+A source-level suppression is also possible when its narrower scope is appropriate:
+
+```csharp
+#pragma warning disable OPENAI001
+// Code that uses the experimental API.
+#pragma warning restore OPENAI001
+```
+
+Suppress an experimental diagnostic only after deciding that the API's potential compile-time and behavioral changes are acceptable for the application. See [Preview APIs](https://learn.microsoft.com/dotnet/fundamentals/apicompat/preview-apis) for the .NET behavior and additional suppression options.
+
+When an individual protocol model or convenience API becomes stable, it is covered by the library's strong backward compatibility commitment. Breaking changes are considered only in rare and critical circumstances, such as a severe security issue.

--- a/docs/FeatureLifecycle.md
+++ b/docs/FeatureLifecycle.md
@@ -1,18 +1,18 @@
 # Feature lifecycle in the OpenAI .NET client library
 
-This document explains how new OpenAI features are introduced in the OpenAI client library for .NET and what to expect as an API matures.
+This document explains how client APIs for new OpenAI service features are introduced in the OpenAI client library for .NET and what to expect as they mature.
 
 ## Goals
 
-The library is designed to make new OpenAI capabilities available quickly while providing a high-quality, idiomatic .NET experience for APIs that warrant it.
+The library is designed to make new OpenAI service capabilities available quickly while providing developers with a high-quality, idiomatic .NET experience.
 
-The library provides three complementary API layers. Applications can use the layer that best fits their scenario and move to a lower-level layer when they need more control.
+The library provides three complementary client API layers. Applications can use the layer that best fits their scenario and move to a lower-level layer when they need more control.
 
-- **Convenience APIs** are opinionated, high-level APIs designed to make common scenarios easy to discover and implement.
+- **Convenience APIs** are opinionated, high-level client APIs designed to make common scenarios easy to discover and implement.
 - **Protocol models** cover the majority of scenarios with .NET types that more closely follow the REST contract.
 - **Protocol methods** are the low-level, JSON-focused escape hatch for advanced, specialized, or highly customized scenarios.
 
-Not every OpenAI feature needs all three layers. A straightforward or less commonly used feature may be fully supported by protocol models without requiring a convenience API.
+Not every OpenAI service feature needs all three layers. A straightforward or less commonly used feature may be fully supported by protocol models without requiring a convenience API.
 
 ## Feature lifecycle
 
@@ -20,25 +20,25 @@ Not every OpenAI feature needs all three layers. A straightforward or less commo
 
 A new capability is added to the OpenAI service and documented in the REST API specification.
 
-### 2. Available through protocol methods
+### 2. Available in the client library through protocol methods
 
-Protocol methods generally fast-follow OpenAI service features. They provide the earliest library access to an HTTP operation and are the most flexible layer in the client library.
+Protocol methods generally fast-follow new OpenAI service features. They provide the earliest client library access to an HTTP operation and are the most flexible layer in the library.
 
-Protocol methods are JSON-focused. They accept request bodies as `BinaryContent` and expose response bodies as `BinaryData`. They are intended for scenarios that need complete control over the request, response, headers, or other details of the underlying REST operation.
+Protocol methods are JSON-focused. They accept request bodies as [`BinaryContent`](https://learn.microsoft.com/dotnet/api/system.clientmodel.binarycontent) and return a [`ClientResult`](https://learn.microsoft.com/dotnet/api/system.clientmodel.clientresult). The result's raw [`PipelineResponse`](https://learn.microsoft.com/dotnet/api/system.clientmodel.primitives.pipelineresponse) exposes response content as [`BinaryData`](https://learn.microsoft.com/dotnet/api/system.binarydata). They are intended for scenarios that need complete control over the request, response, headers, or other details of the underlying REST operation.
 
-This layer is appropriate when an application needs a feature immediately, has advanced requirements, or needs behavior not represented by higher-level APIs. It also requires more work from the application, including constructing valid JSON and interpreting the service response.
+This layer is appropriate when an application needs a service feature immediately, has advanced requirements, or needs behavior not represented by higher-level client APIs. It also requires more work from the application, including constructing valid JSON and interpreting the service response.
 
-### 3. Available through protocol models
+### 3. Available in the client library through protocol models
 
-Protocol models generally follow protocol methods once the library has completed the design work needed to represent REST request and response shapes as .NET types.
+Protocol models generally follow protocol methods once the library has completed the design work needed to represent the service's REST request and response shapes as .NET types.
 
 These models more closely follow the REST contract while providing an object-based alternative to raw JSON. They are intended to cover the majority of application scenarios without imposing the opinions and abstractions of a convenience API.
 
-For many straightforward or less frequently used features, protocol models are the final API form. Applications that need lower-level control can continue to use protocol methods.
+For many straightforward or less frequently used service features, protocol models are the final client API form. Applications that need lower-level control can continue to use protocol methods.
 
-### 4. Available through a convenience API
+### 4. Available in the client library through a convenience API
 
-Convenience APIs are considered for feature areas that are complex, broadly used, or benefit substantially from a guided .NET experience.
+Convenience APIs are considered for service feature areas that are complex, broadly used, or benefit substantially from a guided .NET experience.
 
 They provide opinionated models, abstractions, validation, and workflow-focused methods that make common scenarios easy to discover and implement. They are optimized for typical "Hello World" usage rather than every possible service scenario.
 
@@ -46,9 +46,9 @@ Because convenience APIs require significant design to establish an idiomatic an
 
 ## Stable and experimental APIs
 
-A feature area can be stable while new APIs are still introduced within it. Stability of a feature area means that its established public API is covered by the library's strong backward compatibility commitment.
+A client API feature area can be stable while new client APIs are still introduced within it. Stability of a client API feature area means that its established public API is covered by the library's strong backward compatibility commitment.
 
-For a stable feature area, new protocol methods are introduced as stable because their public shape closely reflects the REST operation. New protocol models and convenience APIs are introduced as experimental while their .NET design is validated.
+For a stable client API feature area, new protocol methods are introduced as stable because their public shape closely reflects the REST operation. New protocol models and convenience APIs are introduced as experimental while their .NET design is validated.
 
 Protocol models are generally promoted to stable after a short period of feedback and refinement. Convenience APIs undergo a more thorough feedback and tuning process because they introduce opinionated abstractions intended for long-term use.
 


### PR DESCRIPTION
## Summary
- Documents the lifecycle of client APIs marked `[Experimental]`, including the potential for compile-time and behavioral breaking changes.
- Places the guidance after installation and before client usage.
- Clarifies that the Assistants client designation does not describe the service API lifecycle.

## Related issue
- Fixes #514

## Validation
- `git diff --check`