### PR TITLE
Fix VectorStore usage byte overflow

### DIFF
--- a/OpenAI/src/Custom/VectorStores/VectorStore.cs
+++ b/OpenAI/src/Custom/VectorStores/VectorStore.cs
@@ -13,6 +13,10 @@ public partial class VectorStore
     [CodeGenMember("Object")]
     internal string Object { get; } = "vector_store";
 
+    // CUSTOM: Changed type.
+    /// <summary> The total number of bytes used by the files in the vector store. </summary>
+    public long UsageBytes { get; }
+
     /// <summary>
     /// Gets the policy that controls when this vector store will be automatically deleted.
     /// </summary>

--- a/OpenAI/src/Generated/Models/VectorStores/VectorStore.Serialization.cs
+++ b/OpenAI/src/Generated/Models/VectorStores/VectorStore.Serialization.cs
@@ -190,7 +190,7 @@ namespace OpenAI.VectorStores
             string @object = default;
             DateTimeOffset createdAt = default;
             string name = default;
-            int usageBytes = default;
+            long usageBytes = default;
             VectorStoreFileCounts fileCounts = default;
             VectorStoreStatus status = default;
             VectorStoreExpirationPolicy expirationPolicy = default;
@@ -222,7 +222,7 @@ namespace OpenAI.VectorStores
                 }
                 if (prop.NameEquals("usage_bytes"u8))
                 {
-                    usageBytes = prop.Value.GetInt32();
+                    usageBytes = prop.Value.GetInt64();
                     continue;
                 }
                 if (prop.NameEquals("file_counts"u8))

--- a/OpenAI/src/Generated/Models/VectorStores/VectorStore.cs
+++ b/OpenAI/src/Generated/Models/VectorStores/VectorStore.cs
@@ -14,7 +14,7 @@ namespace OpenAI.VectorStores
     {
         private protected IDictionary<string, BinaryData> _additionalBinaryDataProperties;
 
-        internal VectorStore(string id, DateTimeOffset createdAt, string name, int usageBytes, VectorStoreFileCounts fileCounts, VectorStoreStatus status, DateTimeOffset? lastActiveAt)
+        internal VectorStore(string id, DateTimeOffset createdAt, string name, long usageBytes, VectorStoreFileCounts fileCounts, VectorStoreStatus status, DateTimeOffset? lastActiveAt)
         {
             Id = id;
             CreatedAt = createdAt;
@@ -26,7 +26,7 @@ namespace OpenAI.VectorStores
             Metadata = new ChangeTrackingDictionary<string, string>();
         }
 
-        internal VectorStore(string id, string @object, DateTimeOffset createdAt, string name, int usageBytes, VectorStoreFileCounts fileCounts, VectorStoreStatus status, VectorStoreExpirationPolicy expirationPolicy, DateTimeOffset? expiresAt, DateTimeOffset? lastActiveAt, IReadOnlyDictionary<string, string> metadata, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        internal VectorStore(string id, string @object, DateTimeOffset createdAt, string name, long usageBytes, VectorStoreFileCounts fileCounts, VectorStoreStatus status, VectorStoreExpirationPolicy expirationPolicy, DateTimeOffset? expiresAt, DateTimeOffset? lastActiveAt, IReadOnlyDictionary<string, string> metadata, IDictionary<string, BinaryData> additionalBinaryDataProperties)
         {
             // Plugin customization: ensure initialization of collections
             Id = id;
@@ -49,7 +49,7 @@ namespace OpenAI.VectorStores
 
         public string Name { get; }
 
-        public int UsageBytes { get; }
+        public long UsageBytes { get; }
 
         public VectorStoreFileCounts FileCounts { get; }
 

--- a/OpenAI/src/Generated/Models/VectorStores/VectorStore.cs
+++ b/OpenAI/src/Generated/Models/VectorStores/VectorStore.cs
@@ -49,8 +49,6 @@ namespace OpenAI.VectorStores
 
         public string Name { get; }
 
-        public long UsageBytes { get; }
-
         public VectorStoreFileCounts FileCounts { get; }
 
         public VectorStoreStatus Status { get; }

--- a/OpenAI/src/Generated/OpenAIModelFactory.cs
+++ b/OpenAI/src/Generated/OpenAIModelFactory.cs
@@ -2342,7 +2342,7 @@ namespace OpenAI
             return new ModerationResult(flagged, additionalBinaryDataProperties: null);
         }
 
-        public static VectorStore VectorStore(string id = default, DateTimeOffset createdAt = default, string name = default, int usageBytes = default, VectorStoreFileCounts fileCounts = default, VectorStoreStatus status = default, VectorStoreExpirationPolicy expirationPolicy = default, DateTimeOffset? expiresAt = default, DateTimeOffset? lastActiveAt = default, IReadOnlyDictionary<string, string> metadata = default)
+        public static VectorStore VectorStore(string id = default, DateTimeOffset createdAt = default, string name = default, long usageBytes = default, VectorStoreFileCounts fileCounts = default, VectorStoreStatus status = default, VectorStoreExpirationPolicy expirationPolicy = default, DateTimeOffset? expiresAt = default, DateTimeOffset? lastActiveAt = default, IReadOnlyDictionary<string, string> metadata = default)
         {
             metadata ??= new ChangeTrackingDictionary<string, string>();
 

--- a/api/in-progress/net10.0/OpenAI.VectorStores.net10.0.cs
+++ b/api/in-progress/net10.0/OpenAI.VectorStores.net10.0.cs
@@ -35,7 +35,7 @@ namespace OpenAI.VectorStores {
         public IReadOnlyDictionary<string, string> Metadata { get; }
         public string Name { get; }
         public VectorStoreStatus Status { get; }
-        public int UsageBytes { get; }
+        public long UsageBytes { get; }
         public static explicit operator VectorStore(ClientResult result);
     }
     [Experimental("OPENAI001")]

--- a/api/in-progress/net8.0/OpenAI.VectorStores.net8.0.cs
+++ b/api/in-progress/net8.0/OpenAI.VectorStores.net8.0.cs
@@ -35,7 +35,7 @@ namespace OpenAI.VectorStores {
         public IReadOnlyDictionary<string, string> Metadata { get; }
         public string Name { get; }
         public VectorStoreStatus Status { get; }
-        public int UsageBytes { get; }
+        public long UsageBytes { get; }
         public static explicit operator VectorStore(ClientResult result);
     }
     [Experimental("OPENAI001")]

--- a/api/in-progress/netstandard2.0/OpenAI.VectorStores.netstandard2.0.cs
+++ b/api/in-progress/netstandard2.0/OpenAI.VectorStores.netstandard2.0.cs
@@ -31,7 +31,7 @@ namespace OpenAI.VectorStores {
         public IReadOnlyDictionary<string, string> Metadata { get; }
         public string Name { get; }
         public VectorStoreStatus Status { get; }
-        public int UsageBytes { get; }
+        public long UsageBytes { get; }
         public static explicit operator VectorStore(ClientResult result);
     }
     public class VectorStoreClient {

--- a/codegen/generator/src/Visitors/NumericTypesVisitor.cs
+++ b/codegen/generator/src/Visitors/NumericTypesVisitor.cs
@@ -23,6 +23,8 @@ public class NumericTypesVisitor : ScmLibraryVisitor
 
         "OpenAI.Containers.ContainerFileResource.SizeInBytes",
 
+        "OpenAI.VectorStores.VectorStore.UsageBytes",
+
         "OpenAI.VectorStores.VectorStoreFile.UsageInBytes",
     };
 

--- a/specification/client/vector-stores.client.tsp
+++ b/specification/client/vector-stores.client.tsp
@@ -15,8 +15,6 @@ using Azure.ClientGenerator.Core;
 
 @@alternateType(VectorStoreExpirationAfter.anchor, VectorStoreExpirationAnchor);
 
-@@alternateType(VectorStoreObject.usage_bytes, int64);
-
 @@clientName(VectorStoreFileObject.usage_bytes, "UsageInBytes");
 @@alternateType(VectorStoreFileObject.usage_bytes, int64 | null);
 

--- a/specification/client/vector-stores.client.tsp
+++ b/specification/client/vector-stores.client.tsp
@@ -15,6 +15,8 @@ using Azure.ClientGenerator.Core;
 
 @@alternateType(VectorStoreExpirationAfter.anchor, VectorStoreExpirationAnchor);
 
+@@alternateType(VectorStoreObject.usage_bytes, int64);
+
 @@clientName(VectorStoreFileObject.usage_bytes, "UsageInBytes");
 @@alternateType(VectorStoreFileObject.usage_bytes, int64 | null);
 

--- a/tests/Assistants/AssistantsSmokeTests.cs
+++ b/tests/Assistants/AssistantsSmokeTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using OpenAI.Assistants;
+using OpenAI.VectorStores;
 using System;
 using System.ClientModel.Primitives;
 
@@ -11,6 +12,35 @@ namespace OpenAI.Tests.Assistants;
 [Category("Smoke")]
 public class AssistantsSmokeTests
 {
+    [Test]
+    public void VectorStoreDeserializationSupportsLargeUsageBytes()
+    {
+        long usageBytes = (long)int.MaxValue + 1;
+        BinaryData vectorStoreData = BinaryData.FromString($$"""
+            {
+              "id": "vs_abc123",
+              "object": "vector_store",
+              "created_at": 1767865408,
+              "name": "example",
+              "usage_bytes": {{usageBytes}},
+              "status": "completed",
+              "file_counts": {
+                "in_progress": 0,
+                "completed": 20214,
+                "failed": 26,
+                "cancelled": 0,
+                "total": 20240
+              },
+              "last_active_at": 1774444241,
+              "metadata": {}
+            }
+            """);
+
+        VectorStore vectorStore = ModelReaderWriter.Read<VectorStore>(vectorStoreData);
+
+        Assert.That(vectorStore.UsageBytes, Is.EqualTo(usageBytes));
+    }
+
     [Test]
     public void RunStepDeserialization()
     {


### PR DESCRIPTION
## Summary

- preserve `VectorStore.UsageBytes` as a `long` during code generation
- deserialize `usage_bytes` with `GetInt64()`
- add regression coverage for values above `Int32.MaxValue`

Fixes #1373

## Testing

- `dotnet test .\tests\OpenAI.Tests.csproj --configuration Release --framework net8.0 --filter "FullyQualifiedName~OpenAI.Tests.Assistants.AssistantsSmokeTests.VectorStoreDeserializationSupportsLargeUsageBytes" --no-restore`
- `dotnet test .\tests\OpenAI.Tests.csproj --configuration Release --framework net10.0 --filter "FullyQualifiedName~OpenAI.Tests.Assistants.AssistantsSmokeTests" --no-restore`
- `.\scripts\Export-Api.ps1`
- `dotnet msbuild .\codegen\generator\src\OpenAI.Library.Plugin.csproj -target:Compile -property:Configuration=Release -verbosity:minimal`