### PR TITLE
Remove synchronous Realtime APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Thank you to our developer community members who helped to make the OpenAI clien
 - OpenAI.Realtime:
   - Updated the function-calling example to parse and validate model-provided arguments before invoking the local function. _(A community contribution, courtesy of [Rohan5commit](https://github.com/Rohan5commit))_
 
+### Breaking Changes in Experimental APIs
+
+- OpenAI.Realtime:
+  - The service and session operations on `RealtimeClient` and `RealtimeSessionClient` are now async-only. The synchronous service and session operations they previously exposed (session and client-secret creation, sending commands and audio, receiving updates, session configuration, and conversation item helpers) have been removed, along with the underlying synchronous connection path. Use the corresponding `*Async` APIs instead.
+
 ## 2.13.0 (2026-08-10)
 
 ### Acknowledgments

--- a/OpenAI/src/Custom/Realtime/RealtimeClient.Protocol.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeClient.Protocol.cs
@@ -19,17 +19,6 @@ public partial class RealtimeClient
             cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary> Start a new Realtime conversation session. </summary>
-    public virtual RealtimeSessionClient StartConversationSession(string model, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(model, nameof(model));
-        return StartSession(
-            model: model,
-            intent: null,
-            options: options,
-            cancellationToken: cancellationToken);
-    }
-
     /// <summary> Start a new Realtime transcription session. </summary>
     public virtual async Task<RealtimeSessionClient> StartTranscriptionSessionAsync(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default)
     {
@@ -38,16 +27,6 @@ public partial class RealtimeClient
             intent: "transcription",
             options: options,
             cancellationToken: cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary> Start a new Realtime transcription session. </summary>
-    public virtual RealtimeSessionClient StartTranscriptionSession(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default)
-    {
-        return StartSession(
-            model: null,
-            intent: "transcription",
-            options: options,
-            cancellationToken: cancellationToken);
     }
 
     /// <summary> Starts a new realtime session. </summary>
@@ -82,11 +61,5 @@ public partial class RealtimeClient
         {
             sessionClient?.Dispose();
         }
-    }
-
-    /// <summary> Starts a new realtime session. </summary>
-    public virtual RealtimeSessionClient StartSession(string model, string intent, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default)
-    {
-        return StartSessionAsync(model, intent, options, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 }

--- a/OpenAI/src/Custom/Realtime/RealtimeClient.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeClient.cs
@@ -3,9 +3,14 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace OpenAI.Realtime;
 
+// CUSTOM:
+// - Suppressed the generated synchronous overloads (client is now async-only).
+[CodeGenSuppress("CreateRealtimeClientSecret", typeof(BinaryContent), typeof(RequestOptions))]
+[CodeGenSuppress("CreateRealtimeClientSecret", typeof(CreateClientSecretOptions), typeof(CancellationToken))]
 [CodeGenType("Realtime")]
 public partial class RealtimeClient
 {

--- a/OpenAI/src/Custom/Realtime/RealtimeSessionClient.Protocol.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeSessionClient.Protocol.cs
@@ -60,11 +60,6 @@ public partial class RealtimeSessionClient
         WebSocket = clientWebSocket;
     }
 
-    protected internal virtual void Connect(string queryString = null, IDictionary<string, string> headers = null, CancellationToken cancellationToken = default)
-    {
-        ConnectAsync(queryString, headers, cancellationToken).Wait();
-    }
-
     public virtual async Task SendCommandAsync(BinaryData data, RequestOptions options)
     {
         Argument.AssertNotNull(data, nameof(data));
@@ -91,12 +86,6 @@ public partial class RealtimeSessionClient
         }
     }
 
-    public virtual void SendCommand(BinaryData data, RequestOptions options)
-    {
-        // ClientWebSocket does **not** include a synchronous Send()
-        SendCommandAsync(data, options).ConfigureAwait(false).GetAwaiter().GetResult();
-    }
-
     public virtual async IAsyncEnumerable<ClientResult> ReceiveUpdatesAsync(RequestOptions options)
     {
         lock (_singleReceiveLock)
@@ -112,11 +101,6 @@ public partial class RealtimeSessionClient
             }
             yield return result;
         }
-    }
-
-    public virtual IEnumerable<ClientResult> ReceiveUpdates(RequestOptions options)
-    {
-        throw new NotImplementedException();
     }
 
     private static Uri BuildSessionUri(Uri endpoint, string model, string intent)

--- a/OpenAI/src/Custom/Realtime/RealtimeSessionClient.cs
+++ b/OpenAI/src/Custom/Realtime/RealtimeSessionClient.cs
@@ -94,50 +94,6 @@ public partial class RealtimeSessionClient : IDisposable
         }
     }
 
-    public virtual void SendInputAudio(Stream audio, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(audio, nameof(audio));
-        using (_audioSendSemaphore.AutoReleaseWait(cancellationToken))
-        {
-            if (_isSendingAudioStream)
-            {
-                throw new InvalidOperationException($"Only one stream of audio may be sent at once.");
-            }
-            _isSendingAudioStream = true;
-        }
-
-        byte[] buffer = null;
-        try
-        {
-            buffer = ArrayPool<byte>.Shared.Rent(1024 * 16);
-            while (true)
-            {
-                int bytesRead = audio.Read(buffer, 0, buffer.Length);
-                if (bytesRead == 0)
-                {
-                    break;
-                }
-
-                ReadOnlyMemory<byte> audioMemory = buffer.AsMemory(0, bytesRead);
-                BinaryData audioData = BinaryData.FromBytes(audioMemory);
-
-                RealtimeClientCommandInputAudioBufferAppend internalCommand = new(audioData);
-                SendCommand(internalCommand, cancellationToken);
-            }
-        }
-        finally
-        {
-            if (buffer is not null)
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-            using (_audioSendSemaphore.AutoReleaseWait(CancellationToken.None))
-            {
-                _isSendingAudioStream = false;
-            }
-        }
-    }
-
     /// <summary>
     /// Transmits a single chunk of audio.
     /// </summary>
@@ -160,38 +116,10 @@ public partial class RealtimeSessionClient : IDisposable
         }
     }
 
-    /// <summary>
-    /// Transmits a single chunk of audio.
-    /// </summary>
-    /// <param name="audio"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
-    public virtual void SendInputAudio(BinaryData audio, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(audio, nameof(audio));
-        using (_audioSendSemaphore.AutoReleaseWait(cancellationToken))
-        {
-            if (_isSendingAudioStream)
-            {
-                throw new InvalidOperationException($"Cannot send a standalone audio chunk while a stream is already in progress.");
-            }
-            // TODO: consider automatically limiting/breaking size of chunk (as with streaming)
-            RealtimeClientCommandInputAudioBufferAppend internalCommand = new(audio);
-            SendCommand(internalCommand, cancellationToken);
-        }
-    }
-
     public virtual async Task ClearInputAudioAsync(CancellationToken cancellationToken = default)
     {
         RealtimeClientCommandInputAudioBufferClear internalCommand = new();
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
-    }
-
-    public virtual void ClearInputAudio(CancellationToken cancellationToken = default)
-    {
-        RealtimeClientCommandInputAudioBufferClear internalCommand = new();
-        SendCommand(internalCommand, cancellationToken);
     }
 
     public virtual async Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default)
@@ -201,13 +129,6 @@ public partial class RealtimeSessionClient : IDisposable
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void ConfigureConversationSession(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(sessionOptions, nameof(sessionOptions));
-        RealtimeClientCommandSessionUpdate internalCommand = new(sessionOptions);
-        SendCommand(internalCommand, cancellationToken);
-    }
-
     public virtual async Task ConfigureTranscriptionSessionAsync(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(sessionOptions, nameof(sessionOptions));
@@ -215,21 +136,9 @@ public partial class RealtimeSessionClient : IDisposable
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void ConfigureTranscriptionSession(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(sessionOptions, nameof(sessionOptions));
-        RealtimeClientCommandSessionUpdate internalCommand = new(sessionOptions);
-        SendCommand(internalCommand, cancellationToken);
-    }
-
     public virtual async Task AddItemAsync(RealtimeItem item, CancellationToken cancellationToken = default)
     {
         await AddItemAsync(item, previousItemId: null, cancellationToken).ConfigureAwait(false);
-    }
-
-    public virtual void AddItem(RealtimeItem item, CancellationToken cancellationToken = default)
-    {
-        AddItem(item, previousItemId: null, cancellationToken);
     }
 
     public virtual async Task AddItemAsync(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default)
@@ -242,16 +151,6 @@ public partial class RealtimeSessionClient : IDisposable
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void AddItem(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(item, nameof(item));
-        RealtimeClientCommandConversationItemCreate internalCommand = new(item)
-        {
-            PreviousItemId = previousItemId,
-        };
-        SendCommand(internalCommand, cancellationToken);
-    }
-
     public virtual async Task RequestItemRetrievalAsync(string itemId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(itemId, nameof(itemId));
@@ -259,25 +158,11 @@ public partial class RealtimeSessionClient : IDisposable
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void RequestItemRetrieval(string itemId, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(itemId, nameof(itemId));
-        RealtimeClientCommandConversationItemRetrieve internalCommand = new(itemId);
-        SendCommand(internalCommand, cancellationToken);
-    }
-
     public virtual async Task DeleteItemAsync(string itemId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(itemId, nameof(itemId));
         RealtimeClientCommandConversationItemDelete internalCommand = new(itemId);
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
-    }
-
-    public virtual void DeleteItem(string itemId, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(itemId, nameof(itemId));
-        RealtimeClientCommandConversationItemDelete internalCommand = new(itemId);
-        SendCommand(internalCommand, cancellationToken);
     }
 
     public virtual async Task TruncateItemAsync(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default)
@@ -290,36 +175,15 @@ public partial class RealtimeSessionClient : IDisposable
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void TruncateItem(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default)
-    {
-        Argument.AssertNotNull(itemId, nameof(itemId));
-        RealtimeClientCommandConversationItemTruncate internalCommand = new(
-            itemId: itemId,
-            contentIndex: contentPartIndex,
-            audioEndTime: audioDuration);
-        SendCommand(internalCommand, cancellationToken);
-    }
-
     public virtual async Task CommitPendingAudioAsync(CancellationToken cancellationToken = default)
     {
         RealtimeClientCommandInputAudioBufferCommit internalCommand = new();
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void CommitPendingAudio(CancellationToken cancellationToken = default)
-    {
-        RealtimeClientCommandInputAudioBufferCommit internalCommand = new();
-        SendCommand(internalCommand, cancellationToken);
-    }
-
     public virtual async Task StartResponseAsync(CancellationToken cancellationToken = default)
     {
         await StartResponseAsync(new RealtimeResponseOptions(), cancellationToken).ConfigureAwait(false);
-    }
-
-    public virtual void StartResponse(CancellationToken cancellationToken = default)
-    {
-        StartResponse(new RealtimeResponseOptions(), cancellationToken);
     }
 
     public virtual async Task StartResponseAsync(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default)
@@ -331,25 +195,10 @@ public partial class RealtimeSessionClient : IDisposable
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void StartResponse(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default)
-    {
-        RealtimeClientCommandResponseCreate internalCommand = new()
-        {
-            ResponseOptions = responseOptions,
-        };
-        SendCommand(internalCommand, cancellationToken);
-    }
-
     public virtual async Task CancelResponseAsync(CancellationToken cancellationToken = default)
     {
         RealtimeClientCommandResponseCancel internalCommand = new();
         await SendCommandAsync(internalCommand, cancellationToken).ConfigureAwait(false);
-    }
-
-    public virtual void CancelResponse(CancellationToken cancellationToken = default)
-    {
-        RealtimeClientCommandResponseCancel internalCommand = new();
-        SendCommand(internalCommand, cancellationToken);
     }
 
     public virtual async IAsyncEnumerable<RealtimeServerUpdate> ReceiveUpdatesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -366,22 +215,10 @@ public partial class RealtimeSessionClient : IDisposable
         }
     }
 
-    public virtual IEnumerable<RealtimeServerUpdate> ReceiveUpdates(CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
     public virtual async Task SendCommandAsync(RealtimeClientCommand command, CancellationToken cancellationToken = default)
     {
         BinaryData requestData = ModelReaderWriter.Write(command, ModelReaderWriterOptions.Json, OpenAIContext.Default);
         RequestOptions cancellationOptions = cancellationToken.ToRequestOptions();
         await SendCommandAsync(requestData, cancellationOptions).ConfigureAwait(false);
-    }
-
-    public virtual void SendCommand(RealtimeClientCommand command, CancellationToken cancellationToken = default)
-    {
-        BinaryData requestData = ModelReaderWriter.Write(command, ModelReaderWriterOptions.Json, OpenAIContext.Default);
-        RequestOptions cancellationOptions = cancellationToken.ToRequestOptions();
-        SendCommand(requestData, cancellationOptions);
     }
 }

--- a/OpenAI/src/Generated/RealtimeClient.cs
+++ b/OpenAI/src/Generated/RealtimeClient.cs
@@ -29,28 +29,12 @@ namespace OpenAI.Realtime
 
         public ClientPipeline Pipeline { get; }
 
-        public virtual ClientResult CreateRealtimeClientSecret(BinaryContent content, RequestOptions options = null)
-        {
-            Argument.AssertNotNull(content, nameof(content));
-
-            using PipelineMessage message = CreateCreateRealtimeClientSecretRequest(content, options);
-            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
-        }
-
         public virtual async Task<ClientResult> CreateRealtimeClientSecretAsync(BinaryContent content, RequestOptions options = null)
         {
             Argument.AssertNotNull(content, nameof(content));
 
             using PipelineMessage message = CreateCreateRealtimeClientSecretRequest(content, options);
             return ClientResult.FromResponse(await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false));
-        }
-
-        public virtual ClientResult<CreateClientSecretResult> CreateRealtimeClientSecret(CreateClientSecretOptions options, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(options, nameof(options));
-
-            ClientResult result = CreateRealtimeClientSecret(options, cancellationToken.ToRequestOptions());
-            return ClientResult.FromValue((CreateClientSecretResult)result, result.GetRawResponse());
         }
 
         public virtual async Task<ClientResult<CreateClientSecretResult>> CreateRealtimeClientSecretAsync(CreateClientSecretOptions options, CancellationToken cancellationToken = default)

--- a/OpenAI/src/Utility/SemaphoreSlimExtensions.cs
+++ b/OpenAI/src/Utility/SemaphoreSlimExtensions.cs
@@ -17,16 +17,6 @@ internal static class SemaphoreSlimExtensions
         return wrapper;
     }
 
-    public static IDisposable AutoReleaseWait(
-        this SemaphoreSlim semaphore,
-        CancellationToken cancellationToken = default)
-    {
-        Contract.Requires(semaphore != null);
-        var wrapper = new ReleaseableSemaphoreSlimWrapper(semaphore);
-        semaphore.Wait(cancellationToken);
-        return wrapper;
-    }
-
     private class ReleaseableSemaphoreSlimWrapper
         : IDisposable
     {

--- a/api/in-progress/net10.0/OpenAI.Realtime.net10.0.cs
+++ b/api/in-progress/net10.0/OpenAI.Realtime.net10.0.cs
@@ -68,15 +68,10 @@ namespace OpenAI.Realtime {
             add;
             remove;
         }
-        public virtual ClientResult<CreateClientSecretResult> CreateRealtimeClientSecret(CreateClientSecretOptions options, CancellationToken cancellationToken = default);
-        public virtual ClientResult CreateRealtimeClientSecret(BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult<CreateClientSecretResult>> CreateRealtimeClientSecretAsync(CreateClientSecretOptions options, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult> CreateRealtimeClientSecretAsync(BinaryContent content, RequestOptions options = null);
-        public virtual RealtimeSessionClient StartConversationSession(string model, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartConversationSessionAsync(string model, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
-        public virtual RealtimeSessionClient StartSession(string model, string intent, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartSessionAsync(string model, string intent, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
-        public virtual RealtimeSessionClient StartTranscriptionSession(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartTranscriptionSessionAsync(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
     }
     [Experimental("OPENAI002")]
@@ -1368,44 +1363,25 @@ namespace OpenAI.Realtime {
     public class RealtimeSessionClient : IDisposable {
         protected internal RealtimeSessionClient(ApiKeyCredential credential, Uri endpoint, string model, string intent, RealtimeClient parentClient);
         public Net.WebSockets.WebSocket WebSocket { get; protected set; }
-        public virtual void AddItem(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default);
-        public virtual void AddItem(RealtimeItem item, CancellationToken cancellationToken = default);
         public virtual Task AddItemAsync(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default);
         public virtual Task AddItemAsync(RealtimeItem item, CancellationToken cancellationToken = default);
-        public virtual void CancelResponse(CancellationToken cancellationToken = default);
         public virtual Task CancelResponseAsync(CancellationToken cancellationToken = default);
-        public virtual void ClearInputAudio(CancellationToken cancellationToken = default);
         public virtual Task ClearInputAudioAsync(CancellationToken cancellationToken = default);
-        public virtual void CommitPendingAudio(CancellationToken cancellationToken = default);
         public virtual Task CommitPendingAudioAsync(CancellationToken cancellationToken = default);
-        public virtual void ConfigureConversationSession(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default);
         public virtual Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default);
-        public virtual void ConfigureTranscriptionSession(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default);
         public virtual Task ConfigureTranscriptionSessionAsync(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default);
-        protected internal virtual void Connect(string queryString = null, IDictionary<string, string> headers = null, CancellationToken cancellationToken = default);
         protected internal virtual Task ConnectAsync(string queryString = null, IDictionary<string, string> headers = null, CancellationToken cancellationToken = default);
-        public virtual void DeleteItem(string itemId, CancellationToken cancellationToken = default);
         public virtual Task DeleteItemAsync(string itemId, CancellationToken cancellationToken = default);
         public void Dispose();
-        public virtual IEnumerable<ClientResult> ReceiveUpdates(RequestOptions options);
-        public virtual IEnumerable<RealtimeServerUpdate> ReceiveUpdates(CancellationToken cancellationToken = default);
         public virtual IAsyncEnumerable<ClientResult> ReceiveUpdatesAsync(RequestOptions options);
         public virtual IAsyncEnumerable<RealtimeServerUpdate> ReceiveUpdatesAsync(CancellationToken cancellationToken = default);
-        public virtual void RequestItemRetrieval(string itemId, CancellationToken cancellationToken = default);
         public virtual Task RequestItemRetrievalAsync(string itemId, CancellationToken cancellationToken = default);
-        public virtual void SendCommand(RealtimeClientCommand command, CancellationToken cancellationToken = default);
-        public virtual void SendCommand(BinaryData data, RequestOptions options);
         public virtual Task SendCommandAsync(RealtimeClientCommand command, CancellationToken cancellationToken = default);
         public virtual Task SendCommandAsync(BinaryData data, RequestOptions options);
-        public virtual void SendInputAudio(BinaryData audio, CancellationToken cancellationToken = default);
-        public virtual void SendInputAudio(Stream audio, CancellationToken cancellationToken = default);
         public virtual Task SendInputAudioAsync(BinaryData audio, CancellationToken cancellationToken = default);
         public virtual Task SendInputAudioAsync(Stream audio, CancellationToken cancellationToken = default);
-        public virtual void StartResponse(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default);
-        public virtual void StartResponse(CancellationToken cancellationToken = default);
         public virtual Task StartResponseAsync(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default);
         public virtual Task StartResponseAsync(CancellationToken cancellationToken = default);
-        public virtual void TruncateItem(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default);
         public virtual Task TruncateItemAsync(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default);
     }
     [Experimental("OPENAI002")]

--- a/api/in-progress/net8.0/OpenAI.Realtime.net8.0.cs
+++ b/api/in-progress/net8.0/OpenAI.Realtime.net8.0.cs
@@ -68,15 +68,10 @@ namespace OpenAI.Realtime {
             add;
             remove;
         }
-        public virtual ClientResult<CreateClientSecretResult> CreateRealtimeClientSecret(CreateClientSecretOptions options, CancellationToken cancellationToken = default);
-        public virtual ClientResult CreateRealtimeClientSecret(BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult<CreateClientSecretResult>> CreateRealtimeClientSecretAsync(CreateClientSecretOptions options, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult> CreateRealtimeClientSecretAsync(BinaryContent content, RequestOptions options = null);
-        public virtual RealtimeSessionClient StartConversationSession(string model, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartConversationSessionAsync(string model, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
-        public virtual RealtimeSessionClient StartSession(string model, string intent, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartSessionAsync(string model, string intent, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
-        public virtual RealtimeSessionClient StartTranscriptionSession(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartTranscriptionSessionAsync(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
     }
     [Experimental("OPENAI002")]
@@ -1368,44 +1363,25 @@ namespace OpenAI.Realtime {
     public class RealtimeSessionClient : IDisposable {
         protected internal RealtimeSessionClient(ApiKeyCredential credential, Uri endpoint, string model, string intent, RealtimeClient parentClient);
         public Net.WebSockets.WebSocket WebSocket { get; protected set; }
-        public virtual void AddItem(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default);
-        public virtual void AddItem(RealtimeItem item, CancellationToken cancellationToken = default);
         public virtual Task AddItemAsync(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default);
         public virtual Task AddItemAsync(RealtimeItem item, CancellationToken cancellationToken = default);
-        public virtual void CancelResponse(CancellationToken cancellationToken = default);
         public virtual Task CancelResponseAsync(CancellationToken cancellationToken = default);
-        public virtual void ClearInputAudio(CancellationToken cancellationToken = default);
         public virtual Task ClearInputAudioAsync(CancellationToken cancellationToken = default);
-        public virtual void CommitPendingAudio(CancellationToken cancellationToken = default);
         public virtual Task CommitPendingAudioAsync(CancellationToken cancellationToken = default);
-        public virtual void ConfigureConversationSession(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default);
         public virtual Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default);
-        public virtual void ConfigureTranscriptionSession(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default);
         public virtual Task ConfigureTranscriptionSessionAsync(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default);
-        protected internal virtual void Connect(string queryString = null, IDictionary<string, string> headers = null, CancellationToken cancellationToken = default);
         protected internal virtual Task ConnectAsync(string queryString = null, IDictionary<string, string> headers = null, CancellationToken cancellationToken = default);
-        public virtual void DeleteItem(string itemId, CancellationToken cancellationToken = default);
         public virtual Task DeleteItemAsync(string itemId, CancellationToken cancellationToken = default);
         public void Dispose();
-        public virtual IEnumerable<ClientResult> ReceiveUpdates(RequestOptions options);
-        public virtual IEnumerable<RealtimeServerUpdate> ReceiveUpdates(CancellationToken cancellationToken = default);
         public virtual IAsyncEnumerable<ClientResult> ReceiveUpdatesAsync(RequestOptions options);
         public virtual IAsyncEnumerable<RealtimeServerUpdate> ReceiveUpdatesAsync(CancellationToken cancellationToken = default);
-        public virtual void RequestItemRetrieval(string itemId, CancellationToken cancellationToken = default);
         public virtual Task RequestItemRetrievalAsync(string itemId, CancellationToken cancellationToken = default);
-        public virtual void SendCommand(RealtimeClientCommand command, CancellationToken cancellationToken = default);
-        public virtual void SendCommand(BinaryData data, RequestOptions options);
         public virtual Task SendCommandAsync(RealtimeClientCommand command, CancellationToken cancellationToken = default);
         public virtual Task SendCommandAsync(BinaryData data, RequestOptions options);
-        public virtual void SendInputAudio(BinaryData audio, CancellationToken cancellationToken = default);
-        public virtual void SendInputAudio(Stream audio, CancellationToken cancellationToken = default);
         public virtual Task SendInputAudioAsync(BinaryData audio, CancellationToken cancellationToken = default);
         public virtual Task SendInputAudioAsync(Stream audio, CancellationToken cancellationToken = default);
-        public virtual void StartResponse(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default);
-        public virtual void StartResponse(CancellationToken cancellationToken = default);
         public virtual Task StartResponseAsync(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default);
         public virtual Task StartResponseAsync(CancellationToken cancellationToken = default);
-        public virtual void TruncateItem(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default);
         public virtual Task TruncateItemAsync(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default);
     }
     [Experimental("OPENAI002")]

--- a/api/in-progress/netstandard2.0/OpenAI.Realtime.netstandard2.0.cs
+++ b/api/in-progress/netstandard2.0/OpenAI.Realtime.netstandard2.0.cs
@@ -55,15 +55,10 @@ namespace OpenAI.Realtime {
             add;
             remove;
         }
-        public virtual ClientResult<CreateClientSecretResult> CreateRealtimeClientSecret(CreateClientSecretOptions options, CancellationToken cancellationToken = default);
-        public virtual ClientResult CreateRealtimeClientSecret(BinaryContent content, RequestOptions options = null);
         public virtual Task<ClientResult<CreateClientSecretResult>> CreateRealtimeClientSecretAsync(CreateClientSecretOptions options, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult> CreateRealtimeClientSecretAsync(BinaryContent content, RequestOptions options = null);
-        public virtual RealtimeSessionClient StartConversationSession(string model, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartConversationSessionAsync(string model, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
-        public virtual RealtimeSessionClient StartSession(string model, string intent, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartSessionAsync(string model, string intent, RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
-        public virtual RealtimeSessionClient StartTranscriptionSession(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<RealtimeSessionClient> StartTranscriptionSessionAsync(RealtimeSessionClientOptions options = null, CancellationToken cancellationToken = default);
     }
     public class RealtimeClientCommand : IJsonModel<RealtimeClientCommand>, IPersistableModel<RealtimeClientCommand> {
@@ -1181,44 +1176,25 @@ namespace OpenAI.Realtime {
     public class RealtimeSessionClient : IDisposable {
         protected internal RealtimeSessionClient(ApiKeyCredential credential, Uri endpoint, string model, string intent, RealtimeClient parentClient);
         public Net.WebSockets.WebSocket WebSocket { get; protected set; }
-        public virtual void AddItem(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default);
-        public virtual void AddItem(RealtimeItem item, CancellationToken cancellationToken = default);
         public virtual Task AddItemAsync(RealtimeItem item, string previousItemId, CancellationToken cancellationToken = default);
         public virtual Task AddItemAsync(RealtimeItem item, CancellationToken cancellationToken = default);
-        public virtual void CancelResponse(CancellationToken cancellationToken = default);
         public virtual Task CancelResponseAsync(CancellationToken cancellationToken = default);
-        public virtual void ClearInputAudio(CancellationToken cancellationToken = default);
         public virtual Task ClearInputAudioAsync(CancellationToken cancellationToken = default);
-        public virtual void CommitPendingAudio(CancellationToken cancellationToken = default);
         public virtual Task CommitPendingAudioAsync(CancellationToken cancellationToken = default);
-        public virtual void ConfigureConversationSession(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default);
         public virtual Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions sessionOptions, CancellationToken cancellationToken = default);
-        public virtual void ConfigureTranscriptionSession(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default);
         public virtual Task ConfigureTranscriptionSessionAsync(RealtimeTranscriptionSessionOptions sessionOptions, CancellationToken cancellationToken = default);
-        protected internal virtual void Connect(string queryString = null, IDictionary<string, string> headers = null, CancellationToken cancellationToken = default);
         protected internal virtual Task ConnectAsync(string queryString = null, IDictionary<string, string> headers = null, CancellationToken cancellationToken = default);
-        public virtual void DeleteItem(string itemId, CancellationToken cancellationToken = default);
         public virtual Task DeleteItemAsync(string itemId, CancellationToken cancellationToken = default);
         public void Dispose();
-        public virtual IEnumerable<ClientResult> ReceiveUpdates(RequestOptions options);
-        public virtual IEnumerable<RealtimeServerUpdate> ReceiveUpdates(CancellationToken cancellationToken = default);
         public virtual IAsyncEnumerable<ClientResult> ReceiveUpdatesAsync(RequestOptions options);
         public virtual IAsyncEnumerable<RealtimeServerUpdate> ReceiveUpdatesAsync(CancellationToken cancellationToken = default);
-        public virtual void RequestItemRetrieval(string itemId, CancellationToken cancellationToken = default);
         public virtual Task RequestItemRetrievalAsync(string itemId, CancellationToken cancellationToken = default);
-        public virtual void SendCommand(RealtimeClientCommand command, CancellationToken cancellationToken = default);
-        public virtual void SendCommand(BinaryData data, RequestOptions options);
         public virtual Task SendCommandAsync(RealtimeClientCommand command, CancellationToken cancellationToken = default);
         public virtual Task SendCommandAsync(BinaryData data, RequestOptions options);
-        public virtual void SendInputAudio(BinaryData audio, CancellationToken cancellationToken = default);
-        public virtual void SendInputAudio(Stream audio, CancellationToken cancellationToken = default);
         public virtual Task SendInputAudioAsync(BinaryData audio, CancellationToken cancellationToken = default);
         public virtual Task SendInputAudioAsync(Stream audio, CancellationToken cancellationToken = default);
-        public virtual void StartResponse(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default);
-        public virtual void StartResponse(CancellationToken cancellationToken = default);
         public virtual Task StartResponseAsync(RealtimeResponseOptions responseOptions, CancellationToken cancellationToken = default);
         public virtual Task StartResponseAsync(CancellationToken cancellationToken = default);
-        public virtual void TruncateItem(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default);
         public virtual Task TruncateItemAsync(string itemId, int contentPartIndex, TimeSpan audioDuration, CancellationToken cancellationToken = default);
     }
     public class RealtimeSessionClientOptions {

--- a/tests/Realtime/RealtimeTests.cs
+++ b/tests/Realtime/RealtimeTests.cs
@@ -19,6 +19,7 @@ namespace OpenAI.Tests.Realtime;
 #pragma warning disable OPENAI002
 
 [LiveOnly(Reason = "Test framework doesn't support recording with web sockets yet")]
+[TestFixture(true)]
 public class RealtimeTests : RealtimeTestFixtureBase
 {
     public enum TestAudioSendType { WithAudioStreamHelper, WithManualAudioChunks }

--- a/tests/Realtime/RealtimeTests.cs
+++ b/tests/Realtime/RealtimeTests.cs
@@ -1262,7 +1262,7 @@ public class RealtimeTests : RealtimeTestFixtureBase
             SessionOptions = conversationSessionOptions,
         };
 
-        CreateClientSecretResult result = client.CreateRealtimeClientSecret(createClientSecretOptions);
+        CreateClientSecretResult result = await client.CreateRealtimeClientSecretAsync(createClientSecretOptions, CancellationToken);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Value, Is.Not.Null.And.Not.Empty);
@@ -1384,7 +1384,7 @@ public class RealtimeTests : RealtimeTestFixtureBase
             SessionOptions = transcriptionSessionOptions,
         };
 
-        CreateClientSecretResult result = client.CreateRealtimeClientSecret(createClientSecretOptions);
+        CreateClientSecretResult result = await client.CreateRealtimeClientSecretAsync(createClientSecretOptions, CancellationToken);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Value, Is.Not.Null.And.Not.Empty);

--- a/tests/Realtime/RealtimeToolTests.cs
+++ b/tests/Realtime/RealtimeToolTests.cs
@@ -12,6 +12,7 @@ namespace OpenAI.Tests.Realtime;
 #pragma warning disable OPENAI002
 
 [LiveOnly(Reason = "Test framework doesn't support recording with web sockets yet")]
+[TestFixture(true)]
 public class RealtimeToolTests : RealtimeTestFixtureBase
 {
     public RealtimeToolTests(bool isAsync) : base(isAsync, RecordedTestMode.Live)


### PR DESCRIPTION
## Summary

Removes the synchronous operation surface from `OpenAI.Realtime`, making the service and session operations on `RealtimeClient` and `RealtimeSessionClient` async-only.

This includes:

* removing synchronous session creation, command/audio sending, session configuration, conversation item, response, and update-receiving APIs
* removing the synchronous Realtime connection path and sync-only semaphore helper
* suppressing the generated synchronous `CreateRealtimeClientSecret` overloads so they are not restored by code generation
* migrating the remaining Realtime tests to the async client-secret API
* updating the in-progress API baselines and migration guidance

Async APIs and ordinary synchronous object functionality such as constructors, properties, events, and `IDisposable.Dispose` are unchanged.

Fixes #1370.

## Validation

* `Invoke-CodeGen.ps1 -Clean` completed successfully, including experimental API validation
* code generation does not restore the removed synchronous `CreateRealtimeClientSecret` overloads
* `Export-Api.ps1` completed successfully
* `api/released/**` is unchanged
* library and test projects build with 0 errors and 0 warnings
* Realtime tests (`net10.0`): 19 passed, 0 failed, 40 skipped (`LiveOnly`)
* codegen generator tests: 16 passed, 0 failed
* `git diff --check` passes

The skipped Realtime tests require live/recorded service infrastructure that was not available in the local environment.
