### PR TITLE
Generalize the Responses directory visitor

### DIFF
--- a/codegen/generator/src/Visitors/ResponsesDirectoryVisitor.cs
+++ b/codegen/generator/src/Visitors/ResponsesDirectoryVisitor.cs
@@ -6,12 +6,13 @@ using System.IO;
 namespace OpenAILibraryPlugin.Visitors;
 
 /// <summary>
-/// Routes generated Responses source files into the physical OpenAI.Responses tree
-/// while keeping them in the unified OpenAI package and generated context.
+/// Routes generated Responses source files into the input library's physical Responses tree
+/// while keeping them in the unified package and generated context.
 /// </summary>
 public class ResponsesDirectoryVisitor : ScmLibraryVisitor
 {
-    private const string ResponsesNamespace = "OpenAI.Responses";
+    private static string ResponsesNamespace =>
+        $"{ScmCodeModelGenerator.Instance.InputLibrary.InputNamespace.Name}.Responses";
 
     protected override TypeProvider VisitType(TypeProvider type)
     {
@@ -30,7 +31,7 @@ public class ResponsesDirectoryVisitor : ScmLibraryVisitor
                 {
                     generatedRelativePath = Path.Combine("Models", Path.GetRelativePath(responsesModelRoot, generatedRelativePath));
                 }
-                type.Update(relativeFilePath: Path.Combine("..", "OpenAI.Responses", "src", "Generated", generatedRelativePath));
+                type.Update(relativeFilePath: Path.Combine("..", ResponsesNamespace, "src", "Generated", generatedRelativePath));
             }
         }
 

--- a/codegen/generator/test/Visitors/ResponsesDirectoryVisitorTests.cs
+++ b/codegen/generator/test/Visitors/ResponsesDirectoryVisitorTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.TypeSpec.Generator.Providers;
+using NUnit.Framework;
+using OpenAILibraryPlugin.Tests.TestHelpers;
+using OpenAILibraryPlugin.Visitors;
+using System.IO;
+
+namespace OpenAILibraryPlugin.Tests.Visitors
+{
+    [Category("Visitor")]
+    public class ResponsesDirectoryVisitorTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator(
+                configurationJson: "{ \"package-name\": \"TestLibrary\" }",
+                inputNamespace: "Contoso");
+        }
+
+        [Test]
+        public void VisitType_DerivesResponsesNamespaceFromInputLibrary()
+        {
+            var type = new TestTypeProvider(
+                "Contoso.Responses",
+                Path.Combine("src", "Generated", "ResponsesClient.cs"));
+
+            new TestResponsesDirectoryVisitor().Apply(type);
+
+            Assert.That(
+                type.RelativeFilePath,
+                Is.EqualTo(Path.Combine("..", "Contoso.Responses", "src", "Generated", "ResponsesClient.cs")));
+        }
+
+        [Test]
+        public void VisitType_RoutesNestedResponsesNamespaces()
+        {
+            var type = new TestTypeProvider(
+                "Contoso.Responses.Events",
+                Path.Combine("src", "Generated", "ResponseEvent.cs"));
+
+            new TestResponsesDirectoryVisitor().Apply(type);
+
+            Assert.That(
+                type.RelativeFilePath,
+                Is.EqualTo(Path.Combine("..", "Contoso.Responses", "src", "Generated", "ResponseEvent.cs")));
+        }
+
+        [Test]
+        public void VisitType_RemovesRedundantResponsesModelDirectory()
+        {
+            var type = new TestTypeProvider(
+                "Contoso.Responses",
+                Path.Combine("src", "Generated", "Models", "Responses", "ResponseItem.cs"));
+
+            new TestResponsesDirectoryVisitor().Apply(type);
+
+            Assert.That(
+                type.RelativeFilePath,
+                Is.EqualTo(Path.Combine("..", "Contoso.Responses", "src", "Generated", "Models", "ResponseItem.cs")));
+        }
+
+        [TestCase("Contoso.ResponsesExtra")]
+        [TestCase("Contoso.Chat")]
+        public void VisitType_DoesNotRouteOtherNamespaces(string modelNamespace)
+        {
+            string path = Path.Combine("src", "Generated", "Other.cs");
+            var type = new TestTypeProvider(modelNamespace, path);
+
+            new TestResponsesDirectoryVisitor().Apply(type);
+
+            Assert.That(type.RelativeFilePath, Is.EqualTo(path));
+        }
+
+        [Test]
+        public void VisitType_DoesNotRouteInternalResponsesFiles()
+        {
+            string path = Path.Combine("src", "Generated", "Internal", "ResponseInternal.cs");
+            var type = new TestTypeProvider("Contoso.Responses", path);
+
+            new TestResponsesDirectoryVisitor().Apply(type);
+
+            Assert.That(type.RelativeFilePath, Is.EqualTo(path));
+        }
+
+        private sealed class TestResponsesDirectoryVisitor : ResponsesDirectoryVisitor
+        {
+            public TypeProvider? Apply(TypeProvider type) => base.VisitType(type);
+        }
+
+        private sealed class TestTypeProvider : TypeProvider
+        {
+            private readonly string _namespace;
+            private readonly string _relativeFilePath;
+
+            public TestTypeProvider(string modelNamespace, string relativeFilePath)
+            {
+                _namespace = modelNamespace;
+                _relativeFilePath = relativeFilePath;
+            }
+
+            protected override string BuildNamespace() => _namespace;
+
+            protected override string BuildRelativeFilePath() => _relativeFilePath;
+
+            protected override string BuildName() => "TestModel";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- derive the Responses namespace from the generator input library instead of hard-coding `OpenAI.Responses`
- preserve routing for nested Responses namespaces, model-directory flattening, and internal generated files
- cover a non-OpenAI root namespace, nested namespaces, prefix collisions, and unchanged paths with focused visitor tests

Closes #1174.

## Tests

- `dotnet build codegen/generator/OpenAI.Library.Plugin.slnx --configuration Release --no-restore`: succeeded with 0 warnings and 0 errors
- full generator test project: 16 passed, 0 failed, 0 skipped (including 6 new visitor cases)
- `dotnet format codegen/generator/OpenAI.Library.Plugin.slnx --verify-no-changes --no-restore --include <modified files>`
