### PR TITLE
fix(responses): guard null nested patch targets

### DIFF
--- a/OpenAI.Responses/src/Generated/Models/ResponseResult.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ResponseResult.Serialization.cs
@@ -712,26 +712,50 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("reasoning"u8))
             {
+                if (ReasoningOptions is null)
+                {
+                    return false;
+                }
                 return ReasoningOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("reasoning"u8.Length)], out value);
             }
             if (local.StartsWith("text"u8))
             {
+                if (TextOptions is null)
+                {
+                    return false;
+                }
                 return TextOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("text"u8.Length)], out value);
             }
             if (local.StartsWith("error"u8))
             {
+                if (Error is null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             if (local.StartsWith("incomplete_details"u8))
             {
+                if (IncompleteStatusDetails is null)
+                {
+                    return false;
+                }
                 return IncompleteStatusDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("incomplete_details"u8.Length)], out value);
             }
             if (local.StartsWith("usage"u8))
             {
+                if (Usage is null)
+                {
+                    return false;
+                }
                 return Usage.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("usage"u8.Length)], out value);
             }
             if (local.StartsWith("conversation"u8))
             {
+                if (ConversationOptions is null)
+                {
+                    return false;
+                }
                 return ConversationOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("conversation"u8.Length)], out value);
             }
             if (local.StartsWith("tools"u8))

--- a/tests/Responses/ResponsesSmokeTests.cs
+++ b/tests/Responses/ResponsesSmokeTests.cs
@@ -490,6 +490,25 @@ public partial class ResponsesSmokeTests
         Assert.That(response.ReasoningOptions.Context, Is.EqualTo(ResponseReasoningContext.AllTurns));
     }
 
+    [Test]
+    public void ResponseResultPatchReturnsNullForNullObjectProperties()
+    {
+        ResponseResult response = ModelReaderWriter.Read<ResponseResult>(
+            BinaryData.FromString("""{"reasoning":null,"text":null,"error":null,"incomplete_details":null,"usage":null,"conversation":null}"""));
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.Patch.GetJson("$.reasoning"u8).ToString(), Is.EqualTo("null"));
+            Assert.That(response.Patch.GetJson("$.text"u8).ToString(), Is.EqualTo("null"));
+            Assert.That(response.Patch.GetJson("$.error"u8).ToString(), Is.EqualTo("null"));
+            Assert.That(response.Patch.GetJson("$.incomplete_details"u8).ToString(), Is.EqualTo("null"));
+            Assert.That(response.Patch.GetJson("$.usage"u8).ToString(), Is.EqualTo("null"));
+            Assert.That(response.Patch.GetJson("$.conversation"u8).ToString(), Is.EqualTo("null"));
+        });
+#pragma warning restore SCME0001
+    }
+
     private static void AssertSerializationRoundTrip<T>(
         string serializedJson,
         Action<T> instanceAssertionsAction)


### PR DESCRIPTION
## Summary

- Guard ResponseResult JSON patch propagation when nullable nested response properties are absent or null.
- Add regression coverage for all six affected object properties.

Fixes #1353

## Validation

- CLIENTMODEL_TEST_MODE=Playback CLIENTMODEL_DISABLE_AUTO_RECORDING=true dotnet test tests/OpenAI.Tests.csproj --framework net10.0
  - 1,607 passed, 87 skipped
- Focused regression test passes on net10.0.
- dotnet build OpenAI.slnx --no-restore passes with 0 warnings and 0 errors.
- git diff --check passes.

The net8.0 and net9.0 test runtimes were not installed on the validation machine, so those target-framework test executions were not run.