### PR TITLE
fix(chat): preserve patches on single content parts

### DIFF
--- a/OpenAI/src/Custom/Chat/ChatMessageContent.Serialization.cs
+++ b/OpenAI/src/Custom/Chat/ChatMessageContent.Serialization.cs
@@ -12,7 +12,7 @@ public partial class ChatMessageContent
         {
             writer.WriteNullValue();
         }
-        else if (Count == 1 && this[0].Kind == ChatMessageContentPartKind.Text)
+        else if (Count == 1 && this[0].Kind == ChatMessageContentPartKind.Text && !HasPatchOperations(this[0]))
         {
             writer.WriteStringValue(this[0].Text);
         }
@@ -26,6 +26,13 @@ public partial class ChatMessageContent
             writer.WriteEndArray();
         }
     }
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+    private static bool HasPatchOperations(ChatMessageContentPart part)
+    {
+        return part.Patch.ToBinaryData().ToMemory().Length > 2;
+    }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
     internal static ChatMessageContent DeserializeChatMessageContent(JsonElement element, ModelReaderWriterOptions options = null)
     {

--- a/OpenAI/src/Custom/Chat/ChatMessageContent.Serialization.cs
+++ b/OpenAI/src/Custom/Chat/ChatMessageContent.Serialization.cs
@@ -30,7 +30,7 @@ public partial class ChatMessageContent
 #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
     private static bool HasPatchOperations(ChatMessageContentPart part)
     {
-        return part.Patch.ToBinaryData().ToMemory().Length > 2;
+        return part.Patch.Contains("$"u8) || part.Patch.ToBinaryData().ToMemory().Length > 2;
     }
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 

--- a/OpenAI/src/Custom/Chat/ChatMessageContentPart.Serialization.cs
+++ b/OpenAI/src/Custom/Chat/ChatMessageContentPart.Serialization.cs
@@ -23,37 +23,40 @@ public partial class ChatMessageContentPart : IJsonModel<ChatMessageContentPart>
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
         writer.WriteStartObject();
-        writer.WritePropertyName("type"u8);
-        writer.WriteStringValue(instance._kind.ToSerialString());
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        if (!instance.Patch.Contains("$.type"u8))
+        {
+            writer.WritePropertyName("type"u8);
+            writer.WriteStringValue(instance._kind.ToSerialString());
+        }
 
-        if (instance._kind == ChatMessageContentPartKind.Text)
+        if (instance._kind == ChatMessageContentPartKind.Text && !instance.Patch.Contains("$.text"u8))
         {
             writer.WritePropertyName("text"u8);
             writer.WriteStringValue(instance._text);
         }
-        else if (instance._kind == ChatMessageContentPartKind.Refusal)
+        else if (instance._kind == ChatMessageContentPartKind.Refusal && !instance.Patch.Contains("$.refusal"u8))
         {
             writer.WritePropertyName("refusal"u8);
             writer.WriteStringValue(instance._refusal);
         }
-        else if (instance._kind == ChatMessageContentPartKind.Image)
+        else if (instance._kind == ChatMessageContentPartKind.Image && !instance.Patch.Contains("$.image_url"u8))
         {
             writer.WritePropertyName("image_url"u8);
             writer.WriteObjectValue(instance._imageUri, options);
         }
-        else if (instance._kind == ChatMessageContentPartKind.InputAudio)
+        else if (instance._kind == ChatMessageContentPartKind.InputAudio && !instance.Patch.Contains("$.input_audio"u8))
         {
             writer.WritePropertyName("input_audio"u8);
             writer.WriteObjectValue(instance._inputAudio, options);
         }
-        else if (instance._kind == ChatMessageContentPartKind.File)
+        else if (instance._kind == ChatMessageContentPartKind.File && !instance.Patch.Contains("$.file"u8))
         {
             writer.WritePropertyName("file"u8);
             writer.WriteObjectValue(instance._fileFile, options);
         }
-#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         instance.Patch.WriteTo(writer);
-#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         writer.WriteEndObject();
     }
 

--- a/OpenAI/src/Custom/Chat/Messages/ChatMessage.Serialization.cs
+++ b/OpenAI/src/Custom/Chat/Messages/ChatMessage.Serialization.cs
@@ -41,7 +41,9 @@ public partial class ChatMessage
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void WriteContentProperty(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        if (Optional.IsDefined(Content) && Content.IsInnerCollectionDefined())
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        if (Optional.IsDefined(Content) && Content.IsInnerCollectionDefined() && !Patch.Contains("$.content"u8))
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         {
             writer.WritePropertyName("content"u8);
             Content.WriteTo(writer, options);

--- a/OpenAI/src/Custom/Chat/Messages/FunctionChatMessage.Serialization.cs
+++ b/OpenAI/src/Custom/Chat/Messages/FunctionChatMessage.Serialization.cs
@@ -27,12 +27,23 @@ public partial class FunctionChatMessage : IJsonModel<FunctionChatMessage>
 
         writer.WriteStartObject();
         WriteRoleProperty(writer, options);
-        WriteContentProperty(writer, options);
+        WriteFunctionContentProperty(writer);
         writer.WritePropertyName("name"u8);
         writer.WriteStringValue(FunctionName);
 #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         Patch.WriteTo(writer);
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         writer.WriteEndObject();
+    }
+
+    private void WriteFunctionContentProperty(Utf8JsonWriter writer)
+    {
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        if (Optional.IsDefined(Content) && Content.IsInnerCollectionDefined() && !Patch.Contains("$.content"u8))
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        {
+            writer.WritePropertyName("content"u8);
+            writer.WriteStringValue(Content.Count == 0 ? null : Content[0]?.Text);
+        }
     }
 }

--- a/tests/Chat/ChatSmokeTests.cs
+++ b/tests/Chat/ChatSmokeTests.cs
@@ -493,6 +493,34 @@ public class ChatSmokeTests : ClientTestBase
         Assert.That(serializedMessage, Does.Contain("openai.com/test"));
     }
 
+#pragma warning disable SCME0001
+    [Test]
+    public void SerializeSinglePatchedTextContentAsArray()
+    {
+        BinaryData cacheControl = BinaryData.FromString("""{"type":"ephemeral"}""");
+
+        ChatMessageContentPart systemPart = ChatMessageContentPart.CreateTextPart("You are a helpful assistant.");
+        systemPart.Patch.Set("$.cache_control"u8, cacheControl);
+        using JsonDocument systemJson = JsonDocument.Parse(ModelReaderWriter.Write(new SystemChatMessage(systemPart)));
+
+        JsonElement systemContent = systemJson.RootElement.GetProperty("content");
+        Assert.That(systemContent.ValueKind, Is.EqualTo(JsonValueKind.Array));
+        Assert.That(systemContent.GetArrayLength(), Is.EqualTo(1));
+        Assert.That(systemContent[0].GetProperty("text").GetString(), Is.EqualTo("You are a helpful assistant."));
+        Assert.That(systemContent[0].GetProperty("cache_control").GetProperty("type").GetString(), Is.EqualTo("ephemeral"));
+
+        ChatMessageContentPart toolPart = ChatMessageContentPart.CreateTextPart("{\"price\":1}");
+        toolPart.Patch.Set("$.cache_control"u8, cacheControl);
+        using JsonDocument toolJson = JsonDocument.Parse(ModelReaderWriter.Write(new ToolChatMessage("call_1", toolPart)));
+
+        JsonElement toolContent = toolJson.RootElement.GetProperty("content");
+        Assert.That(toolContent.ValueKind, Is.EqualTo(JsonValueKind.Array));
+        Assert.That(toolContent.GetArrayLength(), Is.EqualTo(1));
+        Assert.That(toolContent[0].GetProperty("text").GetString(), Is.EqualTo("{\"price\":1}"));
+        Assert.That(toolContent[0].GetProperty("cache_control").GetProperty("type").GetString(), Is.EqualTo("ephemeral"));
+    }
+#pragma warning restore SCME0001
+
     [Test]
     public void CanSerializeChatMessage()
     {

--- a/tests/Chat/ChatSmokeTests.cs
+++ b/tests/Chat/ChatSmokeTests.cs
@@ -518,6 +518,72 @@ public class ChatSmokeTests : ClientTestBase
         Assert.That(toolContent.GetArrayLength(), Is.EqualTo(1));
         Assert.That(toolContent[0].GetProperty("text").GetString(), Is.EqualTo("{\"price\":1}"));
         Assert.That(toolContent[0].GetProperty("cache_control").GetProperty("type").GetString(), Is.EqualTo("ephemeral"));
+
+        ChatMessageContentPart rootPatchedPart = ChatMessageContentPart.CreateTextPart("ignored");
+        rootPatchedPart.Patch.Set("$"u8, BinaryData.FromString("{}"));
+        using JsonDocument rootPatchedJson = JsonDocument.Parse(ModelReaderWriter.Write(new SystemChatMessage(rootPatchedPart)));
+        Assert.That(rootPatchedJson.RootElement.GetProperty("content").ValueKind, Is.EqualTo(JsonValueKind.Array));
+        Assert.That(rootPatchedJson.RootElement.GetProperty("content")[0].EnumerateObject(), Is.Empty);
+    }
+#pragma warning restore SCME0001
+
+#pragma warning disable SCME0001
+    [Test]
+    public void ChatPatchReplacesContentWithoutDuplicateProperty()
+    {
+        SystemChatMessage message = new("original");
+        message.Patch.Set("$.content"u8, BinaryData.FromString("""[{"type":"text","text":"replacement"}]"""));
+
+        using JsonDocument json = JsonDocument.Parse(ModelReaderWriter.Write(message));
+        Assert.That(CountProperties(json.RootElement, "content"), Is.EqualTo(1));
+        Assert.That(json.RootElement.GetProperty("content")[0].GetProperty("text").GetString(), Is.EqualTo("replacement"));
+    }
+
+    [Test]
+    public void ContentPartPatchHasPrecedenceOverModeledText()
+    {
+        ChatMessageContentPart replacement = ChatMessageContentPart.CreateTextPart("original");
+        replacement.Patch.Set("$.text"u8, "replacement");
+        using JsonDocument replacementJson = JsonDocument.Parse(ModelReaderWriter.Write(replacement));
+        Assert.That(CountProperties(replacementJson.RootElement, "text"), Is.EqualTo(1));
+        Assert.That(replacementJson.RootElement.GetProperty("text").GetString(), Is.EqualTo("replacement"));
+
+        ChatMessageContentPart removal = ChatMessageContentPart.CreateTextPart("original");
+        removal.Patch.Remove("$.text"u8);
+        using JsonDocument removalJson = JsonDocument.Parse(ModelReaderWriter.Write(removal));
+        Assert.That(CountProperties(removalJson.RootElement, "text"), Is.Zero);
+
+        ChatMessageContentPart nullValue = ChatMessageContentPart.CreateTextPart("original");
+        nullValue.Patch.SetNull("$.text"u8);
+        using JsonDocument nullJson = JsonDocument.Parse(ModelReaderWriter.Write(nullValue));
+        Assert.That(CountProperties(nullJson.RootElement, "text"), Is.EqualTo(1));
+        Assert.That(nullJson.RootElement.GetProperty("text").ValueKind, Is.EqualTo(JsonValueKind.Null));
+    }
+
+#pragma warning disable CS0618
+    [Test]
+    public void FunctionMessageKeepsStringContentWhenPartIsPatched()
+    {
+        FunctionChatMessage message = new("get_price", "1");
+        message.Content[0].Patch.Set("$.custom_property"u8, true);
+
+        using JsonDocument json = JsonDocument.Parse(ModelReaderWriter.Write(message));
+        Assert.That(json.RootElement.GetProperty("content").ValueKind, Is.EqualTo(JsonValueKind.String));
+        Assert.That(json.RootElement.GetProperty("content").GetString(), Is.EqualTo("1"));
+    }
+#pragma warning restore CS0618
+
+    private static int CountProperties(JsonElement element, string name)
+    {
+        int count = 0;
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (property.NameEquals(name))
+            {
+                count++;
+            }
+        }
+        return count;
     }
 #pragma warning restore SCME0001
 


### PR DESCRIPTION
### Summary

Preserve `ChatMessageContentPart.Patch` properties when a chat message contains exactly one text content part.

The serializer previously collapsed every single text part to a plain JSON string. That compact representation cannot carry part-level extension fields, so explicitly patched properties such as `cache_control` were silently dropped. Single text parts with patch operations now retain the array/object representation, while ordinary unpatched single text messages keep the existing string serialization.

### Tests

- Added SystemChatMessage and ToolChatMessage regressions for a patched single text part.
- Existing unpatched single-message serialization remains covered.
- `dotnet build OpenAI.slnx` — succeeded with 0 warnings and 0 errors.
- `ChatSmokeTests` on net10.0 — 74 passed.
- Focused patched/unpatched serialization tests on net10.0 — 4 passed.
- `git diff --check` — passed.

Fixes #1359.