### PR TITLE
Add Responses OpenTelemetry instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Thank you to our developer community members who helped to make the OpenAI clien
 - OpenAI.Chat:
   - Added opt-in support for the latest experimental OpenTelemetry GenAI semantic conventions supported by this library. Set `OTEL_SEMCONV_STABILITY_OPT_IN` to include `gen_ai_latest_experimental` to emit `gen_ai.provider.name` instead of `gen_ai.system`. The default remains compatible with OpenTelemetry GenAI Semantic Conventions v1.27.0. GenAI histograms now also advertise the recommended explicit bucket boundaries. _(A community contribution, courtesy of [trask](https://github.com/trask))_
 - OpenAI.Responses:
+  - Added experimental OpenTelemetry traces and metrics for non-streaming `CreateResponse` operations. The instrumentation follows the configured GenAI semantic convention version and does not capture prompts, generated content, instructions, tools, or end-user identifiers.
   - Added `ResponseReasoningContext` and exposed it through `ResponseReasoningOptions.Context`, allowing the amount of reasoning context preserved across turns to be controlled with `Auto`, `CurrentTurn`, or `AllTurns`. _(A community contribution, courtesy of [hogeheer499-commits](https://github.com/hogeheer499-commits))_
 
 ### Bugs Fixed

--- a/OpenAI.Responses/src/Custom/ResponsesClient.cs
+++ b/OpenAI.Responses/src/Custom/ResponsesClient.cs
@@ -1,4 +1,5 @@
 using Microsoft.TypeSpec.Generator.Customizations;
+using OpenAI.Telemetry;
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
@@ -24,6 +25,8 @@ namespace OpenAI.Responses;
 
 public partial class ResponsesClient
 {
+    private readonly OpenTelemetrySource _telemetry;
+
     // CUSTOM: Added as a convenience.
     /// <summary> Initializes a new instance of <see cref="ResponsesClient"/>. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
@@ -73,6 +76,7 @@ public partial class ResponsesClient
 
         Pipeline = OpenAIClientUtilities.CreatePipeline(authenticationPolicy, options, options.UserAgentApplicationId, options.OrganizationId, options.ProjectId);
         _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        _telemetry = new OpenTelemetrySource(_endpoint);
     }
 
     // CUSTOM:
@@ -90,6 +94,7 @@ public partial class ResponsesClient
 
         Pipeline = pipeline;
         _endpoint = OpenAIClientUtilities.GetEndpoint(options.Endpoint);
+        _telemetry = new OpenTelemetrySource(_endpoint);
     }
 
     [Experimental("SCME0002")]
@@ -117,8 +122,19 @@ public partial class ResponsesClient
                 + $"For streaming scenarios, call {nameof(CreateResponseStreaming)} instead.");
         }
 
-        ClientResult result = CreateResponse((BinaryContent)options, cancellationToken.ToRequestOptions());
-        return ClientResult.FromValue((ResponseResult)result, result.GetRawResponse());
+        using var scope = _telemetry?.StartResponsesScope(options);
+        try
+        {
+            ClientResult result = CreateResponse((BinaryContent)options, cancellationToken.ToRequestOptions());
+            var response = (ResponseResult)result;
+            scope?.RecordResponseResult(response);
+            return ClientResult.FromValue(response, result.GetRawResponse());
+        }
+        catch (Exception ex)
+        {
+            scope?.RecordException(ex);
+            throw;
+        }
     }
 
     // CUSTOM: Added protocol model method.
@@ -144,8 +160,19 @@ public partial class ResponsesClient
             throw new InvalidOperationException($"{nameof(RequestOptions.BufferResponse)} must be set to true when calling {nameof(CreateResponseAsync)}.");
         }
 
-        ClientResult result = await CreateResponseAsync((BinaryContent)options, requestOptions).ConfigureAwait(false);
-        return ClientResult.FromValue((ResponseResult)result, result.GetRawResponse());
+        using var scope = _telemetry?.StartResponsesScope(options);
+        try
+        {
+            ClientResult result = await CreateResponseAsync((BinaryContent)options, requestOptions).ConfigureAwait(false);
+            var response = (ResponseResult)result;
+            scope?.RecordResponseResult(response);
+            return ClientResult.FromValue(response, result.GetRawResponse());
+        }
+        catch (Exception ex)
+        {
+            scope?.RecordException(ex);
+            throw;
+        }
     }
 
     // CUSTOM: Added convenience method with no options.

--- a/OpenAI/src/Utility/Telemetry/OpenTelemetryConstants.cs
+++ b/OpenAI/src/Utility/Telemetry/OpenTelemetryConstants.cs
@@ -17,9 +17,14 @@ internal class OpenTelemetryConstants
     public const string GenAiClientTokenUsageMetricName = "gen_ai.client.token.usage";
 
     public const string GenAiOperationNameKey = "gen_ai.operation.name";
+    public const string GenAiConversationCompactedKey = "gen_ai.conversation.compacted";
+    public const string GenAiConversationIdKey = "gen_ai.conversation.id";
+    public const string GenAiOutputTypeKey = "gen_ai.output.type";
 
     public const string GenAiRequestMaxTokensKey = "gen_ai.request.max_tokens";
     public const string GenAiRequestModelKey = "gen_ai.request.model";
+    public const string GenAiRequestPreviousResponseIdKey = "gen_ai.request.previous_response.id";
+    public const string GenAiRequestReasoningLevelKey = "gen_ai.request.reasoning.level";
     public const string GenAiRequestTemperatureKey = "gen_ai.request.temperature";
     public const string GenAiRequestTopPKey = "gen_ai.request.top_p";
 
@@ -38,4 +43,11 @@ internal class OpenTelemetryConstants
 
     public const string GenAiUsageInputTokensKey = "gen_ai.usage.input_tokens";
     public const string GenAiUsageOutputTokensKey = "gen_ai.usage.output_tokens";
+    public const string GenAiUsageCacheReadInputTokensKey = "gen_ai.usage.cache_read.input_tokens";
+    public const string GenAiUsageReasoningOutputTokensKey = "gen_ai.usage.reasoning.output_tokens";
+
+    public const string OpenAiApiTypeKey = "openai.api.type";
+    public const string OpenAiApiTypeResponsesValue = "responses";
+    public const string OpenAiRequestServiceTierKey = "openai.request.service_tier";
+    public const string OpenAiResponseServiceTierKey = "openai.response.service_tier";
 }

--- a/OpenAI/src/Utility/Telemetry/OpenTelemetryScope.cs
+++ b/OpenAI/src/Utility/Telemetry/OpenTelemetryScope.cs
@@ -22,6 +22,7 @@ internal class OpenTelemetryScope : IDisposable
     private static readonly Histogram<long> s_chatTokens = CreateTokenHistogram(s_chatMeter);
     private static readonly Histogram<double> s_responsesDuration = CreateDurationHistogram(s_responsesMeter);
     private static readonly Histogram<long> s_responsesTokens = CreateTokenHistogram(s_responsesMeter);
+    private static readonly ResponseItemKind s_compactionItemKind = new("compaction");
 
     private readonly ActivitySource _activitySource;
     private readonly Histogram<double> _durationHistogram;
@@ -143,7 +144,7 @@ internal class OpenTelemetryScope : IDisposable
                 SetActivityTagIfNotNull(OpenAiResponseServiceTierKey, responseServiceTier);
                 SetActivityTagIfNotNull(GenAiUsageCacheReadInputTokensKey, response.Usage?.InputTokenDetails?.CachedTokenCount);
                 SetActivityTagIfNotNull(GenAiUsageReasoningOutputTokensKey, response.Usage?.OutputTokenDetails?.ReasoningTokenCount);
-                if (response.OutputItems.Any(item => string.Equals(item.Kind.ToString(), "compaction", StringComparison.Ordinal)))
+                if (response.OutputItems.Any(item => item?.Kind == s_compactionItemKind))
                 {
                     _activity.SetTag(GenAiConversationCompactedKey, true);
                 }
@@ -188,7 +189,7 @@ internal class OpenTelemetryScope : IDisposable
         return meter.CreateHistogram<long>(
             GenAiClientTokenUsageMetricName,
             "{token}",
-            "Measures the number of input and output token used.",
+            "Measures the number of input and output tokens used.",
             advice: new InstrumentAdvice<long>
             {
                 HistogramBucketBoundaries = [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864],
@@ -227,8 +228,8 @@ internal class OpenTelemetryScope : IDisposable
         _activity = _activitySource.StartActivity(
             activityName,
             ActivityKind.Client,
-            Activity.Current?.Context ?? default,
-            activityTags);
+            parentContext: default,
+            tags: activityTags);
     }
 
     private void RecordChatRequestAttributes(ChatCompletionOptions options)
@@ -361,8 +362,28 @@ internal class OpenTelemetryScope : IDisposable
     {
         if (response.Status == ResponseStatus.Failed)
         {
-            var errorType = response.Error?.Code.ToString();
-            return string.IsNullOrEmpty(errorType) ? "failed" : errorType;
+            return response.Error?.Code.ToString() switch
+            {
+                "server_error" => "server_error",
+                "rate_limit_exceeded" => "rate_limit_exceeded",
+                "invalid_prompt" => "invalid_prompt",
+                "vector_store_timeout" => "vector_store_timeout",
+                "invalid_image" => "invalid_image",
+                "invalid_image_format" => "invalid_image_format",
+                "invalid_base64_image" => "invalid_base64_image",
+                "invalid_image_url" => "invalid_image_url",
+                "image_too_large" => "image_too_large",
+                "image_too_small" => "image_too_small",
+                "image_parse_error" => "image_parse_error",
+                "image_content_policy_violation" => "image_content_policy_violation",
+                "invalid_image_mode" => "invalid_image_mode",
+                "image_file_too_large" => "image_file_too_large",
+                "unsupported_image_media_type" => "unsupported_image_media_type",
+                "empty_image_file" => "empty_image_file",
+                "failed_to_download_image" => "failed_to_download_image",
+                "image_file_not_found" => "image_file_not_found",
+                _ => "failed",
+            };
         }
         if (response.Status == ResponseStatus.Cancelled)
         {

--- a/OpenAI/src/Utility/Telemetry/OpenTelemetryScope.cs
+++ b/OpenAI/src/Utility/Telemetry/OpenTelemetryScope.cs
@@ -1,8 +1,11 @@
 ﻿using OpenAI.Chat;
+using OpenAI.Responses;
 using System;
 using System.ClientModel;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Linq;
 
 using static OpenAI.Telemetry.OpenTelemetryConstants;
 
@@ -12,101 +15,154 @@ internal class OpenTelemetryScope : IDisposable
 {
     private static readonly ActivitySource s_chatSource = new ActivitySource("OpenAI.ChatClient");
     private static readonly Meter s_chatMeter = new Meter("OpenAI.ChatClient");
+    private static readonly ActivitySource s_responsesSource = new ActivitySource("OpenAI.ResponsesClient");
+    private static readonly Meter s_responsesMeter = new Meter("OpenAI.ResponsesClient");
 
-    private static readonly Histogram<double> s_duration = s_chatMeter.CreateHistogram<double>(
-        GenAiClientOperationDurationMetricName,
-        "s",
-        "Measures GenAI operation duration.",
-        advice: new InstrumentAdvice<double>
-        {
-            HistogramBucketBoundaries = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92],
-        });
-    private static readonly Histogram<long> s_tokens = s_chatMeter.CreateHistogram<long>(
-        GenAiClientTokenUsageMetricName,
-        "{token}",
-        "Measures the number of input and output token used.",
-        advice: new InstrumentAdvice<long>
-        {
-            HistogramBucketBoundaries = [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864],
-        });
+    private static readonly Histogram<double> s_chatDuration = CreateDurationHistogram(s_chatMeter);
+    private static readonly Histogram<long> s_chatTokens = CreateTokenHistogram(s_chatMeter);
+    private static readonly Histogram<double> s_responsesDuration = CreateDurationHistogram(s_responsesMeter);
+    private static readonly Histogram<long> s_responsesTokens = CreateTokenHistogram(s_responsesMeter);
 
+    private readonly ActivitySource _activitySource;
+    private readonly Histogram<double> _durationHistogram;
+    private readonly Histogram<long> _tokenHistogram;
     private readonly string _operationName;
     private readonly string _serverAddress;
     private readonly int _serverPort;
     private readonly string _requestModel;
+    private readonly bool _useLatestSemanticConventions;
+    private readonly bool _includeErrorDescription;
 
     private Stopwatch _duration;
     private Activity _activity;
     private TagList _commonTags;
 
     private OpenTelemetryScope(
-        string model, string operationName,
-        string serverAddress, int serverPort)
+        ActivitySource activitySource,
+        Histogram<double> durationHistogram,
+        Histogram<long> tokenHistogram,
+        string model,
+        string operationName,
+        string serverAddress,
+        int serverPort,
+        bool useLatestSemanticConventions = false,
+        bool includeErrorDescription = true)
     {
+        _activitySource = activitySource;
+        _durationHistogram = durationHistogram;
+        _tokenHistogram = tokenHistogram;
         _requestModel = model;
         _operationName = operationName;
         _serverAddress = serverAddress;
         _serverPort = serverPort;
+        _useLatestSemanticConventions = useLatestSemanticConventions;
+        _includeErrorDescription = includeErrorDescription;
     }
 
-    private static bool IsChatEnabled => s_chatSource.HasListeners() || s_tokens.Enabled || s_duration.Enabled;
-
-    public static OpenTelemetryScope StartChat(string model, string operationName,
-        string serverAddress, int serverPort, ChatCompletionOptions options,
+    public static OpenTelemetryScope StartChat(
+        string model,
+        string operationName,
+        string serverAddress,
+        int serverPort,
+        ChatCompletionOptions options,
         string providerAttributeKey)
     {
-        if (IsChatEnabled)
+        if (!IsEnabled(s_chatSource, s_chatTokens, s_chatDuration))
         {
-            var scope = new OpenTelemetryScope(model, operationName, serverAddress, serverPort);
-            scope.StartChat(options, providerAttributeKey);
-            return scope;
+            return null;
         }
 
-        return null;
+        var scope = new OpenTelemetryScope(
+            s_chatSource,
+            s_chatDuration,
+            s_chatTokens,
+            model,
+            operationName,
+            serverAddress,
+            serverPort);
+        scope.Start(providerAttributeKey);
+        scope.RecordChatRequestAttributes(options);
+        return scope;
     }
 
-    private void StartChat(ChatCompletionOptions options, string providerAttributeKey)
+    public static OpenTelemetryScope StartResponses(
+        string model,
+        string operationName,
+        string serverAddress,
+        int serverPort,
+        CreateResponseOptions options,
+        string providerAttributeKey,
+        bool useLatestSemanticConventions)
     {
-        _duration = Stopwatch.StartNew();
-        _commonTags = new TagList
+        if (!IsEnabled(s_responsesSource, s_responsesTokens, s_responsesDuration))
         {
-            { providerAttributeKey, GenAiSystemValue },
-            { GenAiRequestModelKey, _requestModel },
-            { ServerAddressKey, _serverAddress },
-            { ServerPortKey, _serverPort },
-            { GenAiOperationNameKey, _operationName },
-        };
-
-        _activity = s_chatSource.StartActivity(string.Concat(_operationName, " ", _requestModel), ActivityKind.Client);
-        if (_activity?.IsAllDataRequested == true)
-        {
-            RecordCommonAttributes();
-            SetActivityTagIfNotNull(GenAiRequestMaxTokensKey, options?.MaxOutputTokenCount);
-            SetActivityTagIfNotNull(GenAiRequestTemperatureKey, options?.Temperature);
-            SetActivityTagIfNotNull(GenAiRequestTopPKey, options?.TopP);
+            return null;
         }
 
-        return;
+        var scope = new OpenTelemetryScope(
+            s_responsesSource,
+            s_responsesDuration,
+            s_responsesTokens,
+            model,
+            operationName,
+            serverAddress,
+            serverPort,
+            useLatestSemanticConventions,
+            includeErrorDescription: false);
+        scope.Start(
+            providerAttributeKey,
+            useLatestSemanticConventions ? OpenAiApiTypeResponsesValue : null);
+        scope.RecordResponsesRequestAttributes(options, useLatestSemanticConventions);
+        return scope;
     }
 
     public void RecordChatCompletion(ChatCompletion completion)
     {
-        RecordMetrics(completion.Model, null, completion.Usage?.InputTokenCount, completion.Usage?.OutputTokenCount);
+        RecordMetrics(completion.Model, null, null, completion.Usage?.InputTokenCount, completion.Usage?.OutputTokenCount);
 
         if (_activity?.IsAllDataRequested == true)
         {
-            RecordResponseAttributes(completion.Id, completion.Model, completion.FinishReason, completion.Usage);
+            RecordResponseAttributes(completion.Id, completion.Model, completion.Usage?.InputTokenCount, completion.Usage?.OutputTokenCount);
+            SetChatFinishReasonAttribute(completion.FinishReason);
+        }
+    }
+
+    public void RecordResponseResult(ResponseResult response)
+    {
+        var errorType = GetResponseErrorType(response);
+        var responseServiceTier = _useLatestSemanticConventions ? response.ServiceTier?.ToString() : null;
+        RecordMetrics(response.Model, responseServiceTier, errorType, response.Usage?.InputTokenCount, response.Usage?.OutputTokenCount);
+
+        if (_activity?.IsAllDataRequested == true)
+        {
+            RecordResponseAttributes(response.Id, response.Model, response.Usage?.InputTokenCount, response.Usage?.OutputTokenCount);
+            SetResponseFinishReasonAttribute(response);
+
+            if (_useLatestSemanticConventions)
+            {
+                SetActivityTagIfNotNull(OpenAiResponseServiceTierKey, responseServiceTier);
+                SetActivityTagIfNotNull(GenAiUsageCacheReadInputTokensKey, response.Usage?.InputTokenDetails?.CachedTokenCount);
+                SetActivityTagIfNotNull(GenAiUsageReasoningOutputTokensKey, response.Usage?.OutputTokenDetails?.ReasoningTokenCount);
+                if (response.OutputItems.Any(item => string.Equals(item.Kind.ToString(), "compaction", StringComparison.Ordinal)))
+                {
+                    _activity.SetTag(GenAiConversationCompactedKey, true);
+                }
+            }
+
+            if (errorType != null)
+            {
+                RecordError(errorType, null);
+            }
         }
     }
 
     public void RecordException(Exception ex)
     {
         var errorType = GetErrorType(ex);
-        RecordMetrics(null, errorType, null, null);
+        RecordMetrics(null, null, errorType, null, null);
         if (_activity?.IsAllDataRequested == true)
         {
-            _activity?.SetTag(OpenTelemetryConstants.ErrorTypeKey, errorType);
-            _activity?.SetStatus(ActivityStatusCode.Error, ex?.Message ?? errorType);
+            RecordError(errorType, _includeErrorDescription ? ex?.Message : null);
         }
     }
 
@@ -115,36 +171,135 @@ internal class OpenTelemetryScope : IDisposable
         _activity?.Stop();
     }
 
-    private void RecordCommonAttributes()
+    private static Histogram<double> CreateDurationHistogram(Meter meter)
     {
-        foreach (var tag in _commonTags)
+        return meter.CreateHistogram<double>(
+            GenAiClientOperationDurationMetricName,
+            "s",
+            "Measures GenAI operation duration.",
+            advice: new InstrumentAdvice<double>
+            {
+                HistogramBucketBoundaries = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92],
+            });
+    }
+
+    private static Histogram<long> CreateTokenHistogram(Meter meter)
+    {
+        return meter.CreateHistogram<long>(
+            GenAiClientTokenUsageMetricName,
+            "{token}",
+            "Measures the number of input and output token used.",
+            advice: new InstrumentAdvice<long>
+            {
+                HistogramBucketBoundaries = [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864],
+            });
+    }
+
+    private static bool IsEnabled(ActivitySource activitySource, Histogram<long> tokens, Histogram<double> duration)
+    {
+        return activitySource.HasListeners() || tokens.Enabled || duration.Enabled;
+    }
+
+    private void Start(string providerAttributeKey, string openAiApiType = null)
+    {
+        _duration = Stopwatch.StartNew();
+        _commonTags = new TagList
         {
-            _activity.SetTag(tag.Key, tag.Value);
+            { providerAttributeKey, GenAiSystemValue },
+            { ServerAddressKey, _serverAddress },
+            { ServerPortKey, _serverPort },
+            { GenAiOperationNameKey, _operationName },
+        };
+        if (!string.IsNullOrEmpty(_requestModel))
+        {
+            _commonTags.Add(GenAiRequestModelKey, _requestModel);
+        }
+
+        var activityTags = _commonTags;
+        if (openAiApiType != null)
+        {
+            activityTags.Add(OpenAiApiTypeKey, openAiApiType);
+        }
+
+        var activityName = string.IsNullOrEmpty(_requestModel)
+            ? _operationName
+            : string.Concat(_operationName, " ", _requestModel);
+        _activity = _activitySource.StartActivity(
+            activityName,
+            ActivityKind.Client,
+            Activity.Current?.Context ?? default,
+            activityTags);
+    }
+
+    private void RecordChatRequestAttributes(ChatCompletionOptions options)
+    {
+        if (_activity?.IsAllDataRequested == true)
+        {
+            SetActivityTagIfNotNull(GenAiRequestMaxTokensKey, options?.MaxOutputTokenCount);
+            SetActivityTagIfNotNull(GenAiRequestTemperatureKey, options?.Temperature);
+            SetActivityTagIfNotNull(GenAiRequestTopPKey, options?.TopP);
         }
     }
 
-    private void RecordMetrics(string responseModel, string errorType, int? inputTokensUsage, int? outputTokensUsage)
+    private void RecordResponsesRequestAttributes(CreateResponseOptions options, bool useLatestSemanticConventions)
     {
-        // tags is a struct, let's copy and modify them
+        if (_activity?.IsAllDataRequested != true)
+        {
+            return;
+        }
+
+        SetActivityTagIfNotNull(GenAiRequestMaxTokensKey, options?.MaxOutputTokenCount);
+        SetActivityTagIfNotNull(GenAiRequestTemperatureKey, options?.Temperature);
+        SetActivityTagIfNotNull(GenAiRequestTopPKey, options?.TopP);
+
+        if (!useLatestSemanticConventions)
+        {
+            return;
+        }
+
+        SetActivityTagIfNotNull(GenAiRequestPreviousResponseIdKey, options?.PreviousResponseId);
+        SetActivityTagIfNotNull(GenAiConversationIdKey, options?.ConversationOptions?.ConversationId);
+        SetActivityTagIfNotNull(GenAiRequestReasoningLevelKey, options?.ReasoningOptions?.ReasoningEffortLevel?.ToString());
+
+        if (options?.ServiceTier is ResponseServiceTier serviceTier && serviceTier != ResponseServiceTier.Auto)
+        {
+            SetActivityTagIfNotNull(OpenAiRequestServiceTierKey, serviceTier.ToString());
+        }
+
+        var outputType = options?.TextOptions?.TextFormat?.Kind switch
+        {
+            ResponseTextFormatKind.Text => "text",
+            ResponseTextFormatKind.JsonObject or ResponseTextFormatKind.JsonSchema => "json",
+            _ => null,
+        };
+        SetActivityTagIfNotNull(GenAiOutputTypeKey, outputType);
+    }
+
+    private void RecordMetrics(string responseModel, string responseServiceTier, string errorType, int? inputTokensUsage, int? outputTokensUsage)
+    {
         var tags = _commonTags;
 
         if (responseModel != null)
         {
             tags.Add(GenAiResponseModelKey, responseModel);
         }
+        if (responseServiceTier != null)
+        {
+            tags.Add(OpenAiResponseServiceTierKey, responseServiceTier);
+        }
 
         if (inputTokensUsage != null)
         {
             var inputUsageTags = tags;
             inputUsageTags.Add(GenAiTokenTypeKey, "input");
-            s_tokens.Record(inputTokensUsage.Value, inputUsageTags);
+            _tokenHistogram.Record(inputTokensUsage.Value, inputUsageTags);
         }
 
         if (outputTokensUsage != null)
         {
             var outputUsageTags = tags;
             outputUsageTags.Add(GenAiTokenTypeKey, "output");
-            s_tokens.Record(outputTokensUsage.Value, outputUsageTags);
+            _tokenHistogram.Record(outputTokensUsage.Value, outputUsageTags);
         }
 
         if (errorType != null)
@@ -152,19 +307,18 @@ internal class OpenTelemetryScope : IDisposable
             tags.Add(ErrorTypeKey, errorType);
         }
 
-        s_duration.Record(_duration.Elapsed.TotalSeconds, tags);
+        _durationHistogram.Record(_duration.Elapsed.TotalSeconds, tags);
     }
 
-    private void RecordResponseAttributes(string responseId, string model, ChatFinishReason? finishReason, ChatTokenUsage usage)
+    private void RecordResponseAttributes(string responseId, string model, int? inputTokenCount, int? outputTokenCount)
     {
         SetActivityTagIfNotNull(GenAiResponseIdKey, responseId);
         SetActivityTagIfNotNull(GenAiResponseModelKey, model);
-        SetActivityTagIfNotNull(GenAiUsageInputTokensKey, usage?.InputTokenCount);
-        SetActivityTagIfNotNull(GenAiUsageOutputTokensKey, usage?.OutputTokenCount);
-        SetFinishReasonAttribute(finishReason);
+        SetActivityTagIfNotNull(GenAiUsageInputTokensKey, inputTokenCount);
+        SetActivityTagIfNotNull(GenAiUsageOutputTokensKey, outputTokenCount);
     }
 
-    private void SetFinishReasonAttribute(ChatFinishReason? finishReason)
+    private void SetChatFinishReasonAttribute(ChatFinishReason? finishReason)
     {
         if (finishReason == null)
         {
@@ -186,16 +340,49 @@ internal class OpenTelemetryScope : IDisposable
         _activity.SetTag(GenAiResponseFinishReasonKey, new[] { reasonStr });
     }
 
-    private string GetChatMessageRole(ChatMessageRole? role) =>
-        role switch
+    private void SetResponseFinishReasonAttribute(ResponseResult response)
+    {
+        var reason = response.Status switch
         {
-            ChatMessageRole.Assistant => "assistant",
-            ChatMessageRole.Function => "function",
-            ChatMessageRole.System => "system",
-            ChatMessageRole.Tool => "tool",
-            ChatMessageRole.User => "user",
-            _ => role?.ToString(),
+            ResponseStatus.Completed => "stop",
+            ResponseStatus.Failed or ResponseStatus.Cancelled => "error",
+            ResponseStatus.Incomplete when response.IncompleteStatusDetails?.Reason == ResponseIncompleteStatusReason.MaxOutputTokens => "length",
+            ResponseStatus.Incomplete when response.IncompleteStatusDetails?.Reason == ResponseIncompleteStatusReason.ContentFilter => "content_filter",
+            ResponseStatus.Incomplete => "incomplete",
+            _ => null,
         };
+        if (reason != null)
+        {
+            _activity.SetTag(GenAiResponseFinishReasonKey, new[] { reason });
+        }
+    }
+
+    private static string GetResponseErrorType(ResponseResult response)
+    {
+        if (response.Status == ResponseStatus.Failed)
+        {
+            var errorType = response.Error?.Code.ToString();
+            return string.IsNullOrEmpty(errorType) ? "failed" : errorType;
+        }
+        if (response.Status == ResponseStatus.Cancelled)
+        {
+            return "cancelled";
+        }
+        return null;
+    }
+
+    private void RecordError(string errorType, string description)
+    {
+        _activity.SetTag(ErrorTypeKey, errorType);
+        if (description is null)
+        {
+            _activity.SetStatus(ActivityStatusCode.Error);
+        }
+        else
+        {
+            _activity.SetStatus(ActivityStatusCode.Error, description);
+        }
+    }
 
     private string GetErrorType(Exception exception)
     {

--- a/OpenAI/src/Utility/Telemetry/OpenTelemetryScope.cs
+++ b/OpenAI/src/Utility/Telemetry/OpenTelemetryScope.cs
@@ -22,6 +22,7 @@ internal class OpenTelemetryScope : IDisposable
     private static readonly Histogram<long> s_chatTokens = CreateTokenHistogram(s_chatMeter);
     private static readonly Histogram<double> s_responsesDuration = CreateDurationHistogram(s_responsesMeter);
     private static readonly Histogram<long> s_responsesTokens = CreateTokenHistogram(s_responsesMeter);
+    // Telemetry sources are linked into tests, where the generated internal ResponseItemKind.Compaction is unavailable.
     private static readonly ResponseItemKind s_compactionItemKind = new("compaction");
 
     private readonly ActivitySource _activitySource;

--- a/OpenAI/src/Utility/Telemetry/OpenTelemetrySource.cs
+++ b/OpenAI/src/Utility/Telemetry/OpenTelemetrySource.cs
@@ -1,4 +1,5 @@
 ﻿using OpenAI.Chat;
+using OpenAI.Responses;
 using System;
 
 namespace OpenAI.Telemetry;
@@ -9,19 +10,26 @@ internal class OpenTelemetrySource
     private readonly bool IsOTelEnabled = AppContextSwitchHelper
         .GetConfigValue("OpenAI.Experimental.EnableOpenTelemetry", "OPENAI_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY");
 
-    private readonly string _providerAttributeKey = OpenTelemetrySemanticConventionStabilityOptIn.IsLatestGenAiSemanticConventionEnabled
-        ? OpenTelemetryConstants.GenAiProviderNameKey
-        : OpenTelemetryConstants.GenAiSystemKey;
-
+    private readonly string _providerAttributeKey;
     private readonly string _serverAddress;
     private readonly int _serverPort;
     private readonly string _model;
+    private readonly bool _useLatestSemanticConventions;
 
     public OpenTelemetrySource(string model, Uri endpoint)
     {
+        _useLatestSemanticConventions = OpenTelemetrySemanticConventionStabilityOptIn.IsLatestGenAiSemanticConventionEnabled;
+        _providerAttributeKey = _useLatestSemanticConventions
+            ? OpenTelemetryConstants.GenAiProviderNameKey
+            : OpenTelemetryConstants.GenAiSystemKey;
         _serverAddress = endpoint.Host;
         _serverPort = endpoint.Port;
         _model = model;
+    }
+
+    public OpenTelemetrySource(Uri endpoint)
+        : this(null, endpoint)
+    {
     }
 
     public OpenTelemetryScope StartChatScope(ChatCompletionOptions completionsOptions)
@@ -31,4 +39,10 @@ internal class OpenTelemetrySource
             : null;
     }
 
+    public OpenTelemetryScope StartResponsesScope(CreateResponseOptions options)
+    {
+        return IsOTelEnabled
+            ? OpenTelemetryScope.StartResponses(options?.Model, ChatOperationName, _serverAddress, _serverPort, options, _providerAttributeKey, _useLatestSemanticConventions)
+            : null;
+    }
 }

--- a/docs/Observability.md
+++ b/docs/Observability.md
@@ -6,7 +6,7 @@
 OpenAI .NET library is instrumented with distributed tracing and metrics using .NET [tracing](https://learn.microsoft.com/dotnet/core/diagnostics/distributed-tracing)
 and [metrics](https://learn.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation) API and supports [OpenTelemetry](https://learn.microsoft.com/dotnet/core/diagnostics/observability-with-otel).
 
-OpenAI .NET instrumentation follows [OpenTelemetry Semantic Conventions for Generative AI systems](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai).
+OpenAI .NET instrumentation follows [OpenTelemetry Semantic Conventions for Generative AI systems](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/docs/gen-ai).
 
 ### How to enable
 
@@ -65,6 +65,7 @@ When this opt-in is enabled, the instrumentation emits attributes following the
 Notable changes include:
 
 - The `gen_ai.system` attribute is replaced by `gen_ai.provider.name`.
+- Responses telemetry identifies the API with `openai.api.type=responses` and records available response, conversation, service-tier, reasoning, output-type, and detailed token-usage attributes.
 
 The default behavior (without the opt-in) remains unchanged and continues to emit v1.27.0 conventions.
 
@@ -73,6 +74,13 @@ The default behavior (without the opt-in) remains unchanged and continues to emi
 The following sources and meters are available:
 
 - `OpenAI.ChatClient` - records traces and metrics for `ChatClient` operations (except streaming and protocol methods which are not instrumented yet)
+- `OpenAI.ResponsesClient` - records traces and metrics for non-streaming `CreateResponse` operations. Streaming, protocol, retrieval, cancellation, deletion, and input-item methods are not instrumented yet.
+
+### OpenTelemetry data and privacy
+
+Responses OpenTelemetry instrumentation records operational details such as model names, response and conversation identifiers, service tiers, token counts, finish reasons, and errors.
+
+Responses instrumentation does not record prompts, generated output, instructions, tool definitions, tool arguments or results, metadata, safety identifiers, end-user identifiers, prompt cache keys, or multimodal payloads. The OpenTelemetry GenAI semantic conventions classify content attributes as opt-in. Enabling this library's experimental OpenTelemetry instrumentation does not opt in to content capture.
 
 ## Telemetry and privacy
 

--- a/tests/Telemetry/ResponsesTelemetryTests.cs
+++ b/tests/Telemetry/ResponsesTelemetryTests.cs
@@ -251,6 +251,30 @@ public class ResponsesTelemetryTests
         Assert.That(tags["openai.api.type"], Is.EqualTo("responses"));
     }
 
+    [TestCase(ActivityIdFormat.W3C)]
+    [TestCase(ActivityIdFormat.Hierarchical)]
+    public void ActivityPreservesAmbientParent(ActivityIdFormat parentIdFormat)
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var parent = new Activity("parent")
+            .SetIdFormat(parentIdFormat)
+            .AddBaggage("baggage-key", "baggage-value")
+            .Start();
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+
+        using (var scope = telemetry.StartResponsesScope(CreateOptions()))
+        {
+            Assert.That(scope, Is.Not.Null);
+            Assert.That(Activity.Current?.Parent, Is.SameAs(parent));
+        }
+
+        Assert.That(Activity.Current, Is.SameAs(parent));
+        var activity = activityListener.Activities.Single();
+        Assert.That(activity.Parent, Is.SameAs(parent));
+        Assert.That(activity.GetBaggageItem("baggage-key"), Is.EqualTo("baggage-value"));
+    }
+
     [TestCase(false)]
     [TestCase(true)]
     public void MissingRequestModelEmitsTelemetry(bool useLatestSemanticConventions)
@@ -277,6 +301,26 @@ public class ResponsesTelemetryTests
         Assert.That(usage, Has.Count.EqualTo(2));
         Assert.That(usage.All(measurement => !measurement.tags.ContainsKey("gen_ai.request.model")), Is.True);
         Assert.That(usage.All(measurement => measurement.tags["gen_ai.response.model"].Equals(ResponseModel)), Is.True);
+    }
+
+    [Test]
+    public void UnknownResponseErrorCodeUsesStableFallback()
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+        var response = CreateResponseResult("failed", null, "request-specific-error");
+
+        using (var scope = telemetry.StartResponsesScope(CreateOptions()))
+        {
+            scope.RecordResponseResult(response);
+        }
+
+        var activity = activityListener.Activities.Single();
+        Assert.That(activity.GetTagItem("error.type"), Is.EqualTo("failed"));
+        var duration = meterListener.GetMeasurements("gen_ai.client.operation.duration").Single();
+        Assert.That(duration.tags["error.type"], Is.EqualTo("failed"));
     }
 
     [Test]
@@ -352,10 +396,10 @@ public class ResponsesTelemetryTests
         return options;
     }
 
-    private static ResponseResult CreateResponseResult(string status, string incompleteReason)
+    private static ResponseResult CreateResponseResult(string status, string incompleteReason, string errorCode = "server_error")
     {
         var error = status == "failed"
-            ? "\"error\":{\"code\":\"server_error\",\"message\":\"synthetic failure\",\"param\":null,\"type\":\"server_error\"},"
+            ? $"\"error\":{{\"code\":\"{errorCode}\",\"message\":\"synthetic failure\",\"param\":null,\"type\":\"server_error\"}},"
             : "\"error\":null,";
         var incompleteDetails = incompleteReason is null
             ? "\"incomplete_details\":null,"
@@ -471,9 +515,10 @@ public class ResponsesTelemetryTests
               ],
               "role": "assistant"
             },
+            null,
             {
               "id": "cmp_synthetic",
-              "type": "compaction",
+              "type": "COMPACTION",
               "encrypted_content": "sensitive compaction content"
             }
           ],

--- a/tests/Telemetry/ResponsesTelemetryTests.cs
+++ b/tests/Telemetry/ResponsesTelemetryTests.cs
@@ -1,0 +1,504 @@
+using Microsoft.ClientModel.TestFramework.Mocks;
+using NUnit.Framework;
+using OpenAI.Responses;
+using OpenAI.Telemetry;
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OpenAI.Tests.Telemetry;
+
+#pragma warning disable OPENAI001
+
+[TestFixture]
+[NonParallelizable]
+[Category("Telemetry")]
+[Category("Smoke")]
+public class ResponsesTelemetryTests
+{
+    private const string ActivitySourceName = "OpenAI.ResponsesClient";
+    private const string RequestModel = "request-model";
+    private const string ResponseModel = "response-model";
+    private const string ResponseId = "resp_synthetic";
+    private const string PreviousResponseId = "resp_previous";
+    private const string ConversationId = "conv_synthetic";
+    private const string Host = "example.invalid";
+    private const string SensitiveInput = "sensitive input";
+    private const int Port = 443;
+    private const int InputTokens = 12;
+    private const int OutputTokens = 34;
+    private static readonly Uri s_endpoint = new($"https://{Host}");
+
+    [Test]
+    public void AllTelemetryOff()
+    {
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+
+        Assert.That(telemetry.StartResponsesScope(CreateOptions()), Is.Null);
+        Assert.That(Activity.Current, Is.Null);
+    }
+
+    [Test]
+    public void SwitchOffAllTelemetryOn()
+    {
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+
+        Assert.That(telemetry.StartResponsesScope(CreateOptions()), Is.Null);
+        Assert.That(Activity.Current, Is.Null);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void MetricsEnabledWithoutTracingEmitsMeasurements(bool useLatestSemanticConventions)
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var _semanticConvention = TestSemanticConventionOptIn.SetLatestGenAiSemanticConvention(useLatestSemanticConventions);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+
+        using (var scope = telemetry.StartResponsesScope(CreateOptions()))
+        {
+            Assert.That(scope, Is.Not.Null);
+            Assert.That(Activity.Current, Is.Null);
+            scope.RecordResponseResult(CreateResponseResult("completed", null));
+        }
+
+        AssertMetrics(meterListener, useLatestSemanticConventions);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void TracingEnabledWithoutMetricsEmitsActivity(bool useLatestSemanticConventions)
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var _semanticConvention = TestSemanticConventionOptIn.SetLatestGenAiSemanticConvention(useLatestSemanticConventions);
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+
+        using (var scope = telemetry.StartResponsesScope(CreateOptions()))
+        {
+            Assert.That(scope, Is.Not.Null);
+            Assert.That(Activity.Current, Is.Not.Null);
+            scope.RecordResponseResult(CreateResponseResult("completed", null));
+        }
+
+        Assert.That(Activity.Current, Is.Null);
+        var activity = activityListener.Activities.Single();
+        Assert.That(activity.DisplayName, Is.EqualTo($"chat {RequestModel}"));
+        Assert.That(activity.GetTagItem("gen_ai.operation.name"), Is.EqualTo("chat"));
+        Assert.That(activity.GetTagItem("gen_ai.request.model"), Is.EqualTo(RequestModel));
+        Assert.That(activity.GetTagItem("gen_ai.request.max_tokens"), Is.EqualTo(100));
+        Assert.That(activity.GetTagItem("gen_ai.response.id"), Is.EqualTo(ResponseId));
+        Assert.That(activity.GetTagItem("gen_ai.response.model"), Is.EqualTo(ResponseModel));
+        Assert.That(activity.GetTagItem("gen_ai.response.finish_reasons"), Is.EqualTo(new[] { "stop" }));
+        Assert.That(activity.GetTagItem("gen_ai.usage.input_tokens"), Is.EqualTo(InputTokens));
+        Assert.That(activity.GetTagItem("gen_ai.usage.output_tokens"), Is.EqualTo(OutputTokens));
+        AssertProviderAttribute(activity, useLatestSemanticConventions);
+    }
+
+    [TestCase(false, false)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(true, true)]
+    public async Task CreateResponseEmitsTelemetry(bool useAsync, bool useLatestSemanticConventions)
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var _semanticConvention = TestSemanticConventionOptIn.SetLatestGenAiSemanticConvention(useLatestSemanticConventions);
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var client = CreateClient(CompletedResponseBody, useAsync: useAsync);
+        var options = CreateOptions();
+
+        var result = useAsync
+            ? await client.CreateResponseAsync(options)
+            : client.CreateResponse(options);
+
+        Assert.That(result.Value.Id, Is.EqualTo(ResponseId));
+        Assert.That(activityListener.Activities, Has.Count.EqualTo(1));
+
+        var activity = activityListener.Activities.Single();
+        Assert.That(activity.DisplayName, Is.EqualTo($"chat {RequestModel}"));
+        Assert.That(activity.GetTagItem("gen_ai.operation.name"), Is.EqualTo("chat"));
+        Assert.That(activity.GetTagItem("gen_ai.request.model"), Is.EqualTo(RequestModel));
+        Assert.That(activity.GetTagItem("server.address"), Is.EqualTo(Host));
+        Assert.That(activity.GetTagItem("server.port"), Is.EqualTo(Port));
+        Assert.That(activity.GetTagItem("gen_ai.request.max_tokens"), Is.EqualTo(100));
+        Assert.That(activity.GetTagItem("gen_ai.request.temperature"), Is.EqualTo(0.4f));
+        Assert.That(activity.GetTagItem("gen_ai.request.top_p"), Is.EqualTo(0.8f));
+        Assert.That(activity.GetTagItem("gen_ai.response.id"), Is.EqualTo(ResponseId));
+        Assert.That(activity.GetTagItem("gen_ai.response.model"), Is.EqualTo(ResponseModel));
+        Assert.That(activity.GetTagItem("gen_ai.response.finish_reasons"), Is.EqualTo(new[] { "stop" }));
+        Assert.That(activity.GetTagItem("gen_ai.usage.input_tokens"), Is.EqualTo(InputTokens));
+        Assert.That(activity.GetTagItem("gen_ai.usage.output_tokens"), Is.EqualTo(OutputTokens));
+        Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Unset));
+        AssertProviderAttribute(activity, useLatestSemanticConventions);
+
+        if (useLatestSemanticConventions)
+        {
+            Assert.That(activity.GetTagItem("openai.api.type"), Is.EqualTo("responses"));
+            Assert.That(activity.GetTagItem("gen_ai.request.previous_response.id"), Is.EqualTo(PreviousResponseId));
+            Assert.That(activity.GetTagItem("gen_ai.conversation.id"), Is.EqualTo(ConversationId));
+            Assert.That(activity.GetTagItem("gen_ai.request.reasoning.level"), Is.EqualTo("high"));
+            Assert.That(activity.GetTagItem("gen_ai.output.type"), Is.EqualTo("json"));
+            Assert.That(activity.GetTagItem("openai.request.service_tier"), Is.EqualTo("flex"));
+            Assert.That(activity.GetTagItem("openai.response.service_tier"), Is.EqualTo("default"));
+            Assert.That(activity.GetTagItem("gen_ai.usage.cache_read.input_tokens"), Is.EqualTo(5));
+            Assert.That(activity.GetTagItem("gen_ai.usage.reasoning.output_tokens"), Is.EqualTo(7));
+            Assert.That(activity.GetTagItem("gen_ai.conversation.compacted"), Is.EqualTo(true));
+        }
+        else
+        {
+            Assert.That(activity.GetTagItem("openai.api.type"), Is.Null);
+            Assert.That(activity.GetTagItem("gen_ai.request.previous_response.id"), Is.Null);
+            Assert.That(activity.GetTagItem("gen_ai.conversation.id"), Is.Null);
+            Assert.That(activity.GetTagItem("gen_ai.request.reasoning.level"), Is.Null);
+            Assert.That(activity.GetTagItem("gen_ai.output.type"), Is.Null);
+            Assert.That(activity.GetTagItem("openai.request.service_tier"), Is.Null);
+            Assert.That(activity.GetTagItem("openai.response.service_tier"), Is.Null);
+            Assert.That(activity.GetTagItem("gen_ai.conversation.compacted"), Is.Null);
+        }
+
+        AssertSensitiveDataNotCaptured(activity);
+        AssertMetrics(meterListener, useLatestSemanticConventions);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void CreateResponseRecordsHttpErrors(bool useLatestSemanticConventions)
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var _semanticConvention = TestSemanticConventionOptIn.SetLatestGenAiSemanticConvention(useLatestSemanticConventions);
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var client = CreateClient(ErrorResponseBody, 400);
+
+        var exception = Assert.Throws<ClientResultException>(() => client.CreateResponse(CreateOptions()));
+
+        Assert.That(exception.Status, Is.EqualTo(400));
+        var activity = activityListener.Activities.Single();
+        Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Error));
+        Assert.That(activity.GetTagItem("error.type"), Is.EqualTo("400"));
+        Assert.That(activity.StatusDescription, Is.Null);
+        Assert.That(activity.TagObjects.Select(tag => tag.Value?.ToString()).Append(activity.StatusDescription), Does.Not.Contain("sensitive request failure"));
+        AssertProviderAttribute(activity, useLatestSemanticConventions);
+
+        var duration = meterListener.GetMeasurements("gen_ai.client.operation.duration").Single();
+        Assert.That(duration.tags["error.type"], Is.EqualTo("400"));
+        Assert.That(meterListener.GetMeasurements("gen_ai.client.token.usage"), Is.Null);
+    }
+
+    [TestCase("incomplete", "max_output_tokens", "length", null)]
+    [TestCase("incomplete", "content_filter", "content_filter", null)]
+    [TestCase("failed", null, "error", "server_error")]
+    [TestCase("cancelled", null, "error", "cancelled")]
+    [TestCase("incomplete", "future_reason", "incomplete", null)]
+    public void ResponseStatusIsMapped(string status, string incompleteReason, string finishReason, string errorType)
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var _semanticConvention = TestSemanticConventionOptIn.SetLatestGenAiSemanticConvention(true);
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+        var response = CreateResponseResult(status, incompleteReason);
+
+        using (var scope = telemetry.StartResponsesScope(CreateOptions()))
+        {
+            scope.RecordResponseResult(response);
+        }
+
+        var activity = activityListener.Activities.Single();
+        Assert.That(activity.GetTagItem("gen_ai.response.finish_reasons"), Is.EqualTo(new[] { finishReason }));
+        Assert.That(activity.GetTagItem("error.type"), Is.EqualTo(errorType));
+        Assert.That(activity.Status, Is.EqualTo(errorType is null ? ActivityStatusCode.Unset : ActivityStatusCode.Error));
+
+        var duration = meterListener.GetMeasurements("gen_ai.client.operation.duration").Single();
+        Assert.That(duration.tags.TryGetValue("error.type", out var actualErrorType), Is.EqualTo(errorType is not null));
+        Assert.That(actualErrorType, Is.EqualTo(errorType));
+    }
+
+    [Test]
+    public void RequiredAttributesAreAvailableToSampler()
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var _semanticConvention = TestSemanticConventionOptIn.SetLatestGenAiSemanticConvention(true);
+        IEnumerable<KeyValuePair<string, object>> creationTags = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
+            {
+                creationTags = options.Tags.ToArray();
+                return ActivitySamplingResult.AllDataAndRecorded;
+            },
+        };
+        ActivitySource.AddActivityListener(listener);
+        var telemetry = new OpenTelemetrySource(s_endpoint);
+
+        using (telemetry.StartResponsesScope(CreateOptions()))
+        {
+        }
+
+        var tags = creationTags.ToDictionary(tag => tag.Key, tag => tag.Value);
+        Assert.That(tags["gen_ai.provider.name"], Is.EqualTo("openai"));
+        Assert.That(tags["gen_ai.operation.name"], Is.EqualTo("chat"));
+        Assert.That(tags["gen_ai.request.model"], Is.EqualTo(RequestModel));
+        Assert.That(tags["openai.api.type"], Is.EqualTo("responses"));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void MissingRequestModelEmitsTelemetry(bool useLatestSemanticConventions)
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var _semanticConvention = TestSemanticConventionOptIn.SetLatestGenAiSemanticConvention(useLatestSemanticConventions);
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var client = CreateClient(CompletedResponseBody);
+
+        client.CreateResponse(new CreateResponseOptions());
+
+        var activity = activityListener.Activities.Single();
+        Assert.That(activity.DisplayName, Is.EqualTo("chat"));
+        Assert.That(activity.GetTagItem("gen_ai.request.model"), Is.Null);
+        Assert.That(activity.GetTagItem("gen_ai.response.model"), Is.EqualTo(ResponseModel));
+        AssertProviderAttribute(activity, useLatestSemanticConventions);
+
+        var duration = meterListener.GetMeasurements("gen_ai.client.operation.duration").Single();
+        Assert.That(duration.tags.ContainsKey("gen_ai.request.model"), Is.False);
+        Assert.That(duration.tags["gen_ai.response.model"], Is.EqualTo(ResponseModel));
+
+        var usage = meterListener.GetMeasurements("gen_ai.client.token.usage");
+        Assert.That(usage, Has.Count.EqualTo(2));
+        Assert.That(usage.All(measurement => !measurement.tags.ContainsKey("gen_ai.request.model")), Is.True);
+        Assert.That(usage.All(measurement => measurement.tags["gen_ai.response.model"].Equals(ResponseModel)), Is.True);
+    }
+
+    [Test]
+    public void ProtocolMethodIsNotInstrumented()
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var client = CreateClient(CompletedResponseBody);
+
+        client.CreateResponse(BinaryContent.Create(BinaryData.FromString("""{"model":"request-model","input":"hello"}""")));
+
+        Assert.That(activityListener.Activities, Is.Empty);
+        Assert.That(meterListener.GetMeasurements("gen_ai.client.operation.duration"), Is.Null);
+        Assert.That(meterListener.GetMeasurements("gen_ai.client.token.usage"), Is.Null);
+    }
+
+    [Test]
+    public void ConvenienceMethodEmitsSingleOperation()
+    {
+        using var _ = TestAppContextSwitchHelper.EnableOpenTelemetry();
+        using var activityListener = new TestActivityListener(ActivitySourceName);
+        using var meterListener = new TestMeterListener(ActivitySourceName);
+        var client = CreateClient(CompletedResponseBody);
+
+        client.CreateResponse(RequestModel, SensitiveInput);
+
+        Assert.That(activityListener.Activities, Has.Count.EqualTo(1));
+        Assert.That(meterListener.GetMeasurements("gen_ai.client.operation.duration"), Has.Count.EqualTo(1));
+        Assert.That(meterListener.GetMeasurements("gen_ai.client.token.usage"), Has.Count.EqualTo(2));
+    }
+
+    private static ResponsesClient CreateClient(string responseBody, int status = 200, bool useAsync = false)
+    {
+        var transport = new MockPipelineTransport(_ => new MockPipelineResponse(status).WithContent(responseBody))
+        {
+            ExpectSyncPipeline = !useAsync,
+        };
+        var options = new ResponsesClientOptions
+        {
+            Endpoint = s_endpoint,
+            Transport = transport,
+        };
+        return new ResponsesClient(new ApiKeyCredential("not-a-real-key"), options);
+    }
+
+    private static CreateResponseOptions CreateOptions()
+    {
+        var options = new CreateResponseOptions(RequestModel, [ResponseItem.CreateUserMessageItem(SensitiveInput)])
+        {
+            ConversationOptions = new ResponseConversationOptions
+            {
+                ConversationId = ConversationId,
+            },
+            EndUserId = "sensitive-user",
+            Instructions = "sensitive instructions",
+            MaxOutputTokenCount = 100,
+            PreviousResponseId = PreviousResponseId,
+            ReasoningOptions = new ResponseReasoningOptions
+            {
+                ReasoningEffortLevel = ResponseReasoningEffortLevel.High,
+            },
+            SafetyIdentifier = "sensitive-safety-id",
+            ServiceTier = ResponseServiceTier.Flex,
+            Temperature = 0.4f,
+            TextOptions = new ResponseTextOptions
+            {
+                TextFormat = ResponseTextFormat.CreateJsonObjectFormat(),
+            },
+            TopP = 0.8f,
+        };
+        options.Metadata["sensitive-key"] = "sensitive-value";
+        return options;
+    }
+
+    private static ResponseResult CreateResponseResult(string status, string incompleteReason)
+    {
+        var error = status == "failed"
+            ? "\"error\":{\"code\":\"server_error\",\"message\":\"synthetic failure\",\"param\":null,\"type\":\"server_error\"},"
+            : "\"error\":null,";
+        var incompleteDetails = incompleteReason is null
+            ? "\"incomplete_details\":null,"
+            : $"\"incomplete_details\":{{\"reason\":\"{incompleteReason}\"}},";
+
+        return ModelReaderWriter.Read<ResponseResult>(BinaryData.FromString(
+            $$"""
+            {
+              "id": "{{ResponseId}}",
+              "object": "response",
+              "created_at": 1,
+              "status": "{{status}}",
+              {{error}}
+              {{incompleteDetails}}
+              "model": "{{ResponseModel}}",
+              "output": [],
+              "parallel_tool_calls": false,
+              "service_tier": "default",
+              "tools": [],
+              "usage": {
+                "input_tokens": {{InputTokens}},
+                "input_tokens_details": {"cached_tokens": 5},
+                "output_tokens": {{OutputTokens}},
+                "output_tokens_details": {"reasoning_tokens": 7},
+                "total_tokens": 46
+              }
+            }
+            """));
+    }
+
+    private static void AssertProviderAttribute(Activity activity, bool useLatestSemanticConventions)
+    {
+        if (useLatestSemanticConventions)
+        {
+            Assert.That(activity.GetTagItem("gen_ai.provider.name"), Is.EqualTo("openai"));
+            Assert.That(activity.GetTagItem("gen_ai.system"), Is.Null);
+        }
+        else
+        {
+            Assert.That(activity.GetTagItem("gen_ai.system"), Is.EqualTo("openai"));
+            Assert.That(activity.GetTagItem("gen_ai.provider.name"), Is.Null);
+        }
+    }
+
+    private static void AssertSensitiveDataNotCaptured(Activity activity)
+    {
+        Assert.That(activity.GetTagItem("gen_ai.input.messages"), Is.Null);
+        Assert.That(activity.GetTagItem("gen_ai.output.messages"), Is.Null);
+        Assert.That(activity.GetTagItem("gen_ai.system_instructions"), Is.Null);
+        Assert.That(activity.GetTagItem("gen_ai.tool.definitions"), Is.Null);
+        Assert.That(activity.GetTagItem("user.id"), Is.Null);
+        var telemetryValues = activity.TagObjects.Select(tag => tag.Value?.ToString()).Append(activity.StatusDescription);
+        Assert.That(telemetryValues, Does.Not.Contain(SensitiveInput));
+        Assert.That(telemetryValues, Does.Not.Contain("sensitive output"));
+        Assert.That(telemetryValues, Does.Not.Contain("sensitive instructions"));
+        Assert.That(telemetryValues, Does.Not.Contain("sensitive-user"));
+        Assert.That(telemetryValues, Does.Not.Contain("sensitive-safety-id"));
+        Assert.That(telemetryValues, Does.Not.Contain("sensitive-value"));
+    }
+
+    private static void AssertMetrics(TestMeterListener meterListener, bool useLatestSemanticConventions)
+    {
+        var durations = meterListener.GetMeasurements("gen_ai.client.operation.duration");
+        Assert.That(durations, Has.Count.EqualTo(1));
+        Assert.That(durations[0].tags["gen_ai.operation.name"], Is.EqualTo("chat"));
+        Assert.That(durations[0].tags["gen_ai.request.model"], Is.EqualTo(RequestModel));
+        Assert.That(durations[0].tags["gen_ai.response.model"], Is.EqualTo(ResponseModel));
+
+        var usage = meterListener.GetMeasurements("gen_ai.client.token.usage");
+        Assert.That(usage, Has.Count.EqualTo(2));
+        Assert.That(usage.Single(measurement => measurement.tags["gen_ai.token.type"].Equals("input")).value, Is.EqualTo(InputTokens));
+        Assert.That(usage.Single(measurement => measurement.tags["gen_ai.token.type"].Equals("output")).value, Is.EqualTo(OutputTokens));
+
+        foreach (var measurement in durations.Concat(usage))
+        {
+            if (useLatestSemanticConventions)
+            {
+                Assert.That(measurement.tags["gen_ai.provider.name"], Is.EqualTo("openai"));
+                Assert.That(measurement.tags.ContainsKey("openai.api.type"), Is.False);
+                Assert.That(measurement.tags["openai.response.service_tier"], Is.EqualTo("default"));
+            }
+            else
+            {
+                Assert.That(measurement.tags["gen_ai.system"], Is.EqualTo("openai"));
+                Assert.That(measurement.tags.ContainsKey("openai.api.type"), Is.False);
+                Assert.That(measurement.tags.ContainsKey("openai.response.service_tier"), Is.False);
+            }
+        }
+    }
+
+    private const string CompletedResponseBody =
+        """
+        {
+          "id": "resp_synthetic",
+          "object": "response",
+          "created_at": 1,
+          "status": "completed",
+          "error": null,
+          "incomplete_details": null,
+          "model": "response-model",
+          "output": [
+            {
+              "id": "msg_synthetic",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "sensitive output"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "id": "cmp_synthetic",
+              "type": "compaction",
+              "encrypted_content": "sensitive compaction content"
+            }
+          ],
+          "parallel_tool_calls": false,
+          "service_tier": "default",
+          "tools": [],
+          "usage": {
+            "input_tokens": 12,
+            "input_tokens_details": {"cached_tokens": 5},
+            "output_tokens": 34,
+            "output_tokens_details": {"reasoning_tokens": 7},
+            "total_tokens": 46
+          }
+        }
+        """;
+
+    private const string ErrorResponseBody =
+        """
+        {
+          "error": {
+            "message": "sensitive request failure",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": "invalid_request"
+          }
+        }
+        """;
+}


### PR DESCRIPTION
# Summary
 
 This change adds experimental OpenTelemetry instrumentation for non-streaming `ResponsesClient.CreateResponse` and `CreateResponseAsync` operations.
 
The implementation builds on the existing Chat telemetry infrastructure while using a separate `OpenAI.ResponsesClient` activity source and meter. It follows the current OpenTelemetry Generative AI semantic conventions and supports both the default convention behavior and `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`.
 
 Partially addresses #653. Streaming Responses telemetry remains outside the scope of this change and will be added in a follow-up pull request after this merges..
 
 ## Details
 
 The new instrumentation:
 
 - Creates client spans for strongly typed, non-streaming Responses operations.
 - Records `gen_ai.operation.name` with the `chat` operation.
 - Uses `chat {model}` as the span name when the requested model is available and `chat` when it is not.
 - Records request model, response model, response ID, supported request parameters, finish reasons, token usage, service tier, reasoning effort, conversation details, and compaction state where defined by the active semantic conventions.
 - Emits `gen_ai.client.operation.duration` and `gen_ai.client.token.usage` metrics through the `OpenAI.ResponsesClient` meter.
 - Marks failed and cancelled responses as errors and records low-cardinality error types without capturing provider-controlled error messages.
 - Makes sampling-relevant attributes available when the span is created.
 - Supports requests where the model is supplied implicitly, such as future saved-prompt scenarios, while preserving an explicitly supplied model as the requested model.
 
 Telemetry is attached only to the strongly typed non-streaming methods. Generated protocol methods, streaming response creation, stored-response retrieval, cancellation, deletion, and input-item listing are not instrumented by this change.
 
 ## Privacy
 
 The implementation does not record prompts, generated output, instructions, tool definitions, tool arguments or results, metadata, safety identifiers, end-user identifiers, prompt cache keys, multimodal payloads, or provider-controlled error messages.
 
 Enabling experimental OpenTelemetry support does not opt callers into content capture.
 
 ## Testing
 
 The synthetic telemetry coverage includes:
 
 - Synchronous and asynchronous response creation.
 - Default and latest experimental semantic conventions.
 - Metrics enabled without tracing.
 - Tracing enabled without metrics.
 - Request and response attributes.
 - Sampling-time attributes.
 - Duration and token usage metrics.
 - Requests without an explicit model.
 - HTTP failures and response status mapping.
 - Completed, incomplete, failed, and cancelled responses.
 - Unknown future incomplete reasons.
 - Response compaction.
 - Sensitive-data exclusion.
 - Protocol method exclusion.
 - Convenience overload deduplication.
 
 The observability documentation and changelog have also been updated to describe the new coverage and its current limitations.