### PR TITLE
fix(realtime): implement synchronous ReceiveUpdates

### DIFF
--- a/OpenAI/src/Custom/Realtime/Internal/AsyncWebsocketMessageEnumerator.cs
+++ b/OpenAI/src/Custom/Realtime/Internal/AsyncWebsocketMessageEnumerator.cs
@@ -38,7 +38,7 @@ internal partial class AsyncWebsocketMessageResultEnumerator : IAsyncEnumerator<
         WebsocketPipelineResponse websocketPipelineResponse = new();
         for (int partialMessageCount = 1; !websocketPipelineResponse.IsComplete; partialMessageCount++)
         {
-            WebSocketReceiveResult receiveResult = await _webSocket.ReceiveAsync(new(_receiveBuffer), _cancellationToken);
+            WebSocketReceiveResult receiveResult = await _webSocket.ReceiveAsync(new(_receiveBuffer), _cancellationToken).ConfigureAwait(false);
             if (receiveResult.CloseStatus.HasValue)
             {
                 Current = null;

--- a/OpenAI/src/Custom/Realtime/RealtimeSessionClient.Protocol.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeSessionClient.Protocol.cs
@@ -103,7 +103,7 @@ public partial class RealtimeSessionClient
         {
             _receiveCollectionResult ??= new(WebSocket, options?.CancellationToken ?? default);
         }
-        await foreach (ClientResult result in _receiveCollectionResult)
+        await foreach (ClientResult result in _receiveCollectionResult.ConfigureAwait(false))
         {
             BinaryData incomingMessage = result?.GetRawResponse()?.Content;
             if (incomingMessage is not null)
@@ -116,7 +116,25 @@ public partial class RealtimeSessionClient
 
     public virtual IEnumerable<ClientResult> ReceiveUpdates(RequestOptions options)
     {
-        throw new NotImplementedException();
+        CancellationToken cancellationToken = options?.CancellationToken ?? default;
+        IAsyncEnumerator<ClientResult> enumerator = new AsyncWebsocketMessageResultEnumerator(WebSocket, cancellationToken);
+        try
+        {
+            while (enumerator.MoveNextAsync().ConfigureAwait(false).GetAwaiter().GetResult())
+            {
+                ClientResult result = enumerator.Current;
+                BinaryData incomingMessage = result?.GetRawResponse()?.Content;
+                if (incomingMessage is not null)
+                {
+                    _parentClient?.RaiseOnReceivingCommand(this, incomingMessage);
+                }
+                yield return result;
+            }
+        }
+        finally
+        {
+            enumerator.DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
     }
 
     private static Uri BuildSessionUri(Uri endpoint, string model, string intent)

--- a/OpenAI/src/Custom/Realtime/RealtimeSessionClient.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeSessionClient.cs
@@ -368,7 +368,16 @@ public partial class RealtimeSessionClient : IDisposable
 
     public virtual IEnumerable<RealtimeServerUpdate> ReceiveUpdates(CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        foreach (ClientResult protocolEvent in ReceiveUpdates(cancellationToken.ToRequestOptions()))
+        {
+            using PipelineResponse response = protocolEvent.GetRawResponse();
+            RealtimeServerUpdate nextUpdate = ModelReaderWriter.Read<RealtimeServerUpdate>(response.Content, ModelReaderWriterOptions.Json, OpenAIContext.Default);
+            // Skip null updates (e.g., conversation.item.done events that are intentionally ignored)
+            if (nextUpdate is not null)
+            {
+                yield return nextUpdate;
+            }
+        }
     }
 
     public virtual async Task SendCommandAsync(RealtimeClientCommand command, CancellationToken cancellationToken = default)

--- a/tests/Realtime/RealtimeUnitTests.cs
+++ b/tests/Realtime/RealtimeUnitTests.cs
@@ -3,8 +3,14 @@ using OpenAI.Realtime;
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.WebSockets;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenAI.Tests.Realtime;
 
@@ -133,6 +139,27 @@ public class RealtimeUnitTests
     }
 
     [Test]
+    public void ReceiveUpdatesSynchronouslyEnumeratesProtocolUpdates()
+    {
+        TestRealtimeSessionClient client = new();
+
+        ClientResult result = client.ReceiveUpdates(new RequestOptions()).Single();
+
+        Assert.That(result.GetRawResponse().Content.ToString(), Does.Contain("item_1"));
+    }
+
+    [Test]
+    public void ReceiveUpdatesSynchronouslyDeserializesTypedUpdates()
+    {
+        TestRealtimeSessionClient client = new();
+
+        RealtimeServerUpdate update = client.ReceiveUpdates().Single();
+
+        Assert.That(update, Is.InstanceOf<RealtimeServerUpdateConversationItemDeleted>());
+        Assert.That(((RealtimeServerUpdateConversationItemDeleted)update).ItemId, Is.EqualTo("item_1"));
+    }
+
+    [Test]
     public void AudioEndMsSerializesAsInteger()
     {
         // A TimeSpan with sub-millisecond precision that would produce a fractional double
@@ -158,5 +185,50 @@ public class RealtimeUnitTests
             BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.That(field, Is.Not.Null, "RealtimeClient should expose its WebSocket endpoint field");
         return (Uri)field.GetValue(client);
+    }
+
+    private sealed class TestRealtimeSessionClient : RealtimeSessionClient
+    {
+        public TestRealtimeSessionClient()
+            : base(new ApiKeyCredential("test-key"), new Uri("wss://example.com/v1/realtime"), "gpt-realtime", null, null)
+        {
+            WebSocket = new TestWebSocket(
+                """{"type":"conversation.item.deleted","event_id":"evt_1","item_id":"item_1"}""");
+        }
+    }
+
+    private sealed class TestWebSocket : WebSocket
+    {
+        private readonly byte[] _message;
+        private bool _messageReceived;
+
+        public TestWebSocket(string message) => _message = Encoding.UTF8.GetBytes(message);
+
+        public override WebSocketCloseStatus? CloseStatus => _messageReceived ? WebSocketCloseStatus.NormalClosure : null;
+        public override string CloseStatusDescription => null;
+        public override WebSocketState State => _messageReceived ? WebSocketState.Closed : WebSocketState.Open;
+        public override string SubProtocol => null;
+
+        public override void Abort() => _messageReceived = true;
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+        public override void Dispose() => _messageReceived = true;
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            if (_messageReceived)
+            {
+                return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true, WebSocketCloseStatus.NormalClosure, null));
+            }
+
+            _message.CopyTo(buffer.Array, buffer.Offset);
+            _messageReceived = true;
+            return Task.FromResult(new WebSocketReceiveResult(_message.Length, WebSocketMessageType.Text, true));
+        }
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+            => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary

- implement both synchronous `RealtimeSessionClient.ReceiveUpdates` overloads
- reuse the existing WebSocket receive pipeline and typed update deserialization
- avoid synchronization-context capture in the receive path used by sync-over-async
- add regressions for both protocol and typed synchronous enumeration

Fixes #1363.

## Validation

- `dotnet test tests/OpenAI.Tests.csproj --filter FullyQualifiedName~RealtimeUnitTests --no-restore`
- 12/12 passed on .NET 8, .NET 9, and .NET 10
- `git diff --check`
