### PR TITLE
Allow opting out of streaming usage

### DIFF
--- a/OpenAI/src/Custom/Chat/ChatClient.cs
+++ b/OpenAI/src/Custom/Chat/ChatClient.cs
@@ -398,7 +398,12 @@ public partial class ChatClient
         if (stream)
         {
             clonedOptions.Stream = true;
-            clonedOptions.StreamOptions = s_includeUsageStreamOptions;
+            clonedOptions.StreamOptions = clonedOptions.IncludeUsageInStreaming switch
+            {
+                true => s_includeUsageStreamOptions,
+                false => new InternalChatCompletionStreamOptions(includeUsage: false, patch: default),
+                null => null,
+            };
         }
         else
         {

--- a/OpenAI/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/OpenAI/src/Custom/Chat/ChatCompletionOptions.cs
@@ -53,6 +53,12 @@ public partial class ChatCompletionOptions
     [CodeGenMember("StreamOptions")]
     internal InternalChatCompletionStreamOptions StreamOptions { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether usage information is included in streaming chat completions.
+    /// Set to <see langword="null"/> to omit <c>stream_options</c> from the request.
+    /// </summary>
+    public bool? IncludeUsageInStreaming { get; set; } = true;
+
     // CUSTOM: Renamed.
     /// <summary> Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the message content. </summary>
     [CodeGenMember("Logprobs")]
@@ -255,6 +261,7 @@ public partial class ChatCompletionOptions
         clone.Seed = Seed;
         clone._patch = _patch;
         clone._patch.SetPropagators(clone.PropagateSet, clone.PropagateGet);
+        clone.IncludeUsageInStreaming = IncludeUsageInStreaming;
         return clone;
     }
 }

--- a/OpenAI/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/OpenAI/src/Custom/Chat/ChatCompletionOptions.cs
@@ -57,7 +57,15 @@ public partial class ChatCompletionOptions
     /// Gets or sets whether usage information is included in streaming chat completions.
     /// Set to <see langword="null"/> to omit <c>stream_options</c> from the request.
     /// </summary>
-    public bool? IncludeUsageInStreaming { get; set; } = true;
+    public bool? IncludeUsageInStreaming
+    {
+        get => StreamOptions is null ? true : StreamOptions.IncludeUsage;
+        set
+        {
+            StreamOptions ??= new InternalChatCompletionStreamOptions();
+            StreamOptions.IncludeUsage = value;
+        }
+    }
 
     // CUSTOM: Renamed.
     /// <summary> Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the message content. </summary>
@@ -261,7 +269,6 @@ public partial class ChatCompletionOptions
         clone.Seed = Seed;
         clone._patch = _patch;
         clone._patch.SetPropagators(clone.PropagateSet, clone.PropagateGet);
-        clone.IncludeUsageInStreaming = IncludeUsageInStreaming;
         return clone;
     }
 }

--- a/api/in-progress/net10.0/OpenAI.Chat.net10.0.cs
+++ b/api/in-progress/net10.0/OpenAI.Chat.net10.0.cs
@@ -225,6 +225,7 @@ namespace OpenAI.Chat {
         [Obsolete("This property is obsolete. Please use Tools instead.")]
         public IList<ChatFunction> Functions { get; }
         public bool? IncludeLogProbabilities { get; set; }
+        public bool? IncludeUsageInStreaming { get; set; }
         public IDictionary<int, int> LogitBiases { get; }
         public int? MaxOutputTokenCount { get; set; }
         public IDictionary<string, string> Metadata { get; }

--- a/api/in-progress/net8.0/OpenAI.Chat.net8.0.cs
+++ b/api/in-progress/net8.0/OpenAI.Chat.net8.0.cs
@@ -225,6 +225,7 @@ namespace OpenAI.Chat {
         [Obsolete("This property is obsolete. Please use Tools instead.")]
         public IList<ChatFunction> Functions { get; }
         public bool? IncludeLogProbabilities { get; set; }
+        public bool? IncludeUsageInStreaming { get; set; }
         public IDictionary<int, int> LogitBiases { get; }
         public int? MaxOutputTokenCount { get; set; }
         public IDictionary<string, string> Metadata { get; }

--- a/api/in-progress/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
+++ b/api/in-progress/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
@@ -179,6 +179,7 @@ namespace OpenAI.Chat {
         [Obsolete("This property is obsolete. Please use Tools instead.")]
         public IList<ChatFunction> Functions { get; }
         public bool? IncludeLogProbabilities { get; set; }
+        public bool? IncludeUsageInStreaming { get; set; }
         public IDictionary<int, int> LogitBiases { get; }
         public int? MaxOutputTokenCount { get; set; }
         public IDictionary<string, string> Metadata { get; }

--- a/tests/Chat/ChatMockTests.cs
+++ b/tests/Chat/ChatMockTests.cs
@@ -9,6 +9,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.IO;
+using System.Text.Json;
 
 namespace OpenAI.Tests.Chat;
 
@@ -288,6 +290,86 @@ public class ChatMockTests : ClientTestBase
         stopwatch.Stop();
 
         Assert.That(response.IsDisposed);
+    }
+
+    [SyncOnly]
+    [Test]
+    public void CompleteChatStreamingIncludesUsageByDefault()
+    {
+        string requestBody = CaptureStreamingRequestBody();
+
+        using JsonDocument document = JsonDocument.Parse(requestBody);
+        JsonElement streamOptions = document.RootElement.GetProperty("stream_options");
+
+        Assert.That(streamOptions.GetProperty("include_usage").GetBoolean(), Is.True);
+    }
+
+    [SyncOnly]
+    [Test]
+    public void CompleteChatStreamingCanOmitUsage()
+    {
+        string requestBody = CaptureStreamingRequestBody(
+            new ChatCompletionOptions
+            {
+                IncludeUsageInStreaming = null
+            });
+
+        using JsonDocument document = JsonDocument.Parse(requestBody);
+
+        Assert.That(
+            document.RootElement.TryGetProperty("stream_options", out _),
+            Is.False);
+    }
+
+    [SyncOnly]
+    [Test]
+    public void CompleteChatStreamingCanDisableUsage()
+    {
+        string requestBody = CaptureStreamingRequestBody(
+            new ChatCompletionOptions
+            {
+                IncludeUsageInStreaming = false
+            });
+
+        using JsonDocument document = JsonDocument.Parse(requestBody);
+        JsonElement streamOptions = document.RootElement.GetProperty("stream_options");
+
+        Assert.That(streamOptions.GetProperty("include_usage").GetBoolean(), Is.False);
+    }
+
+    private string CaptureStreamingRequestBody(ChatCompletionOptions completionOptions = null)
+    {
+        string requestBody = null;
+        MockPipelineResponse response = CreateStreamingChatResponse();
+
+        OpenAIClientOptions options = new()
+        {
+            Transport = new MockPipelineTransport(message =>
+            {
+                using MemoryStream stream = new();
+                message.Request.Content.WriteTo(stream);
+                requestBody = BinaryData.FromBytes(stream.ToArray()).ToString();
+
+                return response;
+            })
+            {
+                ExpectSyncPipeline = true
+            }
+        };
+
+        ChatClient client = CreateProxyFromClient(
+            new ChatClient("model", s_fakeCredential, options));
+
+        CollectionResult<StreamingChatCompletionUpdate> result =
+            client.CompleteChatStreaming(s_messages, completionOptions);
+
+        using IEnumerator<StreamingChatCompletionUpdate> enumerator =
+            result.GetEnumerator();
+
+        Assert.That(enumerator.MoveNext(), Is.True);
+        Assert.That(requestBody, Is.Not.Null);
+
+        return requestBody;
     }
 
     private OpenAIClientOptions GetClientOptionsWithMockResponse(int status, string content)

--- a/tests/Chat/ChatSmokeTests.cs
+++ b/tests/Chat/ChatSmokeTests.cs
@@ -994,6 +994,27 @@ public class ChatSmokeTests : ClientTestBase
     }
 
     [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    [TestCase(null)]
+    public void StreamingUsagePreferenceRoundTrips(bool? includeUsage)
+    {
+        ChatCompletionOptions options = new()
+        {
+            IncludeUsageInStreaming = includeUsage
+        };
+
+        BinaryData serialized = ModelReaderWriter.Write(options);
+
+        ChatCompletionOptions deserialized =
+            ModelReaderWriter.Read<ChatCompletionOptions>(serialized);
+
+        Assert.That(
+            deserialized.IncludeUsageInStreaming,
+            Is.EqualTo(includeUsage));
+    }
+
+    [Test]
     public void StableImageContentPartSerialization()
     {
         string base64HelloWorld = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello world"));


### PR DESCRIPTION
Fixes #616

## Summary

This PR follows up on #616, where `stream_options.include_usage` was discussed as an optional value that is currently forced to `true` for streaming chat completions.

It adds a small option on `ChatCompletionOptions` to control that behavior while preserving the existing default.

- `IncludeUsageInStreaming = true` keeps the current behavior and sends `stream_options.include_usage = true`.
- `IncludeUsageInStreaming = false` sends `stream_options.include_usage = false`.
- `IncludeUsageInStreaming = null` omits `stream_options` from the request entirely.

The default remains `true`, so existing callers keep the current behavior.

## Implementation

- Added `ChatCompletionOptions.IncludeUsageInStreaming`.
- Propagated the value when cloning `ChatCompletionOptions`.
- Updated streaming request creation to distinguish `true`, `false`, and `null`.
- Updated the in-progress public API baselines.
- Added request serialization coverage for:
  - the existing default behavior,
  - explicitly disabling usage,
  - omitting `stream_options`.

## Testing

Validated locally on all supported test target frameworks:

- `net8.0`
- `net9.0`
- `net10.0`

All per-framework test runs pass.

Targeted streaming chat tests also pass.

## Design note

#616 also discussed protocol models as a possible way to address this scenario.

This PR proposes a small convenience API on `ChatCompletionOptions` while keeping the existing behavior unchanged by default. I'm happy to adjust the API shape if a protocol-model-based approach is preferred.