### PR TITLE
Upgrade generator to version 1.0.0-alpha.20260909.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
 
   <!-- Generator-Only Dependencies -->
   <ItemGroup Condition="'$(IsGeneratorProject)' == 'true' or $(MSBuildProjectName.EndsWith('Plugin'))">
-    <PackageVersion Include="Microsoft.TypeSpec.Generator.ClientModel" Version="1.0.0-alpha.20260902.4" />
+    <PackageVersion Include="Microsoft.TypeSpec.Generator.ClientModel" Version="1.0.0-alpha.20260909.5" />
   </ItemGroup>
 
   <!-- Transitive Dependency Overrides: https://github.com/advisories/GHSA-g4vj-cjjj-v7hg -->

--- a/OpenAI.Responses/src/Generated/Models/ApplyPatchCallItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ApplyPatchCallItem.Serialization.cs
@@ -182,6 +182,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("operation"u8))
             {
+                if (Operation == null)
+                {
+                    return false;
+                }
                 return Operation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("operation"u8.Length)], out value);
             }
             return false;
@@ -195,6 +199,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("operation"u8))
             {
+                if (Operation == null)
+                {
+                    return false;
+                }
                 Operation.Patch.Set([.. "$"u8, .. local.Slice("operation"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/CodeInterpreterCallResponseItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CodeInterpreterCallResponseItem.Serialization.cs
@@ -103,7 +103,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Outputs.Count; i++)
                 {
-                    if (Outputs[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.outputs[{i}]")) || Outputs[i] != null && Outputs[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -212,11 +212,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "outputs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Outputs == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveOutputsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Outputs.Count)
+                {
+                    return false;
+                }
+                if (Outputs[index] == null)
                 {
                     return false;
                 }
@@ -235,7 +243,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "outputs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Outputs == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Outputs.Count)
+                {
+                    return false;
+                }
+                if (Outputs[index] == null)
                 {
                     return false;
                 }
@@ -266,7 +282,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Outputs.Count; i++)
             {
-                if (!Outputs[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.outputs[{i}]")) && (Outputs[i] == null || !Outputs[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Outputs[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/CodeInterpreterTool.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CodeInterpreterTool.Serialization.cs
@@ -132,6 +132,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("container"u8))
             {
+                if (Container == null)
+                {
+                    return false;
+                }
                 return Container.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("container"u8.Length)], out value);
             }
             return false;
@@ -145,6 +149,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("container"u8))
             {
+                if (Container == null)
+                {
+                    return false;
+                }
                 Container.Patch.Set([.. "$"u8, .. local.Slice("container"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/ComputerCallOutputResponseItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerCallOutputResponseItem.Serialization.cs
@@ -98,7 +98,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < AcknowledgedSafetyChecks.Count; i++)
                 {
-                    if (AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.acknowledged_safety_checks[{i}]")) || AcknowledgedSafetyChecks[i] != null && AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -210,17 +210,29 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("output"u8))
             {
+                if (Output == null)
+                {
+                    return false;
+                }
                 return Output.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("output"u8.Length)], out value);
             }
             if (local.StartsWith("acknowledged_safety_checks"u8))
             {
                 int propertyLength = "acknowledged_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (AcknowledgedSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveAcknowledgedSafetyChecksArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= AcknowledgedSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (AcknowledgedSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -237,6 +249,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("output"u8))
             {
+                if (Output == null)
+                {
+                    return false;
+                }
                 Output.Patch.Set([.. "$"u8, .. local.Slice("output"u8.Length)], value);
                 return true;
             }
@@ -244,7 +260,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "acknowledged_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (AcknowledgedSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= AcknowledgedSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (AcknowledgedSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -275,7 +299,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < AcknowledgedSafetyChecks.Count; i++)
             {
-                if (!AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.acknowledged_safety_checks[{i}]")) && (AcknowledgedSafetyChecks[i] == null || !AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return AcknowledgedSafetyChecks[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/ComputerCallResponseItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ComputerCallResponseItem.Serialization.cs
@@ -103,7 +103,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < PendingSafetyChecks.Count; i++)
                 {
-                    if (PendingSafetyChecks[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.pending_safety_checks[{i}]")) || PendingSafetyChecks[i] != null && PendingSafetyChecks[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -206,17 +206,29 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 return Action.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("action"u8.Length)], out value);
             }
             if (local.StartsWith("pending_safety_checks"u8))
             {
                 int propertyLength = "pending_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (PendingSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolvePendingSafetyChecksArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= PendingSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (PendingSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -233,6 +245,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 Action.Patch.Set([.. "$"u8, .. local.Slice("action"u8.Length)], value);
                 return true;
             }
@@ -240,7 +256,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "pending_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (PendingSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= PendingSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (PendingSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -271,7 +295,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < PendingSafetyChecks.Count; i++)
             {
-                if (!PendingSafetyChecks[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.pending_safety_checks[{i}]")) && (PendingSafetyChecks[i] == null || !PendingSafetyChecks[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return PendingSafetyChecks[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/CreateResponseOptions.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CreateResponseOptions.Serialization.cs
@@ -188,7 +188,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Tools.Count; i++)
                 {
-                    if (Tools[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || Tools[i] != null && Tools[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -221,7 +221,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < InputItems.Count; i++)
                 {
-                    if (InputItems[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.input[{i}]")) || InputItems[i] != null && InputItems[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -641,25 +641,45 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("reasoning"u8))
             {
+                if (ReasoningOptions == null)
+                {
+                    return false;
+                }
                 return ReasoningOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("reasoning"u8.Length)], out value);
             }
             if (local.StartsWith("text"u8))
             {
+                if (TextOptions == null)
+                {
+                    return false;
+                }
                 return TextOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("text"u8.Length)], out value);
             }
             if (local.StartsWith("conversation"u8))
             {
+                if (ConversationOptions == null)
+                {
+                    return false;
+                }
                 return ConversationOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("conversation"u8.Length)], out value);
             }
             if (local.StartsWith("tools"u8))
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -669,11 +689,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "input"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InputItems == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveInputItemsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InputItems.Count)
+                {
+                    return false;
+                }
+                if (InputItems[index] == null)
                 {
                     return false;
                 }
@@ -690,16 +718,28 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("reasoning"u8))
             {
+                if (ReasoningOptions == null)
+                {
+                    return false;
+                }
                 ReasoningOptions.Patch.Set([.. "$"u8, .. local.Slice("reasoning"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("text"u8))
             {
+                if (TextOptions == null)
+                {
+                    return false;
+                }
                 TextOptions.Patch.Set([.. "$"u8, .. local.Slice("text"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("conversation"u8))
             {
+                if (ConversationOptions == null)
+                {
+                    return false;
+                }
                 ConversationOptions.Patch.Set([.. "$"u8, .. local.Slice("conversation"u8.Length)], value);
                 return true;
             }
@@ -707,7 +747,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -718,7 +766,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "input"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InputItems == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InputItems.Count)
+                {
+                    return false;
+                }
+                if (InputItems[index] == null)
                 {
                     return false;
                 }
@@ -749,7 +805,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Tools.Count; i++)
             {
-                if (!Tools[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (Tools[i] == null || !Tools[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Tools[i];
                 }
@@ -777,7 +833,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < InputItems.Count; i++)
             {
-                if (!InputItems[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.input[{i}]")) && (InputItems[i] == null || !InputItems[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return InputItems[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/CustomMcpToolCallApprovalPolicy.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CustomMcpToolCallApprovalPolicy.Serialization.cs
@@ -140,10 +140,18 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("always"u8))
             {
+                if (ToolsAlwaysRequiringApproval == null)
+                {
+                    return false;
+                }
                 return ToolsAlwaysRequiringApproval.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("always"u8.Length)], out value);
             }
             if (local.StartsWith("never"u8))
             {
+                if (ToolsNeverRequiringApproval == null)
+                {
+                    return false;
+                }
                 return ToolsNeverRequiringApproval.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("never"u8.Length)], out value);
             }
             return false;
@@ -157,11 +165,19 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("always"u8))
             {
+                if (ToolsAlwaysRequiringApproval == null)
+                {
+                    return false;
+                }
                 ToolsAlwaysRequiringApproval.Patch.Set([.. "$"u8, .. local.Slice("always"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("never"u8))
             {
+                if (ToolsNeverRequiringApproval == null)
+                {
+                    return false;
+                }
                 ToolsNeverRequiringApproval.Patch.Set([.. "$"u8, .. local.Slice("never"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/CustomTool.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CustomTool.Serialization.cs
@@ -219,6 +219,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("format"u8))
             {
+                if (ToolFormat == null)
+                {
+                    return false;
+                }
                 return ToolFormat.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("format"u8.Length)], out value);
             }
             return false;
@@ -232,6 +236,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("format"u8))
             {
+                if (ToolFormat == null)
+                {
+                    return false;
+                }
                 ToolFormat.Patch.Set([.. "$"u8, .. local.Slice("format"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/CustomToolCallItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CustomToolCallItem.Serialization.cs
@@ -240,10 +240,18 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 return Agent.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("agent"u8.Length)], out value);
             }
             if (local.StartsWith("caller"u8))
             {
+                if (Caller == null)
+                {
+                    return false;
+                }
                 return Caller.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("caller"u8.Length)], out value);
             }
             return false;
@@ -257,11 +265,19 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 Agent.Patch.Set([.. "$"u8, .. local.Slice("agent"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("caller"u8))
             {
+                if (Caller == null)
+                {
+                    return false;
+                }
                 Caller.Patch.Set([.. "$"u8, .. local.Slice("caller"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/CustomToolCallOutputItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/CustomToolCallOutputItem.Serialization.cs
@@ -93,7 +93,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Output.Count; i++)
                 {
-                    if (Output[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.output[{i}]")) || Output[i] != null && Output[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -235,21 +235,37 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 return Agent.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("agent"u8.Length)], out value);
             }
             if (local.StartsWith("caller"u8))
             {
+                if (Caller == null)
+                {
+                    return false;
+                }
                 return Caller.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("caller"u8.Length)], out value);
             }
             if (local.StartsWith("output"u8))
             {
                 int propertyLength = "output"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Output == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveOutputArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Output.Count)
+                {
+                    return false;
+                }
+                if (Output[index] == null)
                 {
                     return false;
                 }
@@ -266,11 +282,19 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 Agent.Patch.Set([.. "$"u8, .. local.Slice("agent"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("caller"u8))
             {
+                if (Caller == null)
+                {
+                    return false;
+                }
                 Caller.Patch.Set([.. "$"u8, .. local.Slice("caller"u8.Length)], value);
                 return true;
             }
@@ -278,7 +302,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "output"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Output == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Output.Count)
+                {
+                    return false;
+                }
+                if (Output[index] == null)
                 {
                     return false;
                 }
@@ -309,7 +341,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Output.Count; i++)
             {
-                if (!Output[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.output[{i}]")) && (Output[i] == null || !Output[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Output[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/FileSearchCallResponseItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/FileSearchCallResponseItem.Serialization.cs
@@ -121,7 +121,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Results.Count; i++)
                 {
-                    if (Results[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.results[{i}]")) || Results[i] != null && Results[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -235,11 +235,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "results"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Results == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveResultsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Results.Count)
+                {
+                    return false;
+                }
+                if (Results[index] == null)
                 {
                     return false;
                 }
@@ -258,7 +266,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "results"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Results == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Results.Count)
+                {
+                    return false;
+                }
+                if (Results[index] == null)
                 {
                     return false;
                 }
@@ -289,7 +305,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Results.Count; i++)
             {
-                if (!Results[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.results[{i}]")) && (Results[i] == null || !Results[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Results[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/FileSearchTool.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/FileSearchTool.Serialization.cs
@@ -227,6 +227,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("ranking_options"u8))
             {
+                if (RankingOptions == null)
+                {
+                    return false;
+                }
                 return RankingOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("ranking_options"u8.Length)], out value);
             }
             return false;
@@ -240,6 +244,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("ranking_options"u8))
             {
+                if (RankingOptions == null)
+                {
+                    return false;
+                }
                 RankingOptions.Patch.Set([.. "$"u8, .. local.Slice("ranking_options"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/ImageGenerationTool.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ImageGenerationTool.Serialization.cs
@@ -291,6 +291,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("input_image_mask"u8))
             {
+                if (InputImageMask == null)
+                {
+                    return false;
+                }
                 return InputImageMask.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("input_image_mask"u8.Length)], out value);
             }
             return false;
@@ -304,6 +308,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("input_image_mask"u8))
             {
+                if (InputImageMask == null)
+                {
+                    return false;
+                }
                 InputImageMask.Patch.Set([.. "$"u8, .. local.Slice("input_image_mask"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/InternalCodeInterpreterToolCallItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalCodeInterpreterToolCallItemParam.Serialization.cs
@@ -98,7 +98,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Outputs.Count; i++)
                 {
-                    if (Outputs[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.outputs[{i}]")) || Outputs[i] != null && Outputs[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -184,11 +184,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "outputs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Outputs == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveOutputsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Outputs.Count)
+                {
+                    return false;
+                }
+                if (Outputs[index] == null)
                 {
                     return false;
                 }
@@ -207,7 +215,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "outputs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Outputs == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Outputs.Count)
+                {
+                    return false;
+                }
+                if (Outputs[index] == null)
                 {
                     return false;
                 }
@@ -238,7 +254,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Outputs.Count; i++)
             {
-                if (!Outputs[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.outputs[{i}]")) && (Outputs[i] == null || !Outputs[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Outputs[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalComputerActionDrag.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalComputerActionDrag.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Path.Count; i++)
                 {
-                    if (Path[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.path[{i}]")) || Path[i] != null && Path[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -158,11 +158,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "path"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Path == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolvePathArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Path.Count)
+                {
+                    return false;
+                }
+                if (Path[index] == null)
                 {
                     return false;
                 }
@@ -181,7 +189,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "path"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Path == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Path.Count)
+                {
+                    return false;
+                }
+                if (Path[index] == null)
                 {
                     return false;
                 }
@@ -212,7 +228,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Path.Count; i++)
             {
-                if (!Path[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.path[{i}]")) && (Path[i] == null || !Path[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Path[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalComputerUsePreviewToolCallItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalComputerUsePreviewToolCallItemParam.Serialization.cs
@@ -98,7 +98,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < PendingSafetyChecks.Count; i++)
                 {
-                    if (PendingSafetyChecks[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.pending_safety_checks[{i}]")) || PendingSafetyChecks[i] != null && PendingSafetyChecks[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -178,17 +178,29 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 return Action.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("action"u8.Length)], out value);
             }
             if (local.StartsWith("pending_safety_checks"u8))
             {
                 int propertyLength = "pending_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (PendingSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolvePendingSafetyChecksArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= PendingSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (PendingSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -205,6 +217,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 Action.Patch.Set([.. "$"u8, .. local.Slice("action"u8.Length)], value);
                 return true;
             }
@@ -212,7 +228,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "pending_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (PendingSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= PendingSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (PendingSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -243,7 +267,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < PendingSafetyChecks.Count; i++)
             {
-                if (!PendingSafetyChecks[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.pending_safety_checks[{i}]")) && (PendingSafetyChecks[i] == null || !PendingSafetyChecks[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return PendingSafetyChecks[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalComputerUsePreviewToolCallOutputItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalComputerUsePreviewToolCallOutputItemParam.Serialization.cs
@@ -93,7 +93,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < AcknowledgedSafetyChecks.Count; i++)
                 {
-                    if (AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.acknowledged_safety_checks[{i}]")) || AcknowledgedSafetyChecks[i] != null && AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -182,17 +182,29 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("output"u8))
             {
+                if (Output == null)
+                {
+                    return false;
+                }
                 return Output.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("output"u8.Length)], out value);
             }
             if (local.StartsWith("acknowledged_safety_checks"u8))
             {
                 int propertyLength = "acknowledged_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (AcknowledgedSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveAcknowledgedSafetyChecksArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= AcknowledgedSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (AcknowledgedSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -209,6 +221,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("output"u8))
             {
+                if (Output == null)
+                {
+                    return false;
+                }
                 Output.Patch.Set([.. "$"u8, .. local.Slice("output"u8.Length)], value);
                 return true;
             }
@@ -216,7 +232,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "acknowledged_safety_checks"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (AcknowledgedSafetyChecks == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= AcknowledgedSafetyChecks.Count)
+                {
+                    return false;
+                }
+                if (AcknowledgedSafetyChecks[index] == null)
                 {
                     return false;
                 }
@@ -247,7 +271,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < AcknowledgedSafetyChecks.Count; i++)
             {
-                if (!AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.acknowledged_safety_checks[{i}]")) && (AcknowledgedSafetyChecks[i] == null || !AcknowledgedSafetyChecks[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return AcknowledgedSafetyChecks[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalFileSearchToolCallItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalFileSearchToolCallItemParam.Serialization.cs
@@ -116,7 +116,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Results.Count; i++)
                 {
-                    if (Results[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.results[{i}]")) || Results[i] != null && Results[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -208,11 +208,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "results"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Results == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveResultsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Results.Count)
+                {
+                    return false;
+                }
+                if (Results[index] == null)
                 {
                     return false;
                 }
@@ -231,7 +239,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "results"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Results == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Results.Count)
+                {
+                    return false;
+                }
+                if (Results[index] == null)
                 {
                     return false;
                 }
@@ -262,7 +278,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Results.Count; i++)
             {
-                if (!Results[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.results[{i}]")) && (Results[i] == null || !Results[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Results[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalItemContentOutputText.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalItemContentOutputText.Serialization.cs
@@ -93,7 +93,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Annotations.Count; i++)
                 {
-                    if (Annotations[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.annotations[{i}]")) || Annotations[i] != null && Annotations[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -116,7 +116,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Logprobs.Count; i++)
                 {
-                    if (Logprobs[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) || Logprobs[i] != null && Logprobs[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -207,11 +207,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "annotations"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Annotations == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveAnnotationsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Annotations.Count)
+                {
+                    return false;
+                }
+                if (Annotations[index] == null)
                 {
                     return false;
                 }
@@ -221,11 +229,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveLogprobsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Logprobs.Count)
+                {
+                    return false;
+                }
+                if (Logprobs[index] == null)
                 {
                     return false;
                 }
@@ -244,7 +260,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "annotations"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Annotations == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Annotations.Count)
+                {
+                    return false;
+                }
+                if (Annotations[index] == null)
                 {
                     return false;
                 }
@@ -255,7 +279,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Logprobs.Count)
+                {
+                    return false;
+                }
+                if (Logprobs[index] == null)
                 {
                     return false;
                 }
@@ -286,7 +318,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Annotations.Count; i++)
             {
-                if (!Annotations[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.annotations[{i}]")) && (Annotations[i] == null || !Annotations[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Annotations[i];
                 }
@@ -314,7 +346,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Logprobs.Count; i++)
             {
-                if (!Logprobs[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) && (Logprobs[i] == null || !Logprobs[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Logprobs[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalLocalShellToolCallItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalLocalShellToolCallItemParam.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 return Action.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("action"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 Action.Patch.Set([.. "$"u8, .. local.Slice("action"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/InternalLocalShellToolCallItemResource.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalLocalShellToolCallItemResource.Serialization.cs
@@ -170,6 +170,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 return Action.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("action"u8.Length)], out value);
             }
             return false;
@@ -183,6 +187,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 Action.Patch.Set([.. "$"u8, .. local.Slice("action"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/InternalMCPListToolsItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalMCPListToolsItemParam.Serialization.cs
@@ -93,7 +93,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Tools.Count; i++)
                 {
-                    if (Tools[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || Tools[i] != null && Tools[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -185,11 +185,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -208,7 +216,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -239,7 +255,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Tools.Count; i++)
             {
-                if (!Tools[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (Tools[i] == null || !Tools[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Tools[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalMCPToolRequireApproval1.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalMCPToolRequireApproval1.Serialization.cs
@@ -140,10 +140,18 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("always"u8))
             {
+                if (Always == null)
+                {
+                    return false;
+                }
                 return Always.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("always"u8.Length)], out value);
             }
             if (local.StartsWith("never"u8))
             {
+                if (Never == null)
+                {
+                    return false;
+                }
                 return Never.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("never"u8.Length)], out value);
             }
             return false;
@@ -157,11 +165,19 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("always"u8))
             {
+                if (Always == null)
+                {
+                    return false;
+                }
                 Always.Patch.Set([.. "$"u8, .. local.Slice("always"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("never"u8))
             {
+                if (Never == null)
+                {
+                    return false;
+                }
                 Never.Patch.Set([.. "$"u8, .. local.Slice("never"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/InternalReasoningItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalReasoningItemParam.Serialization.cs
@@ -93,7 +93,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Summary.Count; i++)
                 {
-                    if (Summary[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.summary[{i}]")) || Summary[i] != null && Summary[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -174,11 +174,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "summary"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Summary == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveSummaryArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Summary.Count)
+                {
+                    return false;
+                }
+                if (Summary[index] == null)
                 {
                     return false;
                 }
@@ -197,7 +205,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "summary"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Summary == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Summary.Count)
+                {
+                    return false;
+                }
+                if (Summary[index] == null)
                 {
                     return false;
                 }
@@ -228,7 +244,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Summary.Count; i++)
             {
-                if (!Summary[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.summary[{i}]")) && (Summary[i] == null || !Summary[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Summary[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponseErrorResponse.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponseErrorResponse.Serialization.cs
@@ -125,6 +125,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             return false;
@@ -138,6 +142,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 Error.Patch.Set([.. "$"u8, .. local.Slice("error"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesAssistantMessage.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesAssistantMessage.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < InternalContent.Count; i++)
                 {
-                    if (InternalContent[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || InternalContent[i] != null && InternalContent[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -186,11 +186,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveInternalContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -209,7 +217,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -240,7 +256,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < InternalContent.Count; i++)
             {
-                if (!InternalContent[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (InternalContent[i] == null || !InternalContent[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return InternalContent[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesAssistantMessageItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesAssistantMessageItemParam.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Content.Count; i++)
                 {
-                    if (Content[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || Content[i] != null && Content[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -164,11 +164,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -187,7 +195,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -218,7 +234,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Content.Count; i++)
             {
-                if (!Content[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (Content[i] == null || !Content[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Content[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesDeveloperMessage.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesDeveloperMessage.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < InternalContent.Count; i++)
                 {
-                    if (InternalContent[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || InternalContent[i] != null && InternalContent[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -186,11 +186,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveInternalContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -209,7 +217,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -240,7 +256,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < InternalContent.Count; i++)
             {
-                if (!InternalContent[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (InternalContent[i] == null || !InternalContent[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return InternalContent[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesDeveloperMessageItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesDeveloperMessageItemParam.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Content.Count; i++)
                 {
-                    if (Content[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || Content[i] != null && Content[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -164,11 +164,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -187,7 +195,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -218,7 +234,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Content.Count; i++)
             {
-                if (!Content[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (Content[i] == null || !Content[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Content[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesSystemMessage.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesSystemMessage.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < InternalContent.Count; i++)
                 {
-                    if (InternalContent[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || InternalContent[i] != null && InternalContent[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -186,11 +186,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveInternalContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -209,7 +217,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -240,7 +256,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < InternalContent.Count; i++)
             {
-                if (!InternalContent[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (InternalContent[i] == null || !InternalContent[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return InternalContent[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesSystemMessageItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesSystemMessageItemParam.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Content.Count; i++)
                 {
-                    if (Content[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || Content[i] != null && Content[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -164,11 +164,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -187,7 +195,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -218,7 +234,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Content.Count; i++)
             {
-                if (!Content[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (Content[i] == null || !Content[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Content[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesUserMessage.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesUserMessage.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < InternalContent.Count; i++)
                 {
-                    if (InternalContent[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || InternalContent[i] != null && InternalContent[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -186,11 +186,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveInternalContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -209,7 +217,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InternalContent == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InternalContent.Count)
+                {
+                    return false;
+                }
+                if (InternalContent[index] == null)
                 {
                     return false;
                 }
@@ -240,7 +256,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < InternalContent.Count; i++)
             {
-                if (!InternalContent[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (InternalContent[i] == null || !InternalContent[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return InternalContent[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/InternalResponsesUserMessageItemParam.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/InternalResponsesUserMessageItemParam.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Content.Count; i++)
                 {
-                    if (Content[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || Content[i] != null && Content[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -164,11 +164,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -187,7 +195,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -218,7 +234,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Content.Count; i++)
             {
-                if (!Content[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (Content[i] == null || !Content[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Content[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/McpTool.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/McpTool.Serialization.cs
@@ -274,10 +274,18 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("allowed_tools"u8))
             {
+                if (AllowedTools == null)
+                {
+                    return false;
+                }
                 return AllowedTools.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("allowed_tools"u8.Length)], out value);
             }
             if (local.StartsWith("require_approval"u8))
             {
+                if (ToolCallApprovalPolicy == null)
+                {
+                    return false;
+                }
                 return ToolCallApprovalPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("require_approval"u8.Length)], out value);
             }
             return false;
@@ -291,11 +299,19 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("allowed_tools"u8))
             {
+                if (AllowedTools == null)
+                {
+                    return false;
+                }
                 AllowedTools.Patch.Set([.. "$"u8, .. local.Slice("allowed_tools"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("require_approval"u8))
             {
+                if (ToolCallApprovalPolicy == null)
+                {
+                    return false;
+                }
                 ToolCallApprovalPolicy.Patch.Set([.. "$"u8, .. local.Slice("require_approval"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/McpToolDefinitionListItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/McpToolDefinitionListItem.Serialization.cs
@@ -93,7 +93,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < ToolDefinitions.Count; i++)
                 {
-                    if (ToolDefinitions[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || ToolDefinitions[i] != null && ToolDefinitions[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -204,11 +204,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolDefinitions == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolDefinitionsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolDefinitions.Count)
+                {
+                    return false;
+                }
+                if (ToolDefinitions[index] == null)
                 {
                     return false;
                 }
@@ -227,7 +235,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolDefinitions == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolDefinitions.Count)
+                {
+                    return false;
+                }
+                if (ToolDefinitions[index] == null)
                 {
                     return false;
                 }
@@ -258,7 +274,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < ToolDefinitions.Count; i++)
             {
-                if (!ToolDefinitions[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (ToolDefinitions[i] == null || !ToolDefinitions[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return ToolDefinitions[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/ReasoningResponseItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ReasoningResponseItem.Serialization.cs
@@ -98,7 +98,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < SummaryParts.Count; i++)
                 {
-                    if (SummaryParts[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.summary[{i}]")) || SummaryParts[i] != null && SummaryParts[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -201,11 +201,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "summary"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (SummaryParts == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveSummaryPartsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= SummaryParts.Count)
+                {
+                    return false;
+                }
+                if (SummaryParts[index] == null)
                 {
                     return false;
                 }
@@ -224,7 +232,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "summary"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (SummaryParts == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= SummaryParts.Count)
+                {
+                    return false;
+                }
+                if (SummaryParts[index] == null)
                 {
                     return false;
                 }
@@ -255,7 +271,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < SummaryParts.Count; i++)
             {
-                if (!SummaryParts[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.summary[{i}]")) && (SummaryParts[i] == null || !SummaryParts[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return SummaryParts[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/ResponseItemCollectionPage.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ResponseItemCollectionPage.Serialization.cs
@@ -101,7 +101,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Data.Count; i++)
                 {
-                    if (Data[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) || Data[i] != null && Data[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -210,11 +210,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveDataArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -233,7 +241,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -264,7 +280,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Data.Count; i++)
             {
-                if (!Data[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) && (Data[i] == null || !Data[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Data[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/ResponseResult.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ResponseResult.Serialization.cs
@@ -207,7 +207,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Tools.Count; i++)
                 {
-                    if (Tools[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || Tools[i] != null && Tools[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -278,7 +278,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < OutputItems.Count; i++)
                 {
-                    if (OutputItems[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.output[{i}]")) || OutputItems[i] != null && OutputItems[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -301,7 +301,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Instructions.Count; i++)
                 {
-                    if (Instructions[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.instructions[{i}]")) || Instructions[i] != null && Instructions[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -712,37 +712,69 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("reasoning"u8))
             {
+                if (ReasoningOptions == null)
+                {
+                    return false;
+                }
                 return ReasoningOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("reasoning"u8.Length)], out value);
             }
             if (local.StartsWith("text"u8))
             {
+                if (TextOptions == null)
+                {
+                    return false;
+                }
                 return TextOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("text"u8.Length)], out value);
             }
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             if (local.StartsWith("incomplete_details"u8))
             {
+                if (IncompleteStatusDetails == null)
+                {
+                    return false;
+                }
                 return IncompleteStatusDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("incomplete_details"u8.Length)], out value);
             }
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 return Usage.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("usage"u8.Length)], out value);
             }
             if (local.StartsWith("conversation"u8))
             {
+                if (ConversationOptions == null)
+                {
+                    return false;
+                }
                 return ConversationOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("conversation"u8.Length)], out value);
             }
             if (local.StartsWith("tools"u8))
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -752,11 +784,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "output"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (OutputItems == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveOutputItemsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= OutputItems.Count)
+                {
+                    return false;
+                }
+                if (OutputItems[index] == null)
                 {
                     return false;
                 }
@@ -766,11 +806,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "instructions"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Instructions == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveInstructionsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Instructions.Count)
+                {
+                    return false;
+                }
+                if (Instructions[index] == null)
                 {
                     return false;
                 }
@@ -787,31 +835,55 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("reasoning"u8))
             {
+                if (ReasoningOptions == null)
+                {
+                    return false;
+                }
                 ReasoningOptions.Patch.Set([.. "$"u8, .. local.Slice("reasoning"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("text"u8))
             {
+                if (TextOptions == null)
+                {
+                    return false;
+                }
                 TextOptions.Patch.Set([.. "$"u8, .. local.Slice("text"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 Error.Patch.Set([.. "$"u8, .. local.Slice("error"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("incomplete_details"u8))
             {
+                if (IncompleteStatusDetails == null)
+                {
+                    return false;
+                }
                 IncompleteStatusDetails.Patch.Set([.. "$"u8, .. local.Slice("incomplete_details"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 Usage.Patch.Set([.. "$"u8, .. local.Slice("usage"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("conversation"u8))
             {
+                if (ConversationOptions == null)
+                {
+                    return false;
+                }
                 ConversationOptions.Patch.Set([.. "$"u8, .. local.Slice("conversation"u8.Length)], value);
                 return true;
             }
@@ -819,7 +891,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -830,7 +910,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "output"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (OutputItems == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= OutputItems.Count)
+                {
+                    return false;
+                }
+                if (OutputItems[index] == null)
                 {
                     return false;
                 }
@@ -841,7 +929,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "instructions"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Instructions == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Instructions.Count)
+                {
+                    return false;
+                }
+                if (Instructions[index] == null)
                 {
                     return false;
                 }
@@ -872,7 +968,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Tools.Count; i++)
             {
-                if (!Tools[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (Tools[i] == null || !Tools[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Tools[i];
                 }
@@ -900,7 +996,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < OutputItems.Count; i++)
             {
-                if (!OutputItems[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.output[{i}]")) && (OutputItems[i] == null || !OutputItems[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return OutputItems[i];
                 }
@@ -928,7 +1024,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Instructions.Count; i++)
             {
-                if (!Instructions[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.instructions[{i}]")) && (Instructions[i] == null || !Instructions[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Instructions[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/ResponseTextOptions.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ResponseTextOptions.Serialization.cs
@@ -125,6 +125,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("format"u8))
             {
+                if (TextFormat == null)
+                {
+                    return false;
+                }
                 return TextFormat.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("format"u8.Length)], out value);
             }
             return false;
@@ -138,6 +142,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("format"u8))
             {
+                if (TextFormat == null)
+                {
+                    return false;
+                }
                 TextFormat.Patch.Set([.. "$"u8, .. local.Slice("format"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/ResponseTokenLogProbabilityDetails.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ResponseTokenLogProbabilityDetails.Serialization.cs
@@ -120,7 +120,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < TopLogProbabilities.Count; i++)
                 {
-                    if (TopLogProbabilities[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.top_logprobs[{i}]")) || TopLogProbabilities[i] != null && TopLogProbabilities[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -213,11 +213,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "top_logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TopLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveTopLogProbabilitiesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TopLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TopLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -236,7 +244,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "top_logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TopLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TopLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TopLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -267,7 +283,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < TopLogProbabilities.Count; i++)
             {
-                if (!TopLogProbabilities[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.top_logprobs[{i}]")) && (TopLogProbabilities[i] == null || !TopLogProbabilities[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return TopLogProbabilities[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/ResponseTokenUsage.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/ResponseTokenUsage.Serialization.cs
@@ -175,10 +175,18 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("input_tokens_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 return InputTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("input_tokens_details"u8.Length)], out value);
             }
             if (local.StartsWith("output_tokens_details"u8))
             {
+                if (OutputTokenDetails == null)
+                {
+                    return false;
+                }
                 return OutputTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("output_tokens_details"u8.Length)], out value);
             }
             return false;
@@ -192,11 +200,19 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("input_tokens_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 InputTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("input_tokens_details"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("output_tokens_details"u8))
             {
+                if (OutputTokenDetails == null)
+                {
+                    return false;
+                }
                 OutputTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("output_tokens_details"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseCompletedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseCompletedUpdate.Serialization.cs
@@ -138,6 +138,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -151,6 +155,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseContentPartAddedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseContentPartAddedUpdate.Serialization.cs
@@ -178,6 +178,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 return Part.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("part"u8.Length)], out value);
             }
             return false;
@@ -191,6 +195,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 Part.Patch.Set([.. "$"u8, .. local.Slice("part"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseContentPartDoneUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseContentPartDoneUpdate.Serialization.cs
@@ -178,6 +178,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 return Part.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("part"u8.Length)], out value);
             }
             return false;
@@ -191,6 +195,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 Part.Patch.Set([.. "$"u8, .. local.Slice("part"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseCreatedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseCreatedUpdate.Serialization.cs
@@ -138,6 +138,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -151,6 +155,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseCustomToolCallInputDeltaUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseCustomToolCallInputDeltaUpdate.Serialization.cs
@@ -183,6 +183,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 return Agent.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("agent"u8.Length)], out value);
             }
             return false;
@@ -196,6 +200,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 Agent.Patch.Set([.. "$"u8, .. local.Slice("agent"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseCustomToolCallInputDoneUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseCustomToolCallInputDoneUpdate.Serialization.cs
@@ -183,6 +183,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 return Agent.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("agent"u8.Length)], out value);
             }
             return false;
@@ -196,6 +200,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("agent"u8))
             {
+                if (Agent == null)
+                {
+                    return false;
+                }
                 Agent.Patch.Set([.. "$"u8, .. local.Slice("agent"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseFailedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseFailedUpdate.Serialization.cs
@@ -138,6 +138,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -151,6 +155,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseInProgressUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseInProgressUpdate.Serialization.cs
@@ -138,6 +138,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -151,6 +155,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseIncompleteUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseIncompleteUpdate.Serialization.cs
@@ -138,6 +138,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -151,6 +155,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputItemAddedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputItemAddedUpdate.Serialization.cs
@@ -149,6 +149,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -162,6 +166,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputItemDoneUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputItemDoneUpdate.Serialization.cs
@@ -149,6 +149,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -162,6 +166,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputTextAnnotationAddedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputTextAnnotationAddedUpdate.Serialization.cs
@@ -190,6 +190,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("annotation"u8))
             {
+                if (Annotation == null)
+                {
+                    return false;
+                }
                 return Annotation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("annotation"u8.Length)], out value);
             }
             return false;
@@ -203,6 +207,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("annotation"u8))
             {
+                if (Annotation == null)
+                {
+                    return false;
+                }
                 Annotation.Patch.Set([.. "$"u8, .. local.Slice("annotation"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputTextDeltaUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputTextDeltaUpdate.Serialization.cs
@@ -108,7 +108,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < TokenLogProbabilities.Count; i++)
                 {
-                    if (TokenLogProbabilities[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) || TokenLogProbabilities[i] != null && TokenLogProbabilities[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -216,11 +216,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TokenLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveTokenLogProbabilitiesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TokenLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TokenLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -239,7 +247,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TokenLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TokenLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TokenLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -270,7 +286,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < TokenLogProbabilities.Count; i++)
             {
-                if (!TokenLogProbabilities[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) && (TokenLogProbabilities[i] == null || !TokenLogProbabilities[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return TokenLogProbabilities[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputTextDoneUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseOutputTextDoneUpdate.Serialization.cs
@@ -108,7 +108,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < TokenLogProbabilities.Count; i++)
                 {
-                    if (TokenLogProbabilities[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) || TokenLogProbabilities[i] != null && TokenLogProbabilities[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -216,11 +216,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TokenLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveTokenLogProbabilitiesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TokenLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TokenLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -239,7 +247,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TokenLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TokenLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TokenLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -270,7 +286,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < TokenLogProbabilities.Count; i++)
             {
-                if (!TokenLogProbabilities[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) && (TokenLogProbabilities[i] == null || !TokenLogProbabilities[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return TokenLogProbabilities[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseQueuedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseQueuedUpdate.Serialization.cs
@@ -138,6 +138,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -151,6 +155,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseReasoningSummaryPartAddedUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseReasoningSummaryPartAddedUpdate.Serialization.cs
@@ -178,6 +178,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 return Part.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("part"u8.Length)], out value);
             }
             return false;
@@ -191,6 +195,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 Part.Patch.Set([.. "$"u8, .. local.Slice("part"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/StreamingResponseReasoningSummaryPartDoneUpdate.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/StreamingResponseReasoningSummaryPartDoneUpdate.Serialization.cs
@@ -178,6 +178,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 return Part.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("part"u8.Length)], out value);
             }
             return false;
@@ -191,6 +195,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 Part.Patch.Set([.. "$"u8, .. local.Slice("part"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/WebSearchCallResponseItem.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/WebSearchCallResponseItem.Serialization.cs
@@ -153,6 +153,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 return Action.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("action"u8.Length)], out value);
             }
             return false;
@@ -166,6 +170,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("action"u8))
             {
+                if (Action == null)
+                {
+                    return false;
+                }
                 Action.Patch.Set([.. "$"u8, .. local.Slice("action"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/WebSearchPreviewTool.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/WebSearchPreviewTool.Serialization.cs
@@ -148,6 +148,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("user_location"u8))
             {
+                if (UserLocation == null)
+                {
+                    return false;
+                }
                 return UserLocation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("user_location"u8.Length)], out value);
             }
             return false;
@@ -161,6 +165,10 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("user_location"u8))
             {
+                if (UserLocation == null)
+                {
+                    return false;
+                }
                 UserLocation.Patch.Set([.. "$"u8, .. local.Slice("user_location"u8.Length)], value);
                 return true;
             }

--- a/OpenAI.Responses/src/Generated/Models/WebSearchSearchAction.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/WebSearchSearchAction.Serialization.cs
@@ -117,7 +117,7 @@ namespace OpenAI.Responses
                 writer.WriteStartArray();
                 for (int i = 0; i < Sources.Count; i++)
                 {
-                    if (Sources[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.sources[{i}]")) || Sources[i] != null && Sources[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -219,11 +219,19 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "sources"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Sources == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveSourcesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Sources.Count)
+                {
+                    return false;
+                }
+                if (Sources[index] == null)
                 {
                     return false;
                 }
@@ -242,7 +250,15 @@ namespace OpenAI.Responses
             {
                 int propertyLength = "sources"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Sources == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Sources.Count)
+                {
+                    return false;
+                }
+                if (Sources[index] == null)
                 {
                     return false;
                 }
@@ -273,7 +289,7 @@ namespace OpenAI.Responses
             }
             for (int i = 0; i < Sources.Count; i++)
             {
-                if (!Sources[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.sources[{i}]")) && (Sources[i] == null || !Sources[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Sources[i];
                 }

--- a/OpenAI.Responses/src/Generated/Models/WebSearchTool.Serialization.cs
+++ b/OpenAI.Responses/src/Generated/Models/WebSearchTool.Serialization.cs
@@ -164,10 +164,18 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("filters"u8))
             {
+                if (Filters == null)
+                {
+                    return false;
+                }
                 return Filters.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("filters"u8.Length)], out value);
             }
             if (local.StartsWith("user_location"u8))
             {
+                if (UserLocation == null)
+                {
+                    return false;
+                }
                 return UserLocation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("user_location"u8.Length)], out value);
             }
             return false;
@@ -181,11 +189,19 @@ namespace OpenAI.Responses
 
             if (local.StartsWith("filters"u8))
             {
+                if (Filters == null)
+                {
+                    return false;
+                }
                 Filters.Patch.Set([.. "$"u8, .. local.Slice("filters"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("user_location"u8))
             {
+                if (UserLocation == null)
+                {
+                    return false;
+                }
                 UserLocation.Patch.Set([.. "$"u8, .. local.Slice("user_location"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Audio/InternalSpeechAudioDeltaEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Audio/InternalSpeechAudioDeltaEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Audio
         InternalSpeechAudioDeltaEvent IPersistableModel<InternalSpeechAudioDeltaEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalSpeechAudioDeltaEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalSpeechAudioDeltaEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalSpeechAudioDeltaEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalSpeechAudioDeltaEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Audio/InternalSpeechAudioDoneEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Audio/InternalSpeechAudioDoneEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Audio
         InternalSpeechAudioDoneEvent IPersistableModel<InternalSpeechAudioDoneEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalSpeechAudioDoneEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalSpeechAudioDoneEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalSpeechAudioDoneEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalSpeechAudioDoneEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Audio/InternalTranscriptTextDeltaEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Audio/InternalTranscriptTextDeltaEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Audio
         InternalTranscriptTextDeltaEvent IPersistableModel<InternalTranscriptTextDeltaEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalTranscriptTextDeltaEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalTranscriptTextDeltaEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalTranscriptTextDeltaEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalTranscriptTextDeltaEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Audio/InternalTranscriptTextDoneEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Audio/InternalTranscriptTextDoneEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Audio
         InternalTranscriptTextDoneEvent IPersistableModel<InternalTranscriptTextDoneEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalTranscriptTextDoneEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalTranscriptTextDoneEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalTranscriptTextDoneEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalTranscriptTextDoneEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Audio/InternalTranscriptTextSegmentEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Audio/InternalTranscriptTextSegmentEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Audio
         InternalTranscriptTextSegmentEvent IPersistableModel<InternalTranscriptTextSegmentEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalTranscriptTextSegmentEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalTranscriptTextSegmentEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalTranscriptTextSegmentEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalTranscriptTextSegmentEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Chat/AssistantChatMessage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/AssistantChatMessage.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < ToolCalls.Count; i++)
                 {
-                    if (ToolCalls[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) || ToolCalls[i] != null && ToolCalls[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -219,21 +219,37 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("audio"u8))
             {
+                if (OutputAudioReference == null)
+                {
+                    return false;
+                }
                 return OutputAudioReference.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 return FunctionCall.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function_call"u8.Length)], out value);
             }
             if (local.StartsWith("tool_calls"u8))
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolCallsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -250,11 +266,19 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("audio"u8))
             {
+                if (OutputAudioReference == null)
+                {
+                    return false;
+                }
                 OutputAudioReference.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 FunctionCall.Patch.Set([.. "$"u8, .. local.Slice("function_call"u8.Length)], value);
                 return true;
             }
@@ -262,7 +286,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -293,7 +325,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < ToolCalls.Count; i++)
             {
-                if (!ToolCalls[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) && (ToolCalls[i] == null || !ToolCalls[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return ToolCalls[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/ChatCompletion.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatCompletion.Serialization.cs
@@ -106,7 +106,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Choices.Count; i++)
                 {
-                    if (Choices[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.choices[{i}]")) || Choices[i] != null && Choices[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -258,17 +258,29 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 return Usage.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("usage"u8.Length)], out value);
             }
             if (local.StartsWith("choices"u8))
             {
                 int propertyLength = "choices"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Choices == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveChoicesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Choices.Count)
+                {
+                    return false;
+                }
+                if (Choices[index] == null)
                 {
                     return false;
                 }
@@ -285,6 +297,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 Usage.Patch.Set([.. "$"u8, .. local.Slice("usage"u8.Length)], value);
                 return true;
             }
@@ -292,7 +308,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "choices"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Choices == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Choices.Count)
+                {
+                    return false;
+                }
+                if (Choices[index] == null)
                 {
                     return false;
                 }
@@ -323,7 +347,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Choices.Count; i++)
             {
-                if (!Choices[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.choices[{i}]")) && (Choices[i] == null || !Choices[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Choices[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/ChatCompletionMessageListDatum.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatCompletionMessageListDatum.Serialization.cs
@@ -105,7 +105,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < ToolCalls.Count; i++)
                 {
-                    if (ToolCalls[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) || ToolCalls[i] != null && ToolCalls[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -128,7 +128,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Annotations.Count; i++)
                 {
-                    if (Annotations[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.annotations[{i}]")) || Annotations[i] != null && Annotations[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -166,7 +166,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < ContentParts.Count; i++)
                 {
-                    if (ContentParts[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content_parts[{i}]")) || ContentParts[i] != null && ContentParts[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -332,21 +332,37 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 return FunctionCall.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function_call"u8.Length)], out value);
             }
             if (local.StartsWith("audio"u8))
             {
+                if (OutputAudio == null)
+                {
+                    return false;
+                }
                 return OutputAudio.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("tool_calls"u8))
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolCallsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -356,11 +372,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "annotations"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Annotations == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveAnnotationsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Annotations.Count)
+                {
+                    return false;
+                }
+                if (Annotations[index] == null)
                 {
                     return false;
                 }
@@ -370,11 +394,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "content_parts"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ContentParts == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentPartsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ContentParts.Count)
+                {
+                    return false;
+                }
+                if (ContentParts[index] == null)
                 {
                     return false;
                 }
@@ -391,11 +423,19 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 FunctionCall.Patch.Set([.. "$"u8, .. local.Slice("function_call"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("audio"u8))
             {
+                if (OutputAudio == null)
+                {
+                    return false;
+                }
                 OutputAudio.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
@@ -403,7 +443,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -414,7 +462,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "annotations"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Annotations == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Annotations.Count)
+                {
+                    return false;
+                }
+                if (Annotations[index] == null)
                 {
                     return false;
                 }
@@ -425,7 +481,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "content_parts"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ContentParts == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ContentParts.Count)
+                {
+                    return false;
+                }
+                if (ContentParts[index] == null)
                 {
                     return false;
                 }
@@ -456,7 +520,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < ToolCalls.Count; i++)
             {
-                if (!ToolCalls[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) && (ToolCalls[i] == null || !ToolCalls[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return ToolCalls[i];
                 }
@@ -484,7 +548,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Annotations.Count; i++)
             {
-                if (!Annotations[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.annotations[{i}]")) && (Annotations[i] == null || !Annotations[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Annotations[i];
                 }
@@ -512,7 +576,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < ContentParts.Count; i++)
             {
-                if (!ContentParts[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content_parts[{i}]")) && (ContentParts[i] == null || !ContentParts[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return ContentParts[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/ChatCompletionOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatCompletionOptions.Serialization.cs
@@ -290,7 +290,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Tools.Count; i++)
                 {
-                    if (Tools[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || Tools[i] != null && Tools[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -328,7 +328,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Functions.Count; i++)
                 {
-                    if (Functions[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.functions[{i}]")) || Functions[i] != null && Functions[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -757,41 +757,77 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("web_search_options"u8))
             {
+                if (WebSearchOptions == null)
+                {
+                    return false;
+                }
                 return WebSearchOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("web_search_options"u8.Length)], out value);
             }
             if (local.StartsWith("response_format"u8))
             {
+                if (ResponseFormat == null)
+                {
+                    return false;
+                }
                 return ResponseFormat.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response_format"u8.Length)], out value);
             }
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 return AudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("prediction"u8))
             {
+                if (OutputPrediction == null)
+                {
+                    return false;
+                }
                 return OutputPrediction.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("prediction"u8.Length)], out value);
             }
             if (local.StartsWith("stream_options"u8))
             {
+                if (StreamOptions == null)
+                {
+                    return false;
+                }
                 return StreamOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("stream_options"u8.Length)], out value);
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 return ToolChoice.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], out value);
             }
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionChoice == null)
+                {
+                    return false;
+                }
                 return FunctionChoice.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function_call"u8.Length)], out value);
             }
             if (local.StartsWith("messages"u8))
             {
                 int propertyLength = "messages"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Messages == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveMessagesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Messages.Count)
+                {
+                    return false;
+                }
+                if (Messages[index] == null)
                 {
                     return false;
                 }
@@ -801,11 +837,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -815,11 +859,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "functions"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Functions == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveFunctionsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Functions.Count)
+                {
+                    return false;
+                }
+                if (Functions[index] == null)
                 {
                     return false;
                 }
@@ -836,36 +888,64 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("web_search_options"u8))
             {
+                if (WebSearchOptions == null)
+                {
+                    return false;
+                }
                 WebSearchOptions.Patch.Set([.. "$"u8, .. local.Slice("web_search_options"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("response_format"u8))
             {
+                if (ResponseFormat == null)
+                {
+                    return false;
+                }
                 ResponseFormat.Patch.Set([.. "$"u8, .. local.Slice("response_format"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 AudioOptions.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("prediction"u8))
             {
+                if (OutputPrediction == null)
+                {
+                    return false;
+                }
                 OutputPrediction.Patch.Set([.. "$"u8, .. local.Slice("prediction"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("stream_options"u8))
             {
+                if (StreamOptions == null)
+                {
+                    return false;
+                }
                 StreamOptions.Patch.Set([.. "$"u8, .. local.Slice("stream_options"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 ToolChoice.Patch.Set([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionChoice == null)
+                {
+                    return false;
+                }
                 FunctionChoice.Patch.Set([.. "$"u8, .. local.Slice("function_call"u8.Length)], value);
                 return true;
             }
@@ -873,7 +953,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "messages"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Messages == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Messages.Count)
+                {
+                    return false;
+                }
+                if (Messages[index] == null)
                 {
                     return false;
                 }
@@ -884,7 +972,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -895,7 +991,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "functions"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Functions == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Functions.Count)
+                {
+                    return false;
+                }
+                if (Functions[index] == null)
                 {
                     return false;
                 }
@@ -926,7 +1030,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Messages.Count; i++)
             {
-                if (!Messages[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.messages[{i}]")) && (Messages[i] == null || !Messages[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Messages[i];
                 }
@@ -954,7 +1058,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Tools.Count; i++)
             {
-                if (!Tools[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (Tools[i] == null || !Tools[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Tools[i];
                 }
@@ -982,7 +1086,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Functions.Count; i++)
             {
-                if (!Functions[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.functions[{i}]")) && (Functions[i] == null || !Functions[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Functions[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/ChatMessageAnnotation.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatMessageAnnotation.Serialization.cs
@@ -136,6 +136,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("url_citation"u8))
             {
+                if (UrlCitation == null)
+                {
+                    return false;
+                }
                 return UrlCitation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("url_citation"u8.Length)], out value);
             }
             return false;
@@ -149,6 +153,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("url_citation"u8))
             {
+                if (UrlCitation == null)
+                {
+                    return false;
+                }
                 UrlCitation.Patch.Set([.. "$"u8, .. local.Slice("url_citation"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/ChatTokenLogProbabilityDetails.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatTokenLogProbabilityDetails.Serialization.cs
@@ -128,7 +128,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < TopLogProbabilities.Count; i++)
                 {
-                    if (TopLogProbabilities[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.top_logprobs[{i}]")) || TopLogProbabilities[i] != null && TopLogProbabilities[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -222,11 +222,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "top_logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TopLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveTopLogProbabilitiesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TopLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TopLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -245,7 +253,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "top_logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (TopLogProbabilities == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= TopLogProbabilities.Count)
+                {
+                    return false;
+                }
+                if (TopLogProbabilities[index] == null)
                 {
                     return false;
                 }
@@ -276,7 +292,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < TopLogProbabilities.Count; i++)
             {
-                if (!TopLogProbabilities[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.top_logprobs[{i}]")) && (TopLogProbabilities[i] == null || !TopLogProbabilities[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return TopLogProbabilities[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/ChatTokenUsage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatTokenUsage.Serialization.cs
@@ -188,10 +188,18 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("completion_tokens_details"u8))
             {
+                if (OutputTokenDetails == null)
+                {
+                    return false;
+                }
                 return OutputTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("completion_tokens_details"u8.Length)], out value);
             }
             if (local.StartsWith("prompt_tokens_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 return InputTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("prompt_tokens_details"u8.Length)], out value);
             }
             return false;
@@ -205,11 +213,19 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("completion_tokens_details"u8))
             {
+                if (OutputTokenDetails == null)
+                {
+                    return false;
+                }
                 OutputTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("completion_tokens_details"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("prompt_tokens_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 InputTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("prompt_tokens_details"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/ChatTool.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatTool.Serialization.cs
@@ -141,6 +141,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 return Function.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function"u8.Length)], out value);
             }
             return false;
@@ -154,6 +158,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 Function.Patch.Set([.. "$"u8, .. local.Slice("function"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/ChatToolCall.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatToolCall.Serialization.cs
@@ -152,6 +152,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 return Function.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function"u8.Length)], out value);
             }
             return false;
@@ -165,6 +169,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 Function.Patch.Set([.. "$"u8, .. local.Slice("function"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/ChatWebSearchOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/ChatWebSearchOptions.Serialization.cs
@@ -141,6 +141,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("user_location"u8))
             {
+                if (UserLocation == null)
+                {
+                    return false;
+                }
                 return UserLocation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("user_location"u8.Length)], out value);
             }
             return false;
@@ -154,6 +158,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("user_location"u8))
             {
+                if (UserLocation == null)
+                {
+                    return false;
+                }
                 UserLocation.Patch.Set([.. "$"u8, .. local.Slice("user_location"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionList.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionList.Serialization.cs
@@ -101,7 +101,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Data.Count; i++)
                 {
-                    if (Data[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) || Data[i] != null && Data[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -210,11 +210,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveDataArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -233,7 +241,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -264,7 +280,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Data.Count; i++)
             {
-                if (!Data[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) && (Data[i] == null || !Data[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Data[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionMessageList.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionMessageList.Serialization.cs
@@ -101,7 +101,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Data.Count; i++)
                 {
-                    if (Data[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) || Data[i] != null && Data[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -210,11 +210,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveDataArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -233,7 +241,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -264,7 +280,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Data.Count; i++)
             {
-                if (!Data[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) && (Data[i] == null || !Data[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Data[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionNamedToolChoice.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionNamedToolChoice.Serialization.cs
@@ -136,6 +136,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 return Function.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function"u8.Length)], out value);
             }
             return false;
@@ -149,6 +153,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 Function.Patch.Set([.. "$"u8, .. local.Slice("function"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionRequestMessageContentPartAudio.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionRequestMessageContentPartAudio.Serialization.cs
@@ -132,6 +132,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("input_audio"u8))
             {
+                if (InputAudio == null)
+                {
+                    return false;
+                }
                 return InputAudio.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("input_audio"u8.Length)], out value);
             }
             return false;
@@ -145,6 +149,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("input_audio"u8))
             {
+                if (InputAudio == null)
+                {
+                    return false;
+                }
                 InputAudio.Patch.Set([.. "$"u8, .. local.Slice("input_audio"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionRequestMessageContentPartFile.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionRequestMessageContentPartFile.Serialization.cs
@@ -132,6 +132,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("file"u8))
             {
+                if (File == null)
+                {
+                    return false;
+                }
                 return File.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("file"u8.Length)], out value);
             }
             return false;
@@ -145,6 +149,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("file"u8))
             {
+                if (File == null)
+                {
+                    return false;
+                }
                 File.Patch.Set([.. "$"u8, .. local.Slice("file"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionRequestMessageContentPartImage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionRequestMessageContentPartImage.Serialization.cs
@@ -132,6 +132,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("image_url"u8))
             {
+                if (ImageUrl == null)
+                {
+                    return false;
+                }
                 return ImageUrl.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("image_url"u8.Length)], out value);
             }
             return false;
@@ -145,6 +149,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("image_url"u8))
             {
+                if (ImageUrl == null)
+                {
+                    return false;
+                }
                 ImageUrl.Patch.Set([.. "$"u8, .. local.Slice("image_url"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionResponseMessage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionResponseMessage.Serialization.cs
@@ -105,7 +105,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < ToolCalls.Count; i++)
                 {
-                    if (ToolCalls[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) || ToolCalls[i] != null && ToolCalls[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -128,7 +128,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Annotations.Count; i++)
                 {
-                    if (Annotations[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.annotations[{i}]")) || Annotations[i] != null && Annotations[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -276,21 +276,37 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 return FunctionCall.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function_call"u8.Length)], out value);
             }
             if (local.StartsWith("audio"u8))
             {
+                if (Audio == null)
+                {
+                    return false;
+                }
                 return Audio.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("tool_calls"u8))
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolCallsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -300,11 +316,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "annotations"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Annotations == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveAnnotationsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Annotations.Count)
+                {
+                    return false;
+                }
+                if (Annotations[index] == null)
                 {
                     return false;
                 }
@@ -321,11 +345,19 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 FunctionCall.Patch.Set([.. "$"u8, .. local.Slice("function_call"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("audio"u8))
             {
+                if (Audio == null)
+                {
+                    return false;
+                }
                 Audio.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
@@ -333,7 +365,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -344,7 +384,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "annotations"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Annotations == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Annotations.Count)
+                {
+                    return false;
+                }
+                if (Annotations[index] == null)
                 {
                     return false;
                 }
@@ -375,7 +423,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < ToolCalls.Count; i++)
             {
-                if (!ToolCalls[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) && (ToolCalls[i] == null || !ToolCalls[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return ToolCalls[i];
                 }
@@ -403,7 +451,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Annotations.Count; i++)
             {
-                if (!Annotations[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.annotations[{i}]")) && (Annotations[i] == null || !Annotations[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Annotations[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/InternalChatCompletionStreamResponseDelta.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalChatCompletionStreamResponseDelta.Serialization.cs
@@ -99,7 +99,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < ToolCalls.Count; i++)
                 {
-                    if (ToolCalls[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) || ToolCalls[i] != null && ToolCalls[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -229,21 +229,37 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("audio"u8))
             {
+                if (Audio == null)
+                {
+                    return false;
+                }
                 return Audio.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 return FunctionCall.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function_call"u8.Length)], out value);
             }
             if (local.StartsWith("tool_calls"u8))
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolCallsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -260,11 +276,19 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("audio"u8))
             {
+                if (Audio == null)
+                {
+                    return false;
+                }
                 Audio.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("function_call"u8))
             {
+                if (FunctionCall == null)
+                {
+                    return false;
+                }
                 FunctionCall.Patch.Set([.. "$"u8, .. local.Slice("function_call"u8.Length)], value);
                 return true;
             }
@@ -272,7 +296,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "tool_calls"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolCalls == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolCalls.Count)
+                {
+                    return false;
+                }
+                if (ToolCalls[index] == null)
                 {
                     return false;
                 }
@@ -303,7 +335,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < ToolCalls.Count; i++)
             {
-                if (!ToolCalls[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tool_calls[{i}]")) && (ToolCalls[i] == null || !ToolCalls[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return ToolCalls[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionRequestWebSearchOptionsUserLocation1.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionRequestWebSearchOptionsUserLocation1.Serialization.cs
@@ -137,6 +137,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("approximate"u8))
             {
+                if (Approximate == null)
+                {
+                    return false;
+                }
                 return Approximate.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("approximate"u8.Length)], out value);
             }
             return false;
@@ -150,6 +154,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("approximate"u8))
             {
+                if (Approximate == null)
+                {
+                    return false;
+                }
                 Approximate.Patch.Set([.. "$"u8, .. local.Slice("approximate"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionResponseChoice.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionResponseChoice.Serialization.cs
@@ -167,10 +167,18 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("message"u8))
             {
+                if (Message == null)
+                {
+                    return false;
+                }
                 return Message.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("message"u8.Length)], out value);
             }
             if (local.StartsWith("logprobs"u8))
             {
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 return Logprobs.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("logprobs"u8.Length)], out value);
             }
             return false;
@@ -184,11 +192,19 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("message"u8))
             {
+                if (Message == null)
+                {
+                    return false;
+                }
                 Message.Patch.Set([.. "$"u8, .. local.Slice("message"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("logprobs"u8))
             {
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 Logprobs.Patch.Set([.. "$"u8, .. local.Slice("logprobs"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionResponseChoiceLogprobs.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionResponseChoiceLogprobs.Serialization.cs
@@ -83,7 +83,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Content.Count; i++)
                 {
-                    if (Content[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || Content[i] != null && Content[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -106,7 +106,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Refusal.Count; i++)
                 {
-                    if (Refusal[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.refusal[{i}]")) || Refusal[i] != null && Refusal[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -191,11 +191,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -205,11 +213,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "refusal"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Refusal == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveRefusalArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Refusal.Count)
+                {
+                    return false;
+                }
+                if (Refusal[index] == null)
                 {
                     return false;
                 }
@@ -228,7 +244,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -239,7 +263,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "refusal"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Refusal == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Refusal.Count)
+                {
+                    return false;
+                }
+                if (Refusal[index] == null)
                 {
                     return false;
                 }
@@ -270,7 +302,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Content.Count; i++)
             {
-                if (!Content[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (Content[i] == null || !Content[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Content[i];
                 }
@@ -298,7 +330,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Refusal.Count; i++)
             {
-                if (!Refusal[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.refusal[{i}]")) && (Refusal[i] == null || !Refusal[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Refusal[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionStreamResponseChoice.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionStreamResponseChoice.Serialization.cs
@@ -106,10 +106,18 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("delta"u8))
             {
+                if (Delta == null)
+                {
+                    return false;
+                }
                 return Delta.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("delta"u8.Length)], out value);
             }
             if (local.StartsWith("logprobs"u8))
             {
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 return Logprobs.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("logprobs"u8.Length)], out value);
             }
             return false;
@@ -123,11 +131,19 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("delta"u8))
             {
+                if (Delta == null)
+                {
+                    return false;
+                }
                 Delta.Patch.Set([.. "$"u8, .. local.Slice("delta"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("logprobs"u8))
             {
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 Logprobs.Patch.Set([.. "$"u8, .. local.Slice("logprobs"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionStreamResponseChoiceLogprobs.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalCreateChatCompletionStreamResponseChoiceLogprobs.Serialization.cs
@@ -83,7 +83,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Content.Count; i++)
                 {
-                    if (Content[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || Content[i] != null && Content[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -106,7 +106,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Refusal.Count; i++)
                 {
-                    if (Refusal[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.refusal[{i}]")) || Refusal[i] != null && Refusal[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -191,11 +191,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -205,11 +213,19 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "refusal"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Refusal == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveRefusalArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Refusal.Count)
+                {
+                    return false;
+                }
+                if (Refusal[index] == null)
                 {
                     return false;
                 }
@@ -228,7 +244,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -239,7 +263,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "refusal"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Refusal == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Refusal.Count)
+                {
+                    return false;
+                }
+                if (Refusal[index] == null)
                 {
                     return false;
                 }
@@ -270,7 +302,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Content.Count; i++)
             {
-                if (!Content[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (Content[i] == null || !Content[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Content[i];
                 }
@@ -298,7 +330,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Refusal.Count; i++)
             {
-                if (!Refusal[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.refusal[{i}]")) && (Refusal[i] == null || !Refusal[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Refusal[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/InternalDotNetChatResponseFormatJsonSchema.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/InternalDotNetChatResponseFormatJsonSchema.Serialization.cs
@@ -132,6 +132,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("json_schema"u8))
             {
+                if (JsonSchema == null)
+                {
+                    return false;
+                }
                 return JsonSchema.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("json_schema"u8.Length)], out value);
             }
             return false;
@@ -145,6 +149,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("json_schema"u8))
             {
+                if (JsonSchema == null)
+                {
+                    return false;
+                }
                 JsonSchema.Patch.Set([.. "$"u8, .. local.Slice("json_schema"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Chat/StreamingChatCompletionUpdate.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/StreamingChatCompletionUpdate.Serialization.cs
@@ -96,7 +96,7 @@ namespace OpenAI.Chat
                 writer.WriteStartArray();
                 for (int i = 0; i < Choices.Count; i++)
                 {
-                    if (Choices[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.choices[{i}]")) || Choices[i] != null && Choices[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -249,17 +249,29 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 return Usage.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("usage"u8.Length)], out value);
             }
             if (local.StartsWith("choices"u8))
             {
                 int propertyLength = "choices"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Choices == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveChoicesArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Choices.Count)
+                {
+                    return false;
+                }
+                if (Choices[index] == null)
                 {
                     return false;
                 }
@@ -276,6 +288,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 Usage.Patch.Set([.. "$"u8, .. local.Slice("usage"u8.Length)], value);
                 return true;
             }
@@ -283,7 +299,15 @@ namespace OpenAI.Chat
             {
                 int propertyLength = "choices"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Choices == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Choices.Count)
+                {
+                    return false;
+                }
+                if (Choices[index] == null)
                 {
                     return false;
                 }
@@ -314,7 +338,7 @@ namespace OpenAI.Chat
             }
             for (int i = 0; i < Choices.Count; i++)
             {
-                if (!Choices[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.choices[{i}]")) && (Choices[i] == null || !Choices[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Choices[i];
                 }

--- a/OpenAI/src/Generated/Models/Chat/StreamingChatToolCallUpdate.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Chat/StreamingChatToolCallUpdate.Serialization.cs
@@ -171,6 +171,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 return Function.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("function"u8.Length)], out value);
             }
             return false;
@@ -184,6 +188,10 @@ namespace OpenAI.Chat
 
             if (local.StartsWith("function"u8))
             {
+                if (Function == null)
+                {
+                    return false;
+                }
                 Function.Patch.Set([.. "$"u8, .. local.Slice("function"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Containers/ContainerAllowlistNetworkPolicy.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Containers/ContainerAllowlistNetworkPolicy.Serialization.cs
@@ -116,7 +116,7 @@ namespace OpenAI.Containers
                 writer.WriteStartArray();
                 for (int i = 0; i < DomainSecrets.Count; i++)
                 {
-                    if (DomainSecrets[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.domain_secrets[{i}]")) || DomainSecrets[i] != null && DomainSecrets[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -208,11 +208,19 @@ namespace OpenAI.Containers
             {
                 int propertyLength = "domain_secrets"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (DomainSecrets == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveDomainSecretsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= DomainSecrets.Count)
+                {
+                    return false;
+                }
+                if (DomainSecrets[index] == null)
                 {
                     return false;
                 }
@@ -231,7 +239,15 @@ namespace OpenAI.Containers
             {
                 int propertyLength = "domain_secrets"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (DomainSecrets == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= DomainSecrets.Count)
+                {
+                    return false;
+                }
+                if (DomainSecrets[index] == null)
                 {
                     return false;
                 }
@@ -262,7 +278,7 @@ namespace OpenAI.Containers
             }
             for (int i = 0; i < DomainSecrets.Count; i++)
             {
-                if (!DomainSecrets[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.domain_secrets[{i}]")) && (DomainSecrets[i] == null || !DomainSecrets[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return DomainSecrets[i];
                 }

--- a/OpenAI/src/Generated/Models/Containers/ContainerCollectionPage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Containers/ContainerCollectionPage.Serialization.cs
@@ -101,7 +101,7 @@ namespace OpenAI.Containers
                 writer.WriteStartArray();
                 for (int i = 0; i < Data.Count; i++)
                 {
-                    if (Data[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) || Data[i] != null && Data[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -210,11 +210,19 @@ namespace OpenAI.Containers
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveDataArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -233,7 +241,15 @@ namespace OpenAI.Containers
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -264,7 +280,7 @@ namespace OpenAI.Containers
             }
             for (int i = 0; i < Data.Count; i++)
             {
-                if (!Data[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) && (Data[i] == null || !Data[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Data[i];
                 }

--- a/OpenAI/src/Generated/Models/Containers/ContainerCreationOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Containers/ContainerCreationOptions.Serialization.cs
@@ -237,10 +237,18 @@ namespace OpenAI.Containers
 
             if (local.StartsWith("expires_after"u8))
             {
+                if (ExpirationPolicy == null)
+                {
+                    return false;
+                }
                 return ExpirationPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("expires_after"u8.Length)], out value);
             }
             if (local.StartsWith("network_policy"u8))
             {
+                if (NetworkPolicy == null)
+                {
+                    return false;
+                }
                 return NetworkPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("network_policy"u8.Length)], out value);
             }
             return false;
@@ -254,11 +262,19 @@ namespace OpenAI.Containers
 
             if (local.StartsWith("expires_after"u8))
             {
+                if (ExpirationPolicy == null)
+                {
+                    return false;
+                }
                 ExpirationPolicy.Patch.Set([.. "$"u8, .. local.Slice("expires_after"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("network_policy"u8))
             {
+                if (NetworkPolicy == null)
+                {
+                    return false;
+                }
                 NetworkPolicy.Patch.Set([.. "$"u8, .. local.Slice("network_policy"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Containers/ContainerFileCollectionPage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Containers/ContainerFileCollectionPage.Serialization.cs
@@ -101,7 +101,7 @@ namespace OpenAI.Containers
                 writer.WriteStartArray();
                 for (int i = 0; i < Data.Count; i++)
                 {
-                    if (Data[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) || Data[i] != null && Data[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -210,11 +210,19 @@ namespace OpenAI.Containers
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveDataArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -233,7 +241,15 @@ namespace OpenAI.Containers
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -264,7 +280,7 @@ namespace OpenAI.Containers
             }
             for (int i = 0; i < Data.Count; i++)
             {
-                if (!Data[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) && (Data[i] == null || !Data[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Data[i];
                 }

--- a/OpenAI/src/Generated/Models/Containers/ContainerResource.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Containers/ContainerResource.Serialization.cs
@@ -248,10 +248,18 @@ namespace OpenAI.Containers
 
             if (local.StartsWith("expires_after"u8))
             {
+                if (ExpirationPolicy == null)
+                {
+                    return false;
+                }
                 return ExpirationPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("expires_after"u8.Length)], out value);
             }
             if (local.StartsWith("network_policy"u8))
             {
+                if (NetworkPolicy == null)
+                {
+                    return false;
+                }
                 return NetworkPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("network_policy"u8.Length)], out value);
             }
             return false;
@@ -265,11 +273,19 @@ namespace OpenAI.Containers
 
             if (local.StartsWith("expires_after"u8))
             {
+                if (ExpirationPolicy == null)
+                {
+                    return false;
+                }
                 ExpirationPolicy.Patch.Set([.. "$"u8, .. local.Slice("expires_after"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("network_policy"u8))
             {
+                if (NetworkPolicy == null)
+                {
+                    return false;
+                }
                 NetworkPolicy.Patch.Set([.. "$"u8, .. local.Slice("network_policy"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Containers/InternalContainersErrorResponse.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Containers/InternalContainersErrorResponse.Serialization.cs
@@ -125,6 +125,10 @@ namespace OpenAI.Containers
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             return false;
@@ -138,6 +142,10 @@ namespace OpenAI.Containers
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 Error.Patch.Set([.. "$"u8, .. local.Slice("error"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Conversations/ConversationCreationOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Conversations/ConversationCreationOptions.Serialization.cs
@@ -124,7 +124,7 @@ namespace OpenAI.Conversations
                 writer.WriteStartArray();
                 for (int i = 0; i < Items.Count; i++)
                 {
-                    if (Items[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.items[{i}]")) || Items[i] != null && Items[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -214,11 +214,19 @@ namespace OpenAI.Conversations
             {
                 int propertyLength = "items"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Items == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveItemsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Items.Count)
+                {
+                    return false;
+                }
+                if (Items[index] == null)
                 {
                     return false;
                 }
@@ -237,7 +245,15 @@ namespace OpenAI.Conversations
             {
                 int propertyLength = "items"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Items == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Items.Count)
+                {
+                    return false;
+                }
+                if (Items[index] == null)
                 {
                     return false;
                 }
@@ -268,7 +284,7 @@ namespace OpenAI.Conversations
             }
             for (int i = 0; i < Items.Count; i++)
             {
-                if (!Items[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.items[{i}]")) && (Items[i] == null || !Items[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Items[i];
                 }

--- a/OpenAI/src/Generated/Models/Conversations/InternalConversationItemCollection.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Conversations/InternalConversationItemCollection.Serialization.cs
@@ -102,7 +102,7 @@ namespace OpenAI.Conversations
                 writer.WriteStartArray();
                 for (int i = 0; i < Data.Count; i++)
                 {
-                    if (Data[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) || Data[i] != null && Data[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -211,11 +211,19 @@ namespace OpenAI.Conversations
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveDataArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -234,7 +242,15 @@ namespace OpenAI.Conversations
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Data == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Data.Count)
+                {
+                    return false;
+                }
+                if (Data[index] == null)
                 {
                     return false;
                 }
@@ -265,7 +281,7 @@ namespace OpenAI.Conversations
             }
             for (int i = 0; i < Data.Count; i++)
             {
-                if (!Data[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) && (Data[i] == null || !Data[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Data[i];
                 }

--- a/OpenAI/src/Generated/Models/Conversations/InternalCreateConversationItemsParametersBody.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Conversations/InternalCreateConversationItemsParametersBody.Serialization.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Conversations
                 writer.WriteStartArray();
                 for (int i = 0; i < Items.Count; i++)
                 {
-                    if (Items[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.items[{i}]")) || Items[i] != null && Items[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -152,11 +152,19 @@ namespace OpenAI.Conversations
             {
                 int propertyLength = "items"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Items == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveItemsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Items.Count)
+                {
+                    return false;
+                }
+                if (Items[index] == null)
                 {
                     return false;
                 }
@@ -175,7 +183,15 @@ namespace OpenAI.Conversations
             {
                 int propertyLength = "items"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Items == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Items.Count)
+                {
+                    return false;
+                }
+                if (Items[index] == null)
                 {
                     return false;
                 }
@@ -206,7 +222,7 @@ namespace OpenAI.Conversations
             }
             for (int i = 0; i < Items.Count; i++)
             {
-                if (!Items[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.items[{i}]")) && (Items[i] == null || !Items[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Items[i];
                 }

--- a/OpenAI/src/Generated/Models/Embeddings/OpenAIEmbeddingCollection.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Embeddings/OpenAIEmbeddingCollection.Serialization.cs
@@ -98,7 +98,7 @@ namespace OpenAI.Embeddings
                 writer.WriteStartArray();
                 for (int i = 0; i < Items.Count; i++)
                 {
-                    if (Items[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) || Items[i] != null && Items[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -194,17 +194,29 @@ namespace OpenAI.Embeddings
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 return Usage.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("usage"u8.Length)], out value);
             }
             if (local.StartsWith("data"u8))
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Items == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveItemsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Items.Count)
+                {
+                    return false;
+                }
+                if (Items[index] == null)
                 {
                     return false;
                 }
@@ -221,6 +233,10 @@ namespace OpenAI.Embeddings
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 Usage.Patch.Set([.. "$"u8, .. local.Slice("usage"u8.Length)], value);
                 return true;
             }
@@ -228,7 +244,15 @@ namespace OpenAI.Embeddings
             {
                 int propertyLength = "data"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Items == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Items.Count)
+                {
+                    return false;
+                }
+                if (Items[index] == null)
                 {
                     return false;
                 }
@@ -259,7 +283,7 @@ namespace OpenAI.Embeddings
             }
             for (int i = 0; i < Items.Count; i++)
             {
-                if (!Items[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.data[{i}]")) && (Items[i] == null || !Items[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Items[i];
                 }

--- a/OpenAI/src/Generated/Models/Images/InternalImageEditCompletedEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Images/InternalImageEditCompletedEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Images
         InternalImageEditCompletedEvent IPersistableModel<InternalImageEditCompletedEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalImageEditCompletedEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalImageEditCompletedEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalImageEditCompletedEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalImageEditCompletedEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Images/InternalImageEditPartialImageEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Images/InternalImageEditPartialImageEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Images
         InternalImageEditPartialImageEvent IPersistableModel<InternalImageEditPartialImageEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalImageEditPartialImageEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalImageEditPartialImageEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalImageEditPartialImageEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalImageEditPartialImageEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Images/InternalImageGenCompletedEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Images/InternalImageGenCompletedEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Images
         InternalImageGenCompletedEvent IPersistableModel<InternalImageGenCompletedEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalImageGenCompletedEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalImageGenCompletedEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalImageGenCompletedEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalImageGenCompletedEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Images/InternalImageGenPartialImageEvent.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Images/InternalImageGenPartialImageEvent.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -49,13 +48,6 @@ namespace OpenAI.Images
         InternalImageGenPartialImageEvent IPersistableModel<InternalImageGenPartialImageEvent>.Create(BinaryData data, ModelReaderWriterOptions options) => PersistableModelCreateCore(data, options);
 
         string IPersistableModel<InternalImageGenPartialImageEvent>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        public static explicit operator InternalImageGenPartialImageEvent(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeInternalImageGenPartialImageEvent(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         void IJsonModel<InternalImageGenPartialImageEvent>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {

--- a/OpenAI/src/Generated/Models/Realtime/CreateClientSecretOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/CreateClientSecretOptions.Serialization.cs
@@ -140,10 +140,18 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("expires_after"u8))
             {
+                if (ExpirationPolicy == null)
+                {
+                    return false;
+                }
                 return ExpirationPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("expires_after"u8.Length)], out value);
             }
             if (local.StartsWith("session"u8))
             {
+                if (SessionOptions == null)
+                {
+                    return false;
+                }
                 return SessionOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("session"u8.Length)], out value);
             }
             return false;
@@ -157,11 +165,19 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("expires_after"u8))
             {
+                if (ExpirationPolicy == null)
+                {
+                    return false;
+                }
                 ExpirationPolicy.Patch.Set([.. "$"u8, .. local.Slice("expires_after"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("session"u8))
             {
+                if (SessionOptions == null)
+                {
+                    return false;
+                }
                 SessionOptions.Patch.Set([.. "$"u8, .. local.Slice("session"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/CreateClientSecretResult.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/CreateClientSecretResult.Serialization.cs
@@ -156,6 +156,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (Session == null)
+                {
+                    return false;
+                }
                 return Session.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("session"u8.Length)], out value);
             }
             return false;
@@ -169,6 +173,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (Session == null)
+                {
+                    return false;
+                }
                 Session.Patch.Set([.. "$"u8, .. local.Slice("session"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandConversationItemCreate.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandConversationItemCreate.Serialization.cs
@@ -154,6 +154,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -167,6 +171,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandResponseCreate.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandResponseCreate.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("response"u8))
             {
+                if (ResponseOptions == null)
+                {
+                    return false;
+                }
                 return ResponseOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("response"u8))
             {
+                if (ResponseOptions == null)
+                {
+                    return false;
+                }
                 ResponseOptions.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandSessionUpdate.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeClientCommandSessionUpdate.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (SessionOptions == null)
+                {
+                    return false;
+                }
                 return SessionOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("session"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (SessionOptions == null)
+                {
+                    return false;
+                }
                 SessionOptions.Patch.Set([.. "$"u8, .. local.Slice("session"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSession.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSession.Serialization.cs
@@ -159,7 +159,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < Tools.Count; i++)
                 {
-                    if (Tools[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || Tools[i] != null && Tools[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -358,37 +358,69 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("client_secret"u8))
             {
+                if (ClientSecret == null)
+                {
+                    return false;
+                }
                 return ClientSecret.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("client_secret"u8.Length)], out value);
             }
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 return AudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("tracing"u8))
             {
+                if (Tracing == null)
+                {
+                    return false;
+                }
                 return Tracing.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("tracing"u8.Length)], out value);
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 return ToolChoice.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], out value);
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 return MaxOutputTokenCount.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], out value);
             }
             if (local.StartsWith("truncation"u8))
             {
+                if (Truncation == null)
+                {
+                    return false;
+                }
                 return Truncation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("truncation"u8.Length)], out value);
             }
             if (local.StartsWith("tools"u8))
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -405,31 +437,55 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("client_secret"u8))
             {
+                if (ClientSecret == null)
+                {
+                    return false;
+                }
                 ClientSecret.Patch.Set([.. "$"u8, .. local.Slice("client_secret"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 AudioOptions.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("tracing"u8))
             {
+                if (Tracing == null)
+                {
+                    return false;
+                }
                 Tracing.Patch.Set([.. "$"u8, .. local.Slice("tracing"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 ToolChoice.Patch.Set([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 MaxOutputTokenCount.Patch.Set([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("truncation"u8))
             {
+                if (Truncation == null)
+                {
+                    return false;
+                }
                 Truncation.Patch.Set([.. "$"u8, .. local.Slice("truncation"u8.Length)], value);
                 return true;
             }
@@ -437,7 +493,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -468,7 +532,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < Tools.Count; i++)
             {
-                if (!Tools[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (Tools[i] == null || !Tools[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Tools[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionAudioOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionAudioOptions.Serialization.cs
@@ -140,10 +140,18 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input"u8))
             {
+                if (InputAudioOptions == null)
+                {
+                    return false;
+                }
                 return InputAudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("input"u8.Length)], out value);
             }
             if (local.StartsWith("output"u8))
             {
+                if (OutputAudioOptions == null)
+                {
+                    return false;
+                }
                 return OutputAudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("output"u8.Length)], out value);
             }
             return false;
@@ -157,11 +165,19 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input"u8))
             {
+                if (InputAudioOptions == null)
+                {
+                    return false;
+                }
                 InputAudioOptions.Patch.Set([.. "$"u8, .. local.Slice("input"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("output"u8))
             {
+                if (OutputAudioOptions == null)
+                {
+                    return false;
+                }
                 OutputAudioOptions.Patch.Set([.. "$"u8, .. local.Slice("output"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionInputAudioOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionInputAudioOptions.Serialization.cs
@@ -171,18 +171,34 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 return AudioFormat.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("format"u8.Length)], out value);
             }
             if (local.StartsWith("transcription"u8))
             {
+                if (AudioTranscriptionOptions == null)
+                {
+                    return false;
+                }
                 return AudioTranscriptionOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("transcription"u8.Length)], out value);
             }
             if (local.StartsWith("noise_reduction"u8))
             {
+                if (NoiseReduction == null)
+                {
+                    return false;
+                }
                 return NoiseReduction.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("noise_reduction"u8.Length)], out value);
             }
             if (local.StartsWith("turn_detection"u8))
             {
+                if (TurnDetection == null)
+                {
+                    return false;
+                }
                 return TurnDetection.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("turn_detection"u8.Length)], out value);
             }
             return false;
@@ -196,21 +212,37 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 AudioFormat.Patch.Set([.. "$"u8, .. local.Slice("format"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("transcription"u8))
             {
+                if (AudioTranscriptionOptions == null)
+                {
+                    return false;
+                }
                 AudioTranscriptionOptions.Patch.Set([.. "$"u8, .. local.Slice("transcription"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("noise_reduction"u8))
             {
+                if (NoiseReduction == null)
+                {
+                    return false;
+                }
                 NoiseReduction.Patch.Set([.. "$"u8, .. local.Slice("noise_reduction"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("turn_detection"u8))
             {
+                if (TurnDetection == null)
+                {
+                    return false;
+                }
                 TurnDetection.Patch.Set([.. "$"u8, .. local.Slice("turn_detection"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionOptions.Serialization.cs
@@ -150,7 +150,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < Tools.Count; i++)
                 {
-                    if (Tools[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || Tools[i] != null && Tools[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -342,33 +342,61 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 return AudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("tracing"u8))
             {
+                if (Tracing == null)
+                {
+                    return false;
+                }
                 return Tracing.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("tracing"u8.Length)], out value);
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 return ToolChoice.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], out value);
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 return MaxOutputTokenCount.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], out value);
             }
             if (local.StartsWith("truncation"u8))
             {
+                if (Truncation == null)
+                {
+                    return false;
+                }
                 return Truncation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("truncation"u8.Length)], out value);
             }
             if (local.StartsWith("tools"u8))
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -385,26 +413,46 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 AudioOptions.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("tracing"u8))
             {
+                if (Tracing == null)
+                {
+                    return false;
+                }
                 Tracing.Patch.Set([.. "$"u8, .. local.Slice("tracing"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 ToolChoice.Patch.Set([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 MaxOutputTokenCount.Patch.Set([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("truncation"u8))
             {
+                if (Truncation == null)
+                {
+                    return false;
+                }
                 Truncation.Patch.Set([.. "$"u8, .. local.Slice("truncation"u8.Length)], value);
                 return true;
             }
@@ -412,7 +460,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -443,7 +499,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < Tools.Count; i++)
             {
-                if (!Tools[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (Tools[i] == null || !Tools[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Tools[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionOutputAudioOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeConversationSessionOutputAudioOptions.Serialization.cs
@@ -155,6 +155,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 return AudioFormat.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("format"u8.Length)], out value);
             }
             return false;
@@ -168,6 +172,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 AudioFormat.Patch.Set([.. "$"u8, .. local.Slice("format"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeCustomMcpToolCallApprovalPolicy.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeCustomMcpToolCallApprovalPolicy.Serialization.cs
@@ -140,10 +140,18 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("always"u8))
             {
+                if (ToolsAlwaysRequiringApproval == null)
+                {
+                    return false;
+                }
                 return ToolsAlwaysRequiringApproval.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("always"u8.Length)], out value);
             }
             if (local.StartsWith("never"u8))
             {
+                if (ToolsNeverRequiringApproval == null)
+                {
+                    return false;
+                }
                 return ToolsNeverRequiringApproval.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("never"u8.Length)], out value);
             }
             return false;
@@ -157,11 +165,19 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("always"u8))
             {
+                if (ToolsAlwaysRequiringApproval == null)
+                {
+                    return false;
+                }
                 ToolsAlwaysRequiringApproval.Patch.Set([.. "$"u8, .. local.Slice("always"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("never"u8))
             {
+                if (ToolsNeverRequiringApproval == null)
+                {
+                    return false;
+                }
                 ToolsNeverRequiringApproval.Patch.Set([.. "$"u8, .. local.Slice("never"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeCustomRetentionRatioTruncation.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeCustomRetentionRatioTruncation.Serialization.cs
@@ -147,6 +147,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("token_limits"u8))
             {
+                if (TokenLimitDetails == null)
+                {
+                    return false;
+                }
                 return TokenLimitDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("token_limits"u8.Length)], out value);
             }
             return false;
@@ -160,6 +164,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("token_limits"u8))
             {
+                if (TokenLimitDetails == null)
+                {
+                    return false;
+                }
                 TokenLimitDetails.Patch.Set([.. "$"u8, .. local.Slice("token_limits"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeMcpTool.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeMcpTool.Serialization.cs
@@ -279,10 +279,18 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("allowed_tools"u8))
             {
+                if (AllowedTools == null)
+                {
+                    return false;
+                }
                 return AllowedTools.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("allowed_tools"u8.Length)], out value);
             }
             if (local.StartsWith("require_approval"u8))
             {
+                if (ToolCallApprovalPolicy == null)
+                {
+                    return false;
+                }
                 return ToolCallApprovalPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("require_approval"u8.Length)], out value);
             }
             return false;
@@ -296,11 +304,19 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("allowed_tools"u8))
             {
+                if (AllowedTools == null)
+                {
+                    return false;
+                }
                 AllowedTools.Patch.Set([.. "$"u8, .. local.Slice("allowed_tools"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("require_approval"u8))
             {
+                if (ToolCallApprovalPolicy == null)
+                {
+                    return false;
+                }
                 ToolCallApprovalPolicy.Patch.Set([.. "$"u8, .. local.Slice("require_approval"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeMcpToolCallApprovalPolicy.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeMcpToolCallApprovalPolicy.Serialization.cs
@@ -65,6 +65,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_policy"u8))
             {
+                if (CustomPolicy == null)
+                {
+                    return false;
+                }
                 return CustomPolicy.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("custom_policy"u8.Length)], out value);
             }
             return false;
@@ -78,6 +82,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_policy"u8))
             {
+                if (CustomPolicy == null)
+                {
+                    return false;
+                }
                 CustomPolicy.Patch.Set([.. "$"u8, .. local.Slice("custom_policy"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeMcpToolCallItem.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeMcpToolCallItem.Serialization.cs
@@ -221,6 +221,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             return false;
@@ -234,6 +238,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 Error.Patch.Set([.. "$"u8, .. local.Slice("error"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeMcpToolDefinitionListItem.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeMcpToolDefinitionListItem.Serialization.cs
@@ -98,7 +98,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < ToolDefinitions.Count; i++)
                 {
-                    if (ToolDefinitions[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || ToolDefinitions[i] != null && ToolDefinitions[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -180,11 +180,19 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolDefinitions == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolDefinitionsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolDefinitions.Count)
+                {
+                    return false;
+                }
+                if (ToolDefinitions[index] == null)
                 {
                     return false;
                 }
@@ -203,7 +211,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (ToolDefinitions == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ToolDefinitions.Count)
+                {
+                    return false;
+                }
+                if (ToolDefinitions[index] == null)
                 {
                     return false;
                 }
@@ -234,7 +250,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < ToolDefinitions.Count; i++)
             {
-                if (!ToolDefinitions[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (ToolDefinitions[i] == null || !ToolDefinitions[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return ToolDefinitions[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeMessageItem.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeMessageItem.Serialization.cs
@@ -108,7 +108,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < Content.Count; i++)
                 {
-                    if (Content[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) || Content[i] != null && Content[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -217,11 +217,19 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveContentArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -240,7 +248,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "content"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Content == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Content.Count)
+                {
+                    return false;
+                }
+                if (Content[index] == null)
                 {
                     return false;
                 }
@@ -271,7 +287,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < Content.Count; i++)
             {
-                if (!Content[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.content[{i}]")) && (Content[i] == null || !Content[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Content[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeResponse.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeResponse.Serialization.cs
@@ -103,7 +103,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < OutputItems.Count; i++)
                 {
-                    if (OutputItems[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.output[{i}]")) || OutputItems[i] != null && OutputItems[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -370,29 +370,53 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("status_details"u8))
             {
+                if (StatusDetails == null)
+                {
+                    return false;
+                }
                 return StatusDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("status_details"u8.Length)], out value);
             }
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 return AudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 return Usage.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("usage"u8.Length)], out value);
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 return MaxOutputTokenCount.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], out value);
             }
             if (local.StartsWith("output"u8))
             {
                 int propertyLength = "output"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (OutputItems == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveOutputItemsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= OutputItems.Count)
+                {
+                    return false;
+                }
+                if (OutputItems[index] == null)
                 {
                     return false;
                 }
@@ -409,21 +433,37 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("status_details"u8))
             {
+                if (StatusDetails == null)
+                {
+                    return false;
+                }
                 StatusDetails.Patch.Set([.. "$"u8, .. local.Slice("status_details"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 AudioOptions.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 Usage.Patch.Set([.. "$"u8, .. local.Slice("usage"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 MaxOutputTokenCount.Patch.Set([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], value);
                 return true;
             }
@@ -431,7 +471,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "output"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (OutputItems == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= OutputItems.Count)
+                {
+                    return false;
+                }
+                if (OutputItems[index] == null)
                 {
                     return false;
                 }
@@ -462,7 +510,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < OutputItems.Count; i++)
             {
-                if (!OutputItems[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.output[{i}]")) && (OutputItems[i] == null || !OutputItems[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return OutputItems[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeResponseAudioOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeResponseAudioOptions.Serialization.cs
@@ -125,6 +125,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("output"u8))
             {
+                if (OutputAudioOptions == null)
+                {
+                    return false;
+                }
                 return OutputAudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("output"u8.Length)], out value);
             }
             return false;
@@ -138,6 +142,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("output"u8))
             {
+                if (OutputAudioOptions == null)
+                {
+                    return false;
+                }
                 OutputAudioOptions.Patch.Set([.. "$"u8, .. local.Slice("output"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeResponseInputTokenUsageDetails.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeResponseInputTokenUsageDetails.Serialization.cs
@@ -191,6 +191,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("cached_tokens_details"u8))
             {
+                if (CachedTokenDetails == null)
+                {
+                    return false;
+                }
                 return CachedTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("cached_tokens_details"u8.Length)], out value);
             }
             return false;
@@ -204,6 +208,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("cached_tokens_details"u8))
             {
+                if (CachedTokenDetails == null)
+                {
+                    return false;
+                }
                 CachedTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("cached_tokens_details"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeResponseOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeResponseOptions.Serialization.cs
@@ -116,7 +116,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < Tools.Count; i++)
                 {
-                    if (Tools[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) || Tools[i] != null && Tools[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -191,7 +191,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < InputItems.Count; i++)
                 {
-                    if (InputItems[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.input[{i}]")) || InputItems[i] != null && InputItems[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -365,25 +365,45 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 return AudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 return ToolChoice.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], out value);
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 return MaxOutputTokenCount.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], out value);
             }
             if (local.StartsWith("tools"u8))
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveToolsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -393,11 +413,19 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "input"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InputItems == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveInputItemsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InputItems.Count)
+                {
+                    return false;
+                }
+                if (InputItems[index] == null)
                 {
                     return false;
                 }
@@ -414,16 +442,28 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 AudioOptions.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("tool_choice"u8))
             {
+                if (ToolChoice == null)
+                {
+                    return false;
+                }
                 ToolChoice.Patch.Set([.. "$"u8, .. local.Slice("tool_choice"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("max_output_tokens"u8))
             {
+                if (MaxOutputTokenCount == null)
+                {
+                    return false;
+                }
                 MaxOutputTokenCount.Patch.Set([.. "$"u8, .. local.Slice("max_output_tokens"u8.Length)], value);
                 return true;
             }
@@ -431,7 +471,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "tools"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Tools == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Tools.Count)
+                {
+                    return false;
+                }
+                if (Tools[index] == null)
                 {
                     return false;
                 }
@@ -442,7 +490,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "input"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (InputItems == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= InputItems.Count)
+                {
+                    return false;
+                }
+                if (InputItems[index] == null)
                 {
                     return false;
                 }
@@ -473,7 +529,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < Tools.Count; i++)
             {
-                if (!Tools[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.tools[{i}]")) && (Tools[i] == null || !Tools[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Tools[i];
                 }
@@ -501,7 +557,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < InputItems.Count; i++)
             {
-                if (!InputItems[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.input[{i}]")) && (InputItems[i] == null || !InputItems[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return InputItems[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeResponseOutputAudioOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeResponseOutputAudioOptions.Serialization.cs
@@ -140,6 +140,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 return AudioFormat.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("format"u8.Length)], out value);
             }
             return false;
@@ -153,6 +157,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 AudioFormat.Patch.Set([.. "$"u8, .. local.Slice("format"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeResponseStatusDetails.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeResponseStatusDetails.Serialization.cs
@@ -155,6 +155,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             return false;
@@ -168,6 +172,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 Error.Patch.Set([.. "$"u8, .. local.Slice("error"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeResponseUsage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeResponseUsage.Serialization.cs
@@ -191,10 +191,18 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input_token_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 return InputTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("input_token_details"u8.Length)], out value);
             }
             if (local.StartsWith("output_token_details"u8))
             {
+                if (OutputTokenDetails == null)
+                {
+                    return false;
+                }
                 return OutputTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("output_token_details"u8.Length)], out value);
             }
             return false;
@@ -208,11 +216,19 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input_token_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 InputTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("input_token_details"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("output_token_details"u8))
             {
+                if (OutputTokenDetails == null)
+                {
+                    return false;
+                }
                 OutputTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("output_token_details"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationCreated.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationCreated.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("conversation"u8))
             {
+                if (Conversation == null)
+                {
+                    return false;
+                }
                 return Conversation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("conversation"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("conversation"u8))
             {
+                if (Conversation == null)
+                {
+                    return false;
+                }
                 Conversation.Patch.Set([.. "$"u8, .. local.Slice("conversation"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemAdded.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemAdded.Serialization.cs
@@ -159,6 +159,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -172,6 +176,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemCreated.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemCreated.Serialization.cs
@@ -159,6 +159,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -172,6 +176,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemDone.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemDone.Serialization.cs
@@ -159,6 +159,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -172,6 +176,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemInputAudioTranscriptionCompleted.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemInputAudioTranscriptionCompleted.Serialization.cs
@@ -108,7 +108,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < Logprobs.Count; i++)
                 {
-                    if (Logprobs[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) || Logprobs[i] != null && Logprobs[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -223,17 +223,29 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 return Usage.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("usage"u8.Length)], out value);
             }
             if (local.StartsWith("logprobs"u8))
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveLogprobsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Logprobs.Count)
+                {
+                    return false;
+                }
+                if (Logprobs[index] == null)
                 {
                     return false;
                 }
@@ -250,6 +262,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("usage"u8))
             {
+                if (Usage == null)
+                {
+                    return false;
+                }
                 Usage.Patch.Set([.. "$"u8, .. local.Slice("usage"u8.Length)], value);
                 return true;
             }
@@ -257,7 +273,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Logprobs.Count)
+                {
+                    return false;
+                }
+                if (Logprobs[index] == null)
                 {
                     return false;
                 }
@@ -288,7 +312,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < Logprobs.Count; i++)
             {
-                if (!Logprobs[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) && (Logprobs[i] == null || !Logprobs[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Logprobs[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemInputAudioTranscriptionDelta.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemInputAudioTranscriptionDelta.Serialization.cs
@@ -108,7 +108,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < Logprobs.Count; i++)
                 {
-                    if (Logprobs[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) || Logprobs[i] != null && Logprobs[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -217,11 +217,19 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveLogprobsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Logprobs.Count)
+                {
+                    return false;
+                }
+                if (Logprobs[index] == null)
                 {
                     return false;
                 }
@@ -240,7 +248,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "logprobs"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (Logprobs == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= Logprobs.Count)
+                {
+                    return false;
+                }
+                if (Logprobs[index] == null)
                 {
                     return false;
                 }
@@ -271,7 +287,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < Logprobs.Count; i++)
             {
-                if (!Logprobs[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.logprobs[{i}]")) && (Logprobs[i] == null || !Logprobs[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return Logprobs[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemInputAudioTranscriptionFailed.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemInputAudioTranscriptionFailed.Serialization.cs
@@ -171,6 +171,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             return false;
@@ -184,6 +188,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 Error.Patch.Set([.. "$"u8, .. local.Slice("error"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemRetrieved.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateConversationItemRetrieved.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateError.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateError.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 return Error.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("error"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("error"u8))
             {
+                if (Error == null)
+                {
+                    return false;
+                }
                 Error.Patch.Set([.. "$"u8, .. local.Slice("error"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateRateLimitsUpdated.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateRateLimitsUpdated.Serialization.cs
@@ -93,7 +93,7 @@ namespace OpenAI.Realtime
                 writer.WriteStartArray();
                 for (int i = 0; i < RateLimitDetails.Count; i++)
                 {
-                    if (RateLimitDetails[i].Patch.IsRemoved("$"u8))
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.rate_limits[{i}]")) || RateLimitDetails[i] != null && RateLimitDetails[i].Patch.IsRemoved("$"u8))
                     {
                         continue;
                     }
@@ -169,11 +169,19 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "rate_limits"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (RateLimitDetails == null)
+                {
+                    return false;
+                }
                 if (currentSlice.IsEmpty)
                 {
                     return TryResolveRateLimitDetailsArray(out value);
                 }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= RateLimitDetails.Count)
+                {
+                    return false;
+                }
+                if (RateLimitDetails[index] == null)
                 {
                     return false;
                 }
@@ -192,7 +200,15 @@ namespace OpenAI.Realtime
             {
                 int propertyLength = "rate_limits"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
+                if (RateLimitDetails == null)
+                {
+                    return false;
+                }
                 if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= RateLimitDetails.Count)
+                {
+                    return false;
+                }
+                if (RateLimitDetails[index] == null)
                 {
                     return false;
                 }
@@ -223,7 +239,7 @@ namespace OpenAI.Realtime
             }
             for (int i = 0; i < RateLimitDetails.Count; i++)
             {
-                if (!RateLimitDetails[i].Patch.IsRemoved("$"u8))
+                if (!Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.rate_limits[{i}]")) && (RateLimitDetails[i] == null || !RateLimitDetails[i].Patch.IsRemoved("$"u8)))
                 {
                     yield return RateLimitDetails[i];
                 }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseContentPartAdded.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseContentPartAdded.Serialization.cs
@@ -195,6 +195,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 return Part.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("part"u8.Length)], out value);
             }
             return false;
@@ -208,6 +212,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 Part.Patch.Set([.. "$"u8, .. local.Slice("part"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseContentPartDone.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseContentPartDone.Serialization.cs
@@ -195,6 +195,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 return Part.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("part"u8.Length)], out value);
             }
             return false;
@@ -208,6 +212,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("part"u8))
             {
+                if (Part == null)
+                {
+                    return false;
+                }
                 Part.Patch.Set([.. "$"u8, .. local.Slice("part"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseCreated.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseCreated.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseDone.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseDone.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 return Response.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("response"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("response"u8))
             {
+                if (Response == null)
+                {
+                    return false;
+                }
                 Response.Patch.Set([.. "$"u8, .. local.Slice("response"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseOutputItemAdded.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseOutputItemAdded.Serialization.cs
@@ -171,6 +171,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -184,6 +188,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseOutputItemDone.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateResponseOutputItemDone.Serialization.cs
@@ -171,6 +171,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 return Item.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("item"u8.Length)], out value);
             }
             return false;
@@ -184,6 +188,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("item"u8))
             {
+                if (Item == null)
+                {
+                    return false;
+                }
                 Item.Patch.Set([.. "$"u8, .. local.Slice("item"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateSessionCreated.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateSessionCreated.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (Session == null)
+                {
+                    return false;
+                }
                 return Session.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("session"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (Session == null)
+                {
+                    return false;
+                }
                 Session.Patch.Set([.. "$"u8, .. local.Slice("session"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateSessionUpdated.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeServerUpdateSessionUpdated.Serialization.cs
@@ -143,6 +143,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (Session == null)
+                {
+                    return false;
+                }
                 return Session.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("session"u8.Length)], out value);
             }
             return false;
@@ -156,6 +160,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("session"u8))
             {
+                if (Session == null)
+                {
+                    return false;
+                }
                 Session.Patch.Set([.. "$"u8, .. local.Slice("session"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeToolChoice.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeToolChoice.Serialization.cs
@@ -65,6 +65,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_tool_choice"u8))
             {
+                if (CustomToolChoice == null)
+                {
+                    return false;
+                }
                 return CustomToolChoice.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("custom_tool_choice"u8.Length)], out value);
             }
             return false;
@@ -78,6 +82,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_tool_choice"u8))
             {
+                if (CustomToolChoice == null)
+                {
+                    return false;
+                }
                 CustomToolChoice.Patch.Set([.. "$"u8, .. local.Slice("custom_tool_choice"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeTracing.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeTracing.Serialization.cs
@@ -65,6 +65,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_tracing"u8))
             {
+                if (CustomTracing == null)
+                {
+                    return false;
+                }
                 return CustomTracing.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("custom_tracing"u8.Length)], out value);
             }
             return false;
@@ -78,6 +82,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_tracing"u8))
             {
+                if (CustomTracing == null)
+                {
+                    return false;
+                }
                 CustomTracing.Patch.Set([.. "$"u8, .. local.Slice("custom_tracing"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSession.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSession.Serialization.cs
@@ -219,6 +219,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 return AudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             return false;
@@ -232,6 +236,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 AudioOptions.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSessionAudioOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSessionAudioOptions.Serialization.cs
@@ -125,6 +125,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input"u8))
             {
+                if (InputAudioOptions == null)
+                {
+                    return false;
+                }
                 return InputAudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("input"u8.Length)], out value);
             }
             return false;
@@ -138,6 +142,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input"u8))
             {
+                if (InputAudioOptions == null)
+                {
+                    return false;
+                }
                 InputAudioOptions.Patch.Set([.. "$"u8, .. local.Slice("input"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSessionInputAudioOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSessionInputAudioOptions.Serialization.cs
@@ -171,18 +171,34 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 return AudioFormat.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("format"u8.Length)], out value);
             }
             if (local.StartsWith("transcription"u8))
             {
+                if (AudioTranscriptionOptions == null)
+                {
+                    return false;
+                }
                 return AudioTranscriptionOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("transcription"u8.Length)], out value);
             }
             if (local.StartsWith("noise_reduction"u8))
             {
+                if (NoiseReduction == null)
+                {
+                    return false;
+                }
                 return NoiseReduction.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("noise_reduction"u8.Length)], out value);
             }
             if (local.StartsWith("turn_detection"u8))
             {
+                if (TurnDetection == null)
+                {
+                    return false;
+                }
                 return TurnDetection.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("turn_detection"u8.Length)], out value);
             }
             return false;
@@ -196,21 +212,37 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("format"u8))
             {
+                if (AudioFormat == null)
+                {
+                    return false;
+                }
                 AudioFormat.Patch.Set([.. "$"u8, .. local.Slice("format"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("transcription"u8))
             {
+                if (AudioTranscriptionOptions == null)
+                {
+                    return false;
+                }
                 AudioTranscriptionOptions.Patch.Set([.. "$"u8, .. local.Slice("transcription"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("noise_reduction"u8))
             {
+                if (NoiseReduction == null)
+                {
+                    return false;
+                }
                 NoiseReduction.Patch.Set([.. "$"u8, .. local.Slice("noise_reduction"u8.Length)], value);
                 return true;
             }
             if (local.StartsWith("turn_detection"u8))
             {
+                if (TurnDetection == null)
+                {
+                    return false;
+                }
                 TurnDetection.Patch.Set([.. "$"u8, .. local.Slice("turn_detection"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSessionOptions.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionSessionOptions.Serialization.cs
@@ -171,6 +171,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 return AudioOptions.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("audio"u8.Length)], out value);
             }
             return false;
@@ -184,6 +188,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("audio"u8))
             {
+                if (AudioOptions == null)
+                {
+                    return false;
+                }
                 AudioOptions.Patch.Set([.. "$"u8, .. local.Slice("audio"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionTokenUsage.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeTranscriptionTokenUsage.Serialization.cs
@@ -175,6 +175,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input_token_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 return InputTokenDetails.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("input_token_details"u8.Length)], out value);
             }
             return false;
@@ -188,6 +192,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("input_token_details"u8))
             {
+                if (InputTokenDetails == null)
+                {
+                    return false;
+                }
                 InputTokenDetails.Patch.Set([.. "$"u8, .. local.Slice("input_token_details"u8.Length)], value);
                 return true;
             }

--- a/OpenAI/src/Generated/Models/Realtime/RealtimeTruncation.Serialization.cs
+++ b/OpenAI/src/Generated/Models/Realtime/RealtimeTruncation.Serialization.cs
@@ -65,6 +65,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_truncation"u8))
             {
+                if (CustomTruncation == null)
+                {
+                    return false;
+                }
                 return CustomTruncation.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("custom_truncation"u8.Length)], out value);
             }
             return false;
@@ -78,6 +82,10 @@ namespace OpenAI.Realtime
 
             if (local.StartsWith("custom_truncation"u8))
             {
+                if (CustomTruncation == null)
+                {
+                    return false;
+                }
                 CustomTruncation.Patch.Set([.. "$"u8, .. local.Slice("custom_truncation"u8.Length)], value);
                 return true;
             }

--- a/codegen/package.json
+++ b/codegen/package.json
@@ -28,11 +28,11 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-tools/typespec-client-generator-core": "0.71.2",
+    "@azure-tools/typespec-client-generator-core": "0.72.0",
     "@open-ai/plugin": "file:",
-    "@typespec/http": "1.15.0",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260902.4",
-    "@typespec/openapi": "1.15.0"
+    "@typespec/http": "1.16.0",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260909.5",
+    "@typespec/openapi": "1.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure-tools/typespec-client-generator-core": "0.71.2",
+        "@azure-tools/typespec-client-generator-core": "0.72.0",
         "@open-ai/plugin": "file:",
-        "@typespec/http": "1.15.0",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260902.4",
-        "@typespec/openapi": "1.15.0"
+        "@typespec/http": "1.16.0",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260909.5",
+        "@typespec/openapi": "1.16.0"
       },
       "devDependencies": {
         "@types/node": "^22.8.1",
@@ -33,6 +33,162 @@
         "rimraf": "^6.1.0",
         "typescript": "^7.0.2",
         "vitest": "^4.0.10"
+      }
+    },
+    "codegen/node_modules/@azure-tools/typespec-azure-core": {
+      "version": "0.72.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.72.0.tgz",
+      "integrity": "sha512-zSi/ydbEZJh7dmGFzwMUv8mO1ijChbWiXBucwM/kM9avmwhE2fmFZNmWoyuakxsWi3sSczuWSlAzKlLYELmZxQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0",
+        "@typespec/http": "^1.16.0",
+        "@typespec/rest": "^0.86.0"
+      }
+    },
+    "codegen/node_modules/@azure-tools/typespec-client-generator-core": {
+      "version": "0.72.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.72.0.tgz",
+      "integrity": "sha512-qTidMUgtM7R4wGy3i2DU3OBHm7eHtK1VCNPzT3O9PVtBVNxSSDc/gY0qENq3KvN+68qS3XoCvUluRz6fUK/h2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.4.4",
+        "pluralize": "^8.0.0",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "^0.72.0",
+        "@typespec/compiler": "^1.16.0",
+        "@typespec/events": "^0.86.0",
+        "@typespec/http": "^1.16.0",
+        "@typespec/openapi": "^1.16.0",
+        "@typespec/rest": "^0.86.0",
+        "@typespec/sse": "^0.86.0",
+        "@typespec/streams": "^0.86.0",
+        "@typespec/versioning": "^0.86.0",
+        "@typespec/xml": "^0.86.0"
+      }
+    },
+    "codegen/node_modules/@typespec/events": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.86.0.tgz",
+      "integrity": "sha512-lT+5uBXSjjJi4npZZsleJel9yhqT6Y39m4d3wIYVsQq/zOznBMylRTrBDuQD5xntTgwKc/nLsxXJ0cuTrUBHDQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0"
+      }
+    },
+    "codegen/node_modules/@typespec/http": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.16.0.tgz",
+      "integrity": "sha512-4cODL4uqoj6YGj3Z04mQx1JwrM7o4Ytv4dO75o3Y3fx66v4BF4B5hF2dwnwh02Xe0e9qO1aDoaRlO2QGDz3mEA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0",
+        "@typespec/streams": "^0.86.0"
+      },
+      "peerDependenciesMeta": {
+        "@typespec/streams": {
+          "optional": true
+        }
+      }
+    },
+    "codegen/node_modules/@typespec/openapi": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.16.0.tgz",
+      "integrity": "sha512-6F+3e1dOJkIV4K0vCsuDpdwxoXnsT6eOomd4MpIUJAwyA7etEraUmPM9Qstp42MLIBoPWm9dK4Y9Whxtohc/KA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0",
+        "@typespec/http": "^1.16.0"
+      }
+    },
+    "codegen/node_modules/@typespec/rest": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.86.0.tgz",
+      "integrity": "sha512-Lbl4x/ZW26r4ZsxpgvS7T3F998J7pvyDs+OsHgVKDI45EvPmdDydI4TKOH++UmHJ2tH8kw8KHzMPqCehWLIa6g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0",
+        "@typespec/http": "^1.16.0"
+      }
+    },
+    "codegen/node_modules/@typespec/sse": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.86.0.tgz",
+      "integrity": "sha512-32+WQ4NDoIA70nkuhpr8MdF+hkBx3VKESNocWMN8z4/RaYq9/CdBOJhV7Y/hy3Y5+tbVg0/3u7lLSfvmtyg5Cw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0",
+        "@typespec/events": "^0.86.0",
+        "@typespec/http": "^1.16.0",
+        "@typespec/streams": "^0.86.0"
+      }
+    },
+    "codegen/node_modules/@typespec/streams": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.86.0.tgz",
+      "integrity": "sha512-zK2kFtj53dVYnza6a6peEc5KPZ2l9iQCLaaoN1mO7IIYhNCaUMotv6qvbNJF7rw46HMm7u1Xzbi6NqeyVnnb9A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0"
+      }
+    },
+    "codegen/node_modules/@typespec/versioning": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.86.0.tgz",
+      "integrity": "sha512-/VUgQXSNcwbhNllTKptGAcoxYCh3+E/a9RUcmlBj7v04yIN4rkSFFmxHKRWKuKaz9LYQerXSPrVNM6Ja1msFlw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0"
+      }
+    },
+    "codegen/node_modules/@typespec/xml": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.86.0.tgz",
+      "integrity": "sha512-i+GNThU32Vz3/VNMnPsH0q/x2BMnWKE6tY00XbiG00zjRjkaTw4zsDGoBNcNOVbS4EFNIfSrhaJEnVPFJY4awQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.16.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
@@ -1369,28 +1525,28 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.15.0.tgz",
-      "integrity": "sha512-NbCIRAIzyozchlSaGPVuyV43bC+y+OpXYCuT+8M8kt35Ln9zWzLFcIt7irofQ5QUXBZrHsBFpI5fTOFdCGeWCA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.16.0.tgz",
+      "integrity": "sha512-pT4gN+OSEXZMLxIhtI3QgIUafeFktfIBKVb7p+X/rAzDymQSO8yAb+srMBQ43PIcmfrvMxCNaD1SKBa9AGhWtA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@inquirer/prompts": "^8.4.1",
-        "ajv": "^8.18.0",
+        "@inquirer/prompts": "^8.6.0",
+        "ajv": "^8.20.0",
         "change-case": "^5.4.4",
         "env-paths": "^4.0.0",
         "is-unicode-supported": "^2.1.0",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
-        "prettier": "^3.9.5",
-        "semver": "^7.7.4",
-        "tar": "^7.5.21",
-        "temporal-polyfill": "^1.0.1",
-        "vscode-languageserver": "^10.0.0",
-        "vscode-languageserver-textdocument": "^1.0.12",
-        "yaml": "^2.8.3",
-        "yargs": "^18.0.0"
+        "prettier": "^3.9.6",
+        "semver": "^7.8.5",
+        "tar": "^7.5.22",
+        "temporal-polyfill": "^1.0.4",
+        "vscode-languageserver": "^10.1.0",
+        "vscode-languageserver-textdocument": "^1.0.13",
+        "yaml": "^2.9.0",
+        "yargs": "^18.1.0"
       },
       "bin": {
         "tsp": "cmd/tsp.js",
@@ -1433,9 +1589,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260902.4",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260902.4.tgz",
-      "integrity": "sha512-NoM2UosS7g7OSMsx7unQ8/vWUBU6ctSYWg0u4cegyBsey60FgpBqouYqaJpM7Jh8BUFkJgZaWTKMhwfNa4fWbw==",
+      "version": "1.0.0-alpha.20260909.5",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260909.5.tgz",
+      "integrity": "sha512-krmxgVz41wRbMAAgQ/WVG/WHeSW9dfdT7LQwPGxii5KALGu7/8HUTqUsGLN/zTKQDsymCSqMfO3g1dz0uFbfnw==",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"


### PR DESCRIPTION
Changes:

package.json: `@typespec/http-client-csharp` → `1.0.0-alpha.20260909.5`. The new emitter's peer deps forced the coupled TypeSpec stack to the `1.16 `/ `0.72` generation, so also bumped `@typespec/http` and `@typespec/openapi` to `1.16.0` and `@azure-tools/typespec-client-generator-core` to `0.72.0`.

Results:

Regeneration touched 157 `*.Serialization.cs` files — a mechanical change adding null-guards before accessing .Patch on nullable nested model properties (JSON-patch serialization). No public API surface change