### PR TITLE
Split OpenAILibraryVisitor into focused visitors

### DIFF
--- a/codegen/generator/src/OpenAILibraryGenerator.cs
+++ b/codegen/generator/src/OpenAILibraryGenerator.cs
@@ -24,7 +24,9 @@ namespace OpenAILibraryPlugin
             AddVisitor(new PageOrderRemovalVisitor(this));
             AddVisitor(new OmittedTypesVisitor());
             AddVisitor(new InvariantFormatAdditionalPropertiesVisitor());
-            AddVisitor(new OpenAILibraryVisitor());
+            AddVisitor(new AdditionalPropertiesVisitor());
+            AddVisitor(new ModelSerializationExtensionsVisitor());
+            AddVisitor(new JsonModelWriteCoreVisitor());
             AddVisitor(new VirtualMessageCreationVisitor());
             AddVisitor(new ProhibitedNamespaceVisitor());
             AddVisitor(new ModelSerializationVisitor());

--- a/codegen/generator/src/Visitors/AdditionalPropertiesVisitor.cs
+++ b/codegen/generator/src/Visitors/AdditionalPropertiesVisitor.cs
@@ -1,0 +1,52 @@
+using Microsoft.TypeSpec.Generator.ClientModel;
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
+
+namespace OpenAILibraryPlugin.Visitors;
+
+/// <summary>
+/// Adds access to serialized additional data and makes its backing field mutable on mutable base models.
+/// </summary>
+public class AdditionalPropertiesVisitor : ScmLibraryVisitor
+{
+    private const string RawDataPropertyName = "SerializedAdditionalRawData";
+    private const string AdditionalPropertiesFieldName = "_additionalBinaryDataProperties";
+
+    protected override TypeProvider VisitType(TypeProvider type)
+    {
+        var additionalPropertiesField = type.Fields.FirstOrDefault(f => f.Name == AdditionalPropertiesFieldName);
+        if (type is ModelProvider { BaseModelProvider: null } && additionalPropertiesField != null)
+        {
+            var properties = new List<PropertyProvider>(type.Properties)
+            {
+                new PropertyProvider($"", MethodSignatureModifiers.Internal,
+                    typeof(IDictionary<string, BinaryData>), RawDataPropertyName,
+                    new ExpressionPropertyBody(
+                        additionalPropertiesField,
+                        type.DeclarationModifiers.HasFlag(TypeSignatureModifiers.ReadOnly) ? null : additionalPropertiesField.Assign(Value)),
+                    type)
+            };
+
+            type.Update(properties: properties);
+        }
+
+        return type;
+    }
+
+    protected override FieldProvider VisitField(FieldProvider field)
+    {
+        if (field.Name == AdditionalPropertiesFieldName && !field.EnclosingType.DeclarationModifiers.HasFlag(TypeSignatureModifiers.ReadOnly))
+        {
+            field.Modifiers &= ~FieldModifiers.ReadOnly;
+        }
+
+        return field;
+    }
+}

--- a/codegen/generator/src/Visitors/JsonModelWriteCoreVisitor.cs
+++ b/codegen/generator/src/Visitors/JsonModelWriteCoreVisitor.cs
@@ -11,14 +11,11 @@ using System.Collections.Generic;
 using System.Linq;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
-namespace OpenAILibraryPlugin;
+namespace OpenAILibraryPlugin.Visitors;
 
-public class OpenAILibraryVisitor : ScmLibraryVisitor
+public class JsonModelWriteCoreVisitor : ScmLibraryVisitor
 {
-    private const string RawDataPropertyName = "SerializedAdditionalRawData";
     private const string AdditionalPropertiesFieldName = "_additionalBinaryDataProperties";
-    private const string SentinelValueFieldName = "_sentinelValue";
-    private const string ModelSerializationExtensionsTypeName = "ModelSerializationExtensions";
     private const string IsSentinelValueMethodName = "IsSentinelValue";
     private const string JsonModelWriteCoreMethodName = "JsonModelWriteCore";
 
@@ -26,7 +23,7 @@ public class OpenAILibraryVisitor : ScmLibraryVisitor
     // a conditional that includes an appropriate "Optional" check, e.g.:
     //   - Optional.IsCollectionDefined(Messages) ... writer.WritePropertyName("messages"u8)
     //   - Optional.IsDefined(Model) ... writer.WritePropertyName("model"u8)
-    private static WritePropertyNameAdditionalReplacementInfo _readonlyStatusReplacementInfo = new("Status", "status", isCollection: false); 
+    private static WritePropertyNameAdditionalReplacementInfo _readonlyStatusReplacementInfo = new("Status", "status", isCollection: false);
     private static readonly Dictionary<string, List<WritePropertyNameAdditionalReplacementInfo>> TypeNameToWritePropertyNameAdditionalConditionMap = new()
     {
         ["ChatCompletionOptions"] =
@@ -52,75 +49,6 @@ public class OpenAILibraryVisitor : ScmLibraryVisitor
     };
     private static readonly SingleLineCommentStatement OptionalDefinedCheckComment =
         new("Plugin customization: apply Optional.Is*Defined() check based on type name dictionary lookup");
-
-    protected override TypeProvider VisitType(TypeProvider type)
-    {
-        var additionalPropertiesField = type.Fields.FirstOrDefault(f => f.Name == AdditionalPropertiesFieldName);
-        if (type is ModelProvider { BaseModelProvider: null } && additionalPropertiesField != null)
-        {
-            // Add an internal AdditionalProperties property to all base models
-            var properties = new List<PropertyProvider>(type.Properties)
-            {
-                new PropertyProvider($"", MethodSignatureModifiers.Internal,
-                    typeof(IDictionary<string, BinaryData>), RawDataPropertyName,
-                    new ExpressionPropertyBody(
-                        additionalPropertiesField,
-                        type.DeclarationModifiers.HasFlag(TypeSignatureModifiers.ReadOnly) ? null : additionalPropertiesField.Assign(Value)),
-                    type)
-            };
-            
-            type.Update(properties: properties);
-        }
-        else if (type.Name == ModelSerializationExtensionsTypeName)
-        {
-            // Add a static BinaryData field representing the sentinel value
-            var sentinelValueField = new FieldProvider(
-                FieldModifiers.Private | FieldModifiers.Static | FieldModifiers.ReadOnly,
-                typeof(BinaryData),
-                SentinelValueFieldName,
-                type,
-                $"",
-                BinaryDataSnippets.FromBytes(LiteralU8("\"__EMPTY__\"").Invoke("ToArray")));
-            var fields = new List<FieldProvider>(type.Fields)
-            {
-                sentinelValueField
-            };
-
-            // Add the IsSentinelValue method
-            var valueParameter = new ParameterProvider("value", $"", typeof(BinaryData));
-            var methods = new List<MethodProvider>(type.Methods)
-            {
-                new MethodProvider(
-                    new MethodSignature(
-                        IsSentinelValueMethodName,
-                        $"",
-                        MethodSignatureModifiers.Internal | MethodSignatureModifiers.Static,
-                        typeof(bool),
-                        $"",
-                        [valueParameter]),
-                    new[]
-                    {
-                        Declare("sentinelSpan", typeof(ReadOnlySpan<byte>), sentinelValueField.As<BinaryData>().ToMemory().Property("Span"), out var sentinelVariable),
-                        Declare("valueSpan", typeof(ReadOnlySpan<byte>), valueParameter.As<BinaryData>().ToMemory().Property("Span"), out var valueVariable),
-                        Return(sentinelVariable.Invoke("SequenceEqual", valueVariable))
-                    },
-                    type)
-            };
-            
-            type.Update(fields: fields, methods: methods);
-        }
-        return type;
-    }
-
-    protected override FieldProvider VisitField(FieldProvider field)
-    {
-        // Make the backing additional properties field not be read only as long as the type is not readonly.
-        if (field.Name == AdditionalPropertiesFieldName && !field.EnclosingType.DeclarationModifiers.HasFlag(TypeSignatureModifiers.ReadOnly))
-        {
-            field.Modifiers &= ~FieldModifiers.ReadOnly;
-        }
-        return field;
-    }
 
     protected override MethodProvider VisitMethod(MethodProvider method)
     {

--- a/codegen/generator/src/Visitors/ModelSerializationExtensionsVisitor.cs
+++ b/codegen/generator/src/Visitors/ModelSerializationExtensionsVisitor.cs
@@ -1,0 +1,64 @@
+using Microsoft.TypeSpec.Generator.ClientModel;
+using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Snippets;
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
+
+namespace OpenAILibraryPlugin.Visitors;
+
+/// <summary>
+/// Adds the sentinel members used when serializing additional binary data properties.
+/// </summary>
+public class ModelSerializationExtensionsVisitor : ScmLibraryVisitor
+{
+    private const string SentinelValueFieldName = "_sentinelValue";
+    private const string ModelSerializationExtensionsTypeName = "ModelSerializationExtensions";
+    private const string IsSentinelValueMethodName = "IsSentinelValue";
+
+    protected override TypeProvider VisitType(TypeProvider type)
+    {
+        if (type.Name != ModelSerializationExtensionsTypeName)
+        {
+            return type;
+        }
+
+        var sentinelValueField = new FieldProvider(
+            FieldModifiers.Private | FieldModifiers.Static | FieldModifiers.ReadOnly,
+            typeof(BinaryData),
+            SentinelValueFieldName,
+            type,
+            $"",
+            BinaryDataSnippets.FromBytes(LiteralU8("\"__EMPTY__\"").Invoke("ToArray")));
+        var fields = new List<FieldProvider>(type.Fields)
+        {
+            sentinelValueField
+        };
+
+        var valueParameter = new ParameterProvider("value", $"", typeof(BinaryData));
+        var methods = new List<MethodProvider>(type.Methods)
+        {
+            new MethodProvider(
+                new MethodSignature(
+                    IsSentinelValueMethodName,
+                    $"",
+                    MethodSignatureModifiers.Internal | MethodSignatureModifiers.Static,
+                    typeof(bool),
+                    $"",
+                    [valueParameter]),
+                new[]
+                {
+                    Declare("sentinelSpan", typeof(ReadOnlySpan<byte>), sentinelValueField.As<BinaryData>().ToMemory().Property("Span"), out var sentinelVariable),
+                    Declare("valueSpan", typeof(ReadOnlySpan<byte>), valueParameter.As<BinaryData>().ToMemory().Property("Span"), out var valueVariable),
+                    Return(sentinelVariable.Invoke("SequenceEqual", valueVariable))
+                },
+                type)
+        };
+
+        type.Update(fields: fields, methods: methods);
+        return type;
+    }
+}

--- a/codegen/generator/test/TestHelpers/MockHelpers.cs
+++ b/codegen/generator/test/TestHelpers/MockHelpers.cs
@@ -19,6 +19,14 @@ namespace OpenAILibraryPlugin.Tests.TestHelpers
         private static readonly string _configFilePath = Path.Combine(AppContext.BaseDirectory, TestHelpersFolder);
         private const string TestHelpersFolder = "TestHelpers";
 
+        public static Mock<GeneratorContext> CreateMockGeneratorContext(string? configurationJson = null)
+        {
+            var loadMethod = typeof(Configuration).GetMethod("Load", BindingFlags.Static | BindingFlags.NonPublic);
+            object?[] parameters = [_configFilePath, configurationJson];
+            var config = loadMethod?.Invoke(null, parameters);
+            return new Mock<GeneratorContext>(config!);
+        }
+
         public static Mock<ScmCodeModelGenerator> LoadMockGenerator(
             Func<InputType, TypeProvider, IReadOnlyList<TypeProvider>>? createSerializationsCore = null,
             Func<InputType, CSharpType>? createCSharpTypeCore = null,
@@ -68,11 +76,7 @@ namespace OpenAILibraryPlugin.Tests.TestHelpers
 
             // initialize the mock singleton instance of the plugin
             var codeModelInstance = typeof(CodeModelGenerator).GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic);
-            // invoke the load method with the config file path
-            var loadMethod = typeof(Configuration).GetMethod("Load", BindingFlags.Static | BindingFlags.NonPublic);
-            object?[] parameters = [_configFilePath, configurationJson];
-            var config = loadMethod?.Invoke(null, parameters);
-            var mockGeneratorContext = new Mock<GeneratorContext>(config!);
+            var mockGeneratorContext = CreateMockGeneratorContext(configurationJson);
             var mockGeneratorInstance = new Mock<ScmCodeModelGenerator>(mockGeneratorContext.Object) { CallBase = true };
             codeModelInstance!.SetValue(null, mockGeneratorInstance.Object);
             mockGeneratorInstance.SetupGet(p => p.InputLibrary).Returns(mockInputLibrary.Object);

--- a/codegen/generator/test/Visitors/OpenAILibraryVisitorTests.cs
+++ b/codegen/generator/test/Visitors/OpenAILibraryVisitorTests.cs
@@ -1,10 +1,15 @@
 using Microsoft.TypeSpec.Generator.ClientModel;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using NUnit.Framework;
+using OpenAILibraryPlugin.Visitors;
 using OpenAILibraryPlugin.Tests.Common;
 using OpenAILibraryPlugin.Tests.TestHelpers;
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace OpenAILibraryPlugin.Tests.Visitors
@@ -23,13 +28,13 @@ namespace OpenAILibraryPlugin.Tests.Visitors
         [TestCase(false)]
         public void TestVisitMethod_JsonModelWriteCore(bool isDynamicModel)
         {
-            var visitor = new TestOpenAILibraryVisitor();
+            var visitor = new TestJsonModelWriteCoreVisitor();
 
             var inputType = InputFactory.Model("TestModel", "Samples", isDynamicModel: isDynamicModel, properties: [
                 InputFactory.Property("cat", InputPrimitiveType.String),
                 InputFactory.Property("requiredDog", InputPrimitiveType.String, isRequired: true)
             ]);
-            var model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType);
+            var model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType)!;
             Assert.That(model, Is.Not.Null);
 
             var jsonWriteCoreMethod = model!.SerializationProviders
@@ -54,12 +59,13 @@ namespace OpenAILibraryPlugin.Tests.Visitors
         [TestCase(false)]
         public void TestVisitMethod_JsonModelWriteCore_CustomConditions(bool isDynamicModel)
         {
-            var visitor = new TestOpenAILibraryVisitor();
+            var visitor = new TestJsonModelWriteCoreVisitor();
 
             var inputType = InputFactory.Model("ChatCompletionOptions", "Samples", isDynamicModel: isDynamicModel, properties: [
                 InputFactory.Property("model", InputPrimitiveType.String, isRequired: true),
             ]);
-            var model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType);
+            ModelProvider model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType)
+                ?? throw new InvalidOperationException("Expected a model provider.");
             Assert.That(model, Is.Not.Null);
 
             var jsonWriteCoreMethod = model!.SerializationProviders
@@ -78,12 +84,69 @@ namespace OpenAILibraryPlugin.Tests.Visitors
             Assert.That(methodBody, Is.EqualTo(Helpers.GetExpectedFromFile(isDynamicModel.ToString())));
         }
 
-        private class TestOpenAILibraryVisitor : OpenAILibraryVisitor
+        [Test]
+        public void TestVisitType_AdditionalProperties()
+        {
+            var inputType = InputFactory.Model("TestModel", "Samples", isDynamicModel: true);
+            ModelProvider model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType)
+                ?? throw new InvalidOperationException("Expected a model provider.");
+
+            var additionalPropertiesField = new FieldProvider(
+                FieldModifiers.Private | FieldModifiers.ReadOnly,
+                typeof(IDictionary<string, BinaryData>),
+                "_additionalBinaryDataProperties",
+                model);
+            model.Update(fields: [.. model.Fields, additionalPropertiesField]);
+
+            var visitor = new TestAdditionalPropertiesVisitor();
+            Assert.That(additionalPropertiesField.Modifiers.HasFlag(FieldModifiers.ReadOnly), Is.True);
+
+            visitor.InvokeVisitField(additionalPropertiesField);
+            visitor.InvokeVisitType(model);
+
+            Assert.That(additionalPropertiesField.Modifiers.HasFlag(FieldModifiers.ReadOnly), Is.False);
+            Assert.That(model.Properties.Any(p => p.Name == "SerializedAdditionalRawData"), Is.True);
+        }
+
+        [Test]
+        public void TestVisitType_ModelSerializationExtensions()
+        {
+            var type = new ModelSerializationExtensionsTypeProvider();
+            var visitor = new TestModelSerializationExtensionsVisitor();
+
+            visitor.InvokeVisitType(type);
+
+            Assert.That(type.Fields.Any(f => f.Name == "_sentinelValue"), Is.True);
+            Assert.That(type.Methods.Any(m => m.Signature.Name == "IsSentinelValue"), Is.True);
+        }
+
+        private class TestJsonModelWriteCoreVisitor : JsonModelWriteCoreVisitor
         {
             public MethodProvider? InvokeVisitMethod(MethodProvider method)
             {
                 return base.VisitMethod(method);
             }
+        }
+
+        private class TestAdditionalPropertiesVisitor : AdditionalPropertiesVisitor
+        {
+            public TypeProvider InvokeVisitType(TypeProvider type) => base.VisitType(type);
+
+            public FieldProvider InvokeVisitField(FieldProvider field) => base.VisitField(field);
+        }
+
+        private class TestModelSerializationExtensionsVisitor : ModelSerializationExtensionsVisitor
+        {
+            public TypeProvider InvokeVisitType(TypeProvider type) => base.VisitType(type);
+        }
+
+        private class ModelSerializationExtensionsTypeProvider : TypeProvider
+        {
+            protected override string BuildNamespace() => "Samples";
+
+            protected override string BuildRelativeFilePath() => $"{Name}.cs";
+
+            protected override string BuildName() => "ModelSerializationExtensions";
         }
 
         private class TestTypeProvider : TypeProvider

--- a/codegen/generator/test/Visitors/OpenAILibraryVisitorTests.cs
+++ b/codegen/generator/test/Visitors/OpenAILibraryVisitorTests.cs
@@ -1,5 +1,9 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.TypeSpec.Generator;
 using Microsoft.TypeSpec.Generator.ClientModel;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
@@ -10,7 +14,9 @@ using OpenAILibraryPlugin.Tests.TestHelpers;
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace OpenAILibraryPlugin.Tests.Visitors
 {
@@ -109,6 +115,74 @@ namespace OpenAILibraryPlugin.Tests.Visitors
         }
 
         [Test]
+        public void TestVisitType_AdditionalProperties_ReadOnlyRootModel()
+        {
+            var inputType = InputFactory.Model("TestModel", "Samples", isDynamicModel: true);
+            ModelProvider model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType)
+                ?? throw new InvalidOperationException("Expected a model provider.");
+            model.Update(modifiers: model.DeclarationModifiers | TypeSignatureModifiers.ReadOnly);
+
+            var additionalPropertiesField = new FieldProvider(
+                FieldModifiers.Private | FieldModifiers.ReadOnly,
+                typeof(IDictionary<string, BinaryData>),
+                "_additionalBinaryDataProperties",
+                model);
+            model.Update(fields: [.. model.Fields, additionalPropertiesField]);
+
+            var visitor = new TestAdditionalPropertiesVisitor();
+            visitor.InvokeVisitField(additionalPropertiesField);
+            visitor.InvokeVisitType(model);
+
+            Assert.That(additionalPropertiesField.Modifiers.HasFlag(FieldModifiers.ReadOnly), Is.True);
+            var property = model.Properties.Single(p => p.Name == "SerializedAdditionalRawData");
+            Assert.That(property.Body, Is.EqualTo(new ExpressionPropertyBody(additionalPropertiesField, null)));
+        }
+
+        [Test]
+        public void TestVisitType_AdditionalProperties_DerivedModelDoesNotAddProperty()
+        {
+            var baseInputType = InputFactory.Model("BaseModel", "Samples", isDynamicModel: true);
+            var derivedInputType = InputFactory.Model("DerivedModel", "Samples", baseModel: baseInputType, isDynamicModel: true);
+            ModelProvider model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(derivedInputType)
+                ?? throw new InvalidOperationException("Expected a model provider.");
+            Assert.That(model.BaseModelProvider, Is.Not.Null);
+
+            var additionalPropertiesField = new FieldProvider(
+                FieldModifiers.Private | FieldModifiers.ReadOnly,
+                typeof(IDictionary<string, BinaryData>),
+                "_additionalBinaryDataProperties",
+                model);
+            model.Update(fields: [.. model.Fields, additionalPropertiesField]);
+
+            new TestAdditionalPropertiesVisitor().InvokeVisitType(model);
+
+            Assert.That(model.Properties.Any(p => p.Name == "SerializedAdditionalRawData"), Is.False);
+        }
+
+        [Test]
+        public void TestVisitType_AdditionalProperties_AbsentFieldDoesNotAddProperty()
+        {
+            var inputType = InputFactory.Model("TestModel", "Samples", isDynamicModel: true);
+            ModelProvider model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType)
+                ?? throw new InvalidOperationException("Expected a model provider.");
+
+            new TestAdditionalPropertiesVisitor().InvokeVisitType(model);
+
+            Assert.That(model.Properties.Any(p => p.Name == "SerializedAdditionalRawData"), Is.False);
+        }
+
+        [Test]
+        public void TestVisitField_AdditionalProperties_NonTargetFieldIsUnchanged()
+        {
+            var type = new TestTypeProvider();
+            var field = new FieldProvider(FieldModifiers.Private | FieldModifiers.ReadOnly, typeof(BinaryData), "_otherField", type);
+
+            new TestAdditionalPropertiesVisitor().InvokeVisitField(field);
+
+            Assert.That(field.Modifiers, Is.EqualTo(FieldModifiers.Private | FieldModifiers.ReadOnly));
+        }
+
+        [Test]
         public void TestVisitType_ModelSerializationExtensions()
         {
             var type = new ModelSerializationExtensionsTypeProvider();
@@ -116,8 +190,141 @@ namespace OpenAILibraryPlugin.Tests.Visitors
 
             visitor.InvokeVisitType(type);
 
-            Assert.That(type.Fields.Any(f => f.Name == "_sentinelValue"), Is.True);
-            Assert.That(type.Methods.Any(m => m.Signature.Name == "IsSentinelValue"), Is.True);
+            var sentinelField = type.Fields.Single(f => f.Name == "_sentinelValue");
+            var sentinelMethod = type.Methods.Single(m => m.Signature.Name == "IsSentinelValue");
+            Assert.That(sentinelField.Modifiers, Is.EqualTo(FieldModifiers.Private | FieldModifiers.Static | FieldModifiers.ReadOnly));
+            Assert.That(sentinelField.Type.FrameworkType, Is.EqualTo(typeof(BinaryData)));
+            Assert.That(sentinelField.InitializationValue, Is.Not.Null);
+            Assert.That(sentinelField.InitializationValue!.ToDisplayString(), Does.Contain("__EMPTY__"));
+            Assert.That(sentinelMethod.Signature.Modifiers, Is.EqualTo(MethodSignatureModifiers.Internal | MethodSignatureModifiers.Static));
+            Assert.That(sentinelMethod.Signature.ReturnType, Is.Not.Null);
+            Assert.That(sentinelMethod.Signature.ReturnType!.FrameworkType, Is.EqualTo(typeof(bool)));
+            Assert.That(sentinelMethod.BodyStatements, Is.Not.Null);
+            Assert.That(sentinelMethod.BodyStatements!.ToDisplayString(), Does.Contain("sentinelSpan.SequenceEqual(valueSpan)"));
+
+            AssertSentinelBehavior(sentinelField, sentinelMethod);
+        }
+
+        [Test]
+        public void TestVisitType_ModelSerializationExtensions_NonTargetTypeIsUnchanged()
+        {
+            var type = new TestTypeProvider();
+
+            new TestModelSerializationExtensionsVisitor().InvokeVisitType(type);
+
+            Assert.That(type.Fields.Any(f => f.Name == "_sentinelValue"), Is.False);
+            Assert.That(type.Methods.Any(m => m.Signature.Name == "IsSentinelValue"), Is.False);
+        }
+
+        [Test]
+        public void TestConfigure_RegisteredSplitVisitorsProduceExpectedChanges()
+        {
+            var generator = new TestOpenAILibraryGenerator(
+                MockHelpers.CreateMockGeneratorContext("{ \"package-name\": \"TestLibrary\" }").Object);
+            generator.InvokeConfigure();
+
+            var visitors = generator.Visitors.ToList();
+            var additionalPropertiesIndex = visitors.FindIndex(v => v is AdditionalPropertiesVisitor);
+            var modelSerializationExtensionsIndex = visitors.FindIndex(v => v is ModelSerializationExtensionsVisitor);
+            var jsonModelWriteCoreIndex = visitors.FindIndex(v => v is JsonModelWriteCoreVisitor);
+            Assert.That(additionalPropertiesIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(modelSerializationExtensionsIndex, Is.EqualTo(additionalPropertiesIndex + 1));
+            Assert.That(jsonModelWriteCoreIndex, Is.EqualTo(modelSerializationExtensionsIndex + 1));
+
+            // Restore the test singleton after configuring the real generator instance.
+            MockHelpers.LoadMockGenerator(configurationJson: "{ \"package-name\": \"TestLibrary\" }");
+
+            var inputType = InputFactory.Model("TestModel", "Samples", isDynamicModel: true, properties: [
+                InputFactory.Property("cat", InputPrimitiveType.String),
+                InputFactory.Property("requiredDog", InputPrimitiveType.String, isRequired: true)
+            ]);
+            ModelProvider model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputType)
+                ?? throw new InvalidOperationException("Expected a model provider.");
+            var additionalPropertiesField = new FieldProvider(
+                FieldModifiers.Private | FieldModifiers.ReadOnly,
+                typeof(IDictionary<string, BinaryData>),
+                "_additionalBinaryDataProperties",
+                model);
+            model.Update(fields: [.. model.Fields, additionalPropertiesField]);
+
+            InvokeRegisteredVisitor(visitors[additionalPropertiesIndex], "VisitField", additionalPropertiesField);
+            InvokeRegisteredVisitor(visitors[additionalPropertiesIndex], "VisitType", model);
+            Assert.That(additionalPropertiesField.Modifiers.HasFlag(FieldModifiers.ReadOnly), Is.False);
+            Assert.That(model.Properties.Any(p => p.Name == "SerializedAdditionalRawData"), Is.True);
+
+            var serializationExtensions = new ModelSerializationExtensionsTypeProvider();
+            InvokeRegisteredVisitor(visitors[modelSerializationExtensionsIndex], "VisitType", serializationExtensions);
+            Assert.That(serializationExtensions.Fields.Any(f => f.Name == "_sentinelValue"), Is.True);
+            Assert.That(serializationExtensions.Methods.Any(m => m.Signature.Name == "IsSentinelValue"), Is.True);
+
+            var jsonWriteCoreMethod = model.SerializationProviders
+                .OfType<MrwSerializationTypeDefinition>()
+                .FirstOrDefault()?
+                .Methods
+                .OfType<MethodProvider>()
+                .First(m => m.Signature.Name == "JsonModelWriteCore")
+                ?? throw new InvalidOperationException("Expected JsonModelWriteCore.");
+            jsonWriteCoreMethod = InvokeRegisteredVisitor(visitors[jsonModelWriteCoreIndex], "VisitMethod", jsonWriteCoreMethod);
+            Assert.That(
+                jsonWriteCoreMethod.BodyStatements!.ToDisplayString(),
+                Is.EqualTo(Helpers.GetExpectedFromFile()));
+        }
+
+        private static void AssertSentinelBehavior(FieldProvider sentinelField, MethodProvider sentinelMethod)
+        {
+            var source = $$"""
+                using System;
+
+                internal static class GeneratedModelSerializationExtensions
+                {
+                    private static readonly BinaryData _sentinelValue = {{sentinelField.InitializationValue!.ToDisplayString()}};
+
+                    internal static bool IsSentinelValue(BinaryData value)
+                    {
+                        {{sentinelMethod.BodyStatements!.ToDisplayString()}}
+                    }
+                }
+                """;
+            var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+            var trustedPlatformAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?
+                .Split(Path.PathSeparator)
+                ?? throw new InvalidOperationException("Expected trusted platform assemblies.");
+            var references = trustedPlatformAssemblies
+                .Append(typeof(BinaryData).Assembly.Location)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(path => MetadataReference.CreateFromFile(path));
+            var compilation = CSharpCompilation.Create(
+                $"SentinelBehavior_{Guid.NewGuid():N}",
+                [syntaxTree],
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            using var assemblyStream = new MemoryStream();
+            var emitResult = compilation.Emit(assemblyStream);
+            Assert.That(
+                emitResult.Success,
+                Is.True,
+                string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+
+            var assembly = Assembly.Load(assemblyStream.ToArray());
+            var method = assembly.GetType("GeneratedModelSerializationExtensions")?
+                .GetMethod("IsSentinelValue", BindingFlags.Static | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("Expected generated sentinel method.");
+            Assert.That(method.Invoke(null, [BinaryData.FromString("\"__EMPTY__\"")]), Is.True);
+            Assert.That(method.Invoke(null, [BinaryData.FromString("__EMPTY__")]), Is.False);
+            Assert.That(method.Invoke(null, [BinaryData.FromString("\"__EMPTY__x\"")]), Is.False);
+        }
+
+        private static T InvokeRegisteredVisitor<T>(LibraryVisitor visitor, string methodName, T provider)
+            where T : class
+        {
+            var method = visitor.GetType().GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                .SingleOrDefault(m =>
+                    m.Name == methodName &&
+                    m.GetParameters() is [{ ParameterType: var parameterType }] &&
+                    parameterType.IsAssignableFrom(provider.GetType()))
+                ?? throw new InvalidOperationException($"Expected {visitor.GetType().Name}.{methodName}.");
+            return (T)(method.Invoke(visitor, [provider])
+                ?? throw new InvalidOperationException($"Expected {methodName} to return a provider."));
         }
 
         private class TestJsonModelWriteCoreVisitor : JsonModelWriteCoreVisitor
@@ -138,6 +345,13 @@ namespace OpenAILibraryPlugin.Tests.Visitors
         private class TestModelSerializationExtensionsVisitor : ModelSerializationExtensionsVisitor
         {
             public TypeProvider InvokeVisitType(TypeProvider type) => base.VisitType(type);
+        }
+
+        private class TestOpenAILibraryGenerator : OpenAILibraryGenerator
+        {
+            public TestOpenAILibraryGenerator(GeneratorContext context) : base(context) { }
+
+            public void InvokeConfigure() => base.Configure();
         }
 
         private class ModelSerializationExtensionsTypeProvider : TypeProvider

--- a/codegen/generator/test/Visitors/TestData/OpenAILibraryVisitorTests/TestConfigure_RegisteredSplitVisitorsProduceExpectedChanges.cs
+++ b/codegen/generator/test/Visitors/TestData/OpenAILibraryVisitorTests/TestConfigure_RegisteredSplitVisitorsProduceExpectedChanges.cs
@@ -1,0 +1,38 @@
+string format = (options.Format == "W") ? ((global::System.ClientModel.Primitives.IPersistableModel<global::Samples.TestModel>)this).GetFormatFromOptions(options) : options.Format;
+if ((format != "J"))
+{
+    throw new global::System.FormatException($"The model {nameof(global::Samples.TestModel)} does not support writing '{format}' format.");
+}
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+if ((global::Samples.Optional.IsDefined(Cat) && !Patch.Contains("$.cat"u8)))
+{
+    writer.WritePropertyName("cat"u8);
+    writer.WriteStringValue(Cat);
+}
+if (!Patch.Contains("$.requiredDog"u8))
+{
+    writer.WritePropertyName("requiredDog"u8);
+    writer.WriteStringValue(RequiredDog);
+}
+
+Patch.WriteTo(writer0);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+if (((options.Format != "W") && (_additionalBinaryDataProperties != null)))
+{
+    foreach (var item in _additionalBinaryDataProperties)
+    {
+        if (global::Samples.ModelSerializationExtensions.IsSentinelValue(item.Value))
+        {
+            continue;
+        }
+        writer0.WritePropertyName(item.Key);
+#if NET6_0_OR_GREATER
+        writer0.WriteRawValue(item.Value);
+#else
+        using (global::System.Text.Json.JsonDocument document = global::System.Text.Json.JsonDocument.Parse(item.Value))
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer0, document.RootElement);
+        }
+#endif
+    }
+}


### PR DESCRIPTION
## Summary

- split the monolithic `OpenAILibraryVisitor` into focused visitors for additional-property handling, model-serialization sentinel members, and `JsonModelWriteCore` rewriting
- register the new visitors explicitly while preserving the existing generator behavior
- add branch-complete additional-properties controls, runtime sentinel validation, and exact combined registered-visitor generated-output coverage alongside the existing dynamic and non-dynamic serialization cases

Closes #747.

## Architecture and behavior notes

The split retains the original three responsibilities and registers the focused visitors at the same point in the generator pipeline. The combined registration test configures the real generator, verifies the focused visitors remain adjacent and ordered, applies the registered visitor instances, and compares the resulting `JsonModelWriteCore` body with an exact generated-output golden.

The additional-properties coverage exercises mutable and readonly root models plus derived-model, absent-field, and non-target controls. The sentinel coverage verifies the generated members, compiles the generated field and method, and executes the equality behavior against matching and mismatching byte values. The existing dynamic/non-dynamic `JsonModelWriteCore` and custom-condition cases continue to pass.

## Validation:

Passed at head `28c321c4d1161125b19f0f05348434b9c9693aa1`:

```text
dotnet build .\codegen\generator\OpenAI.Library.Plugin.slnx --configuration Release --no-restore --nologo
dotnet test .\codegen\generator\test\OpenAI.Library.Plugin.Tests.csproj --configuration Release --no-build --no-restore --nologo
dotnet format .\codegen\generator\OpenAI.Library.Plugin.slnx --verify-no-changes --no-restore --verbosity quiet --include codegen/generator/src/OpenAILibraryGenerator.cs codegen/generator/src/Visitors/AdditionalPropertiesVisitor.cs codegen/generator/src/Visitors/JsonModelWriteCoreVisitor.cs codegen/generator/src/Visitors/ModelSerializationExtensionsVisitor.cs codegen/generator/test/TestHelpers/MockHelpers.cs codegen/generator/test/Visitors/OpenAILibraryVisitorTests.cs codegen/generator/test/Visitors/TestData/OpenAILibraryVisitorTests/TestConfigure_RegisteredSplitVisitorsProduceExpectedChanges.cs
```

- generator build: passed with 0 warnings and 0 errors
- generator test project: 24 passed, 0 failed, 0 skipped
- formatting verification: passed with no changes required
- GitHub CI: pending; approval to run

## Prior work and attribution

- jorgerangel-msft opened issue #747, identified that `OpenAILibraryVisitor` combined multiple transformations, and proposed decomposing it into focused visitors.
- jsquire triaged issue #747 as a team architecture work item.
- cjc0013 implemented the visitor split and the direct regression coverage in this draft.
